### PR TITLE
Split code into more files

### DIFF
--- a/asm/bmcamadjust.s
+++ b/asm/bmcamadjust.s
@@ -1,0 +1,188 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	THUMB_FUNC_START GetPlayerStartCursorPosition
+GetPlayerStartCursorPosition: @ 0x0801DE30
+	push {r4, r5, r6, lr}
+	adds r5, r0, #0
+	adds r6, r1, #0
+	ldr r4, _0801DE74  @ gUnknown_0202BCF0
+	ldrh r0, [r4, #0x10]
+	cmp r0, #1
+	bne _0801DE50
+	bl GetPlayerLeaderUnitId
+	bl GetUnitByCharId
+	adds r1, r0, #0
+	ldrb r0, [r1, #0x10]
+	strb r0, [r4, #0x12]
+	ldrb r0, [r1, #0x11]
+	strb r0, [r4, #0x13]
+_0801DE50:
+	adds r0, r4, #0
+	adds r0, #0x40
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1b
+	cmp r0, #0
+	blt _0801DE78
+	bl GetPlayerLeaderUnitId
+	bl GetUnitByCharId
+	adds r1, r0, #0
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	str r0, [r5]
+	movs r0, #0x11
+	ldrsb r0, [r1, r0]
+	b _0801DE7E
+	.align 2, 0
+_0801DE74: .4byte gUnknown_0202BCF0
+_0801DE78:
+	ldrb r0, [r4, #0x12]
+	str r0, [r5]
+	ldrb r0, [r4, #0x13]
+_0801DE7E:
+	str r0, [r6]
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START GetEnemyStartCursorPosition
+GetEnemyStartCursorPosition: @ 0x0801DE88
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	adds r5, r1, #0
+	ldr r0, _0801DE98  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xf]
+	adds r4, r0, #1
+	b _0801DEDC
+	.align 2, 0
+_0801DE98: .4byte gUnknown_0202BCF0
+_0801DE9C:
+	adds r0, r4, #0
+	bl GetUnitStruct
+	adds r2, r0, #0
+	cmp r2, #0
+	beq _0801DED6
+	ldr r3, [r2]
+	cmp r3, #0
+	beq _0801DED6
+	ldr r0, [r2, #0xc]
+	ldr r1, _0801DEE8  @ 0x00000201
+	ands r0, r1
+	cmp r0, #0
+	bne _0801DED6
+	movs r0, #0x10
+	ldrsb r0, [r2, r0]
+	str r0, [r6]
+	movs r0, #0x11
+	ldrsb r0, [r2, r0]
+	str r0, [r5]
+	ldr r0, [r2, #4]
+	ldr r1, [r3, #0x28]
+	ldr r0, [r0, #0x28]
+	orrs r1, r0
+	movs r0, #0x80
+	lsls r0, r0, #8
+	ands r1, r0
+	cmp r1, #0
+	bne _0801DEE2
+_0801DED6:
+	adds r4, #1
+	ldr r0, _0801DEEC  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xf]
+_0801DEDC:
+	adds r0, #0x40
+	cmp r4, r0
+	blt _0801DE9C
+_0801DEE2:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801DEE8: .4byte 0x00000201
+_0801DEEC: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START sub_801DEF0
+sub_801DEF0: @ 0x0801DEF0
+	push {r4, r5, lr}
+	sub sp, #8
+	adds r5, r0, #0
+	movs r0, #1
+	negs r0, r0
+	str r0, [sp]
+	str r0, [sp, #4]
+	ldr r4, _0801DF14  @ gUnknown_0202BCF0
+	ldrb r0, [r4, #0xf]
+	bl GetPhaseAbleUnitCount
+	cmp r0, #0
+	bne _0801DF18
+	adds r0, r5, #0
+	bl Proc_Delete
+	b _0801DF5A
+	.align 2, 0
+_0801DF14: .4byte gUnknown_0202BCF0
+_0801DF18:
+	ldrb r0, [r4, #0xf]
+	cmp r0, #0x40
+	beq _0801DF38
+	cmp r0, #0x40
+	bgt _0801DF28
+	cmp r0, #0
+	beq _0801DF2E
+	b _0801DF40
+_0801DF28:
+	cmp r0, #0x80
+	beq _0801DF38
+	b _0801DF40
+_0801DF2E:
+	add r1, sp, #4
+	mov r0, sp
+	bl GetPlayerStartCursorPosition
+	b _0801DF40
+_0801DF38:
+	add r1, sp, #4
+	mov r0, sp
+	bl GetEnemyStartCursorPosition
+_0801DF40:
+	ldr r1, [sp]
+	cmp r1, #0
+	blt _0801DF5A
+	ldr r2, [sp, #4]
+	cmp r2, #0
+	blt _0801DF5A
+	adds r0, r5, #0
+	bl EnsureCameraOntoPosition
+	ldr r0, [sp]
+	ldr r1, [sp, #4]
+	bl SetCursorMapPosition
+_0801DF5A:
+	add sp, #8
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START ADJUSTFROMXI_MoveCameraOnSomeUnit
+ADJUSTFROMXI_MoveCameraOnSomeUnit: @ 0x0801DF64
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	bl GetSomeUnitId
+	bl GetUnitStruct
+	cmp r0, #0
+	beq _0801DF8E
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	adds r0, r6, #0
+	adds r1, r4, #0
+	adds r2, r5, #0
+	bl EnsureCameraOntoPosition
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl SetCursorMapPosition
+_0801DF8E:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+.align 2, 0 @ align with 0

--- a/asm/bmdebug.s
+++ b/asm/bmdebug.s
@@ -1382,4 +1382,242 @@ _0801C62E:
 	.align 2, 0
 _0801C638: .4byte 0xFFFFFE7F
 
+	THUMB_FUNC_START sub_801C63C
+sub_801C63C: @ 0x0801C63C
+	push {lr}
+	ldr r0, _0801C64C  @ gUnknown_0859AA84
+	movs r1, #3
+	bl Proc_Create
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0801C64C: .4byte gUnknown_0859AA84
+
+	THUMB_FUNC_START sub_801C650
+sub_801C650: @ 0x0801C650
+	ldr r1, _0801C658  @ gUnknown_0859AA9C
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	bx lr
+	.align 2, 0
+_0801C658: .4byte gUnknown_0859AA9C
+
+	THUMB_FUNC_START sub_801C65C
+sub_801C65C: @ 0x0801C65C
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #0x10
+	adds r3, r0, #0
+	adds r7, r1, #0
+	adds r4, r2, #0
+	mov r1, sp
+	ldr r0, _0801C6A0  @ gUnknown_080D7AB4
+	ldm r0!, {r2, r5, r6}
+	stm r1!, {r2, r5, r6}
+	ldr r0, [r0]
+	str r0, [r1]
+	ldr r0, _0801C6A4  @ gKeyStatusPtr
+	ldr r0, [r0]
+	ldrh r1, [r0, #6]
+	movs r0, #0x10
+	ands r0, r1
+	cmp r0, #0
+	beq _0801C6A8
+	adds r1, r3, #0
+	adds r1, #0x3c
+	ldrb r0, [r1]
+	adds r0, #1
+	strb r0, [r1]
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+	cmp r0, #0x3b
+	bls _0801C6C4
+	movs r0, #0
+	b _0801C6C2
+	.align 2, 0
+_0801C6A0: .4byte gUnknown_080D7AB4
+_0801C6A4: .4byte gKeyStatusPtr
+_0801C6A8:
+	movs r0, #0x20
+	ands r0, r1
+	adds r1, r3, #0
+	adds r1, #0x3c
+	cmp r0, #0
+	beq _0801C6C4
+	ldrb r0, [r1]
+	subs r0, #1
+	strb r0, [r1]
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bge _0801C6C4
+	movs r0, #0x3b
+_0801C6C2:
+	strb r0, [r1]
+_0801C6C4:
+	movs r0, #0
+	ldrsb r0, [r1, r0]
+	bl sub_801C650
+	lsls r0, r0, #0x18
+	lsrs r2, r0, #0x18
+	cmp r2, #0x3e
+	bls _0801C6D6
+	b _0801C7F8
+_0801C6D6:
+	lsls r0, r2, #2
+	ldr r1, _0801C6E0  @ _0801C6E4
+	adds r0, r0, r1
+	ldr r0, [r0]
+	mov pc, r0
+	.align 2, 0
+_0801C6E0: .4byte _0801C6E4
+_0801C6E4: @ jump table
+	.4byte _0801C7E0 @ case 0
+	.4byte _0801C7E0 @ case 1
+	.4byte _0801C7E0 @ case 2
+	.4byte _0801C7E0 @ case 3
+	.4byte _0801C7E0 @ case 4
+	.4byte _0801C7E0 @ case 5
+	.4byte _0801C7E0 @ case 6
+	.4byte _0801C7E0 @ case 7
+	.4byte _0801C7E0 @ case 8
+	.4byte _0801C7E0 @ case 9
+	.4byte _0801C818 @ case 10
+	.4byte _0801C818 @ case 11
+	.4byte _0801C818 @ case 12
+	.4byte _0801C818 @ case 13
+	.4byte _0801C818 @ case 14
+	.4byte _0801C818 @ case 15
+	.4byte _0801C818 @ case 16
+	.4byte _0801C818 @ case 17
+	.4byte _0801C818 @ case 18
+	.4byte _0801C818 @ case 19
+	.4byte _0801C818 @ case 20
+	.4byte _0801C818 @ case 21
+	.4byte _0801C818 @ case 22
+	.4byte _0801C7EC @ case 23
+	.4byte _0801C7EC @ case 24
+	.4byte _0801C7EC @ case 25
+	.4byte _0801C7EC @ case 26
+	.4byte _0801C7EC @ case 27
+	.4byte _0801C7EC @ case 28
+	.4byte _0801C7EC @ case 29
+	.4byte _0801C7EC @ case 30
+	.4byte _0801C7EC @ case 31
+	.4byte _0801C7EC @ case 32
+	.4byte _0801C7EC @ case 33
+	.4byte _0801C7EC @ case 34
+	.4byte _0801C7EC @ case 35
+	.4byte _0801C7F8 @ case 36
+	.4byte _0801C7F8 @ case 37
+	.4byte _0801C7F8 @ case 38
+	.4byte _0801C7F8 @ case 39
+	.4byte _0801C7F8 @ case 40
+	.4byte _0801C7F8 @ case 41
+	.4byte _0801C7F8 @ case 42
+	.4byte _0801C7F8 @ case 43
+	.4byte _0801C7F8 @ case 44
+	.4byte _0801C7F8 @ case 45
+	.4byte _0801C7F8 @ case 46
+	.4byte _0801C7F8 @ case 47
+	.4byte _0801C7F8 @ case 48
+	.4byte _0801C7F8 @ case 49
+	.4byte _0801C7F8 @ case 50
+	.4byte _0801C7F8 @ case 51
+	.4byte _0801C7F8 @ case 52
+	.4byte _0801C7F8 @ case 53
+	.4byte _0801C7F8 @ case 54
+	.4byte _0801C7F8 @ case 55
+	.4byte _0801C7F8 @ case 56
+	.4byte _0801C7F8 @ case 57
+	.4byte _0801C7F8 @ case 58
+	.4byte _0801C7F8 @ case 59
+	.4byte _0801C7F8 @ case 60
+	.4byte _0801C818 @ case 61
+	.4byte _0801C7EC @ case 62
+_0801C7E0:
+	ldr r1, _0801C7E8  @ gUnknown_03001780
+	movs r0, #1
+	b _0801C81C
+	.align 2, 0
+_0801C7E8: .4byte gUnknown_03001780
+_0801C7EC:
+	ldr r1, _0801C7F4  @ gUnknown_03001780
+	movs r0, #3
+	b _0801C81C
+	.align 2, 0
+_0801C7F4: .4byte gUnknown_03001780
+_0801C7F8:
+	ldr r0, _0801C810  @ gKeyStatusPtr
+	ldr r0, [r0]
+	ldrh r1, [r0, #4]
+	movs r0, #0x80
+	lsls r0, r0, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _0801C818
+	ldr r1, _0801C814  @ gUnknown_03001780
+	movs r0, #3
+	b _0801C81C
+	.align 2, 0
+_0801C810: .4byte gKeyStatusPtr
+_0801C814: .4byte gUnknown_03001780
+_0801C818:
+	ldr r1, _0801C888  @ gUnknown_03001780
+	movs r0, #2
+_0801C81C:
+	strb r0, [r1]
+	adds r0, r2, #0
+	bl GetROMChapterStruct
+	ldr r0, [r0]
+	mov sl, r0
+	ldr r0, _0801C888  @ gUnknown_03001780
+	ldrb r0, [r0]
+	lsls r0, r0, #2
+	add r0, sp
+	ldr r0, [r0]
+	mov r9, r0
+	lsls r5, r4, #5
+	adds r5, r5, r7
+	lsls r5, r5, #1
+	ldr r6, _0801C88C  @ gBG0TilemapBuffer
+	adds r5, r5, r6
+	ldr r0, _0801C890  @ gUnknown_080D7AC4
+	mov r8, r0
+	adds r0, r5, #0
+	mov r1, r8
+	bl PrintDebugStringToBG
+	adds r4, #1
+	lsls r4, r4, #5
+	adds r4, r4, r7
+	lsls r4, r4, #1
+	adds r4, r4, r6
+	adds r0, r4, #0
+	mov r1, r8
+	bl PrintDebugStringToBG
+	adds r0, r5, #0
+	mov r1, sl
+	bl PrintDebugStringToBG
+	adds r0, r4, #0
+	mov r1, r9
+	bl PrintDebugStringToBG
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	bl EnablePaletteSync
+	add sp, #0x10
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801C888: .4byte gUnknown_03001780
+_0801C88C: .4byte gBG0TilemapBuffer
+_0801C890: .4byte gUnknown_080D7AC4
+
 	.align 2, 0 @ Don't pad with nop.

--- a/asm/bmxfade.s
+++ b/asm/bmxfade.s
@@ -1,0 +1,146 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	THUMB_FUNC_START sub_801DD1C
+sub_801DD1C: @ 0x0801DD1C
+	push {r4, lr}
+	sub sp, #4
+	adds r0, #0x4c
+	movs r4, #0
+	movs r1, #0x10
+	strh r1, [r0]
+	bl SetupBackgroundForWeatherMaybe
+	str r4, [sp]
+	movs r0, #0
+	movs r1, #0
+	movs r2, #1
+	movs r3, #0
+	bl sub_8001ED0
+	movs r0, #1
+	str r0, [sp]
+	movs r0, #0
+	movs r1, #0
+	movs r2, #0
+	movs r3, #1
+	bl sub_8001F0C
+	add sp, #4
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_801DD54
+sub_801DD54: @ 0x0801DD54
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	adds r4, r5, #0
+	adds r4, #0x4c
+	ldrb r0, [r4]
+	adds r1, r0, #0
+	movs r2, #0x10
+	subs r2, r2, r0
+	lsls r2, r2, #0x18
+	lsrs r2, r2, #0x18
+	movs r0, #1
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	ldrh r0, [r4]
+	subs r0, #1
+	strh r0, [r4]
+	lsls r0, r0, #0x10
+	cmp r0, #0
+	bge _0801DD9C
+	adds r0, r5, #0
+	bl Proc_ClearNativeCallback
+	bl SetDefaultColorEffects
+	movs r0, #2
+	movs r1, #0
+	bl SetBackgroundTileDataOffset
+	ldr r0, _0801DDA4  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #4
+	bl BG_EnableSyncByMask
+_0801DD9C:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801DDA4: .4byte gBG2TilemapBuffer
+
+	THUMB_FUNC_START Destruct6CBMXFADE
+Destruct6CBMXFADE: @ 0x0801DDA8
+	push {r4, lr}
+	adds r4, r0, #0
+	bl SetAllUnitNotBackSprite
+	adds r4, #0x4e
+	movs r1, #0
+	ldrsh r0, [r4, r1]
+	cmp r0, #0
+	beq _0801DDBE
+	bl SubSkipThread2
+_0801DDBE:
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START NewBMXFADE
+NewBMXFADE: @ 0x0801DDC4
+	push {r4, lr}
+	adds r4, r0, #0
+	lsls r4, r4, #0x18
+	lsrs r4, r4, #0x18
+	ldr r0, _0801DDEC  @ gUnknown_0859ADC8
+	movs r1, #3
+	bl Proc_Create
+	lsls r4, r4, #0x18
+	asrs r4, r4, #0x18
+	adds r0, #0x4e
+	strh r4, [r0]
+	cmp r4, #0
+	beq _0801DDE4
+	bl AddSkipThread2
+_0801DDE4:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801DDEC: .4byte gUnknown_0859ADC8
+
+	THUMB_FUNC_START MakeNew6CBMXFADE2
+MakeNew6CBMXFADE2: @ 0x0801DDF0
+	push {r4, lr}
+	adds r4, r0, #0
+	lsls r4, r4, #0x18
+	lsrs r4, r4, #0x18
+	ldr r0, _0801DE14  @ gUnknown_0859ADC8
+	bl Proc_CreateBlockingChild
+	lsls r4, r4, #0x18
+	asrs r4, r4, #0x18
+	adds r0, #0x4e
+	strh r4, [r0]
+	cmp r4, #0
+	beq _0801DE0E
+	bl AddSkipThread2
+_0801DE0E:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801DE14: .4byte gUnknown_0859ADC8
+
+	THUMB_FUNC_START DoesBMXFADEExist
+DoesBMXFADEExist: @ 0x0801DE18
+	push {lr}
+	ldr r0, _0801DE2C  @ gUnknown_0859ADC8
+	bl Proc_Find
+	cmp r0, #0
+	beq _0801DE26
+	movs r0, #1
+_0801DE26:
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0801DE2C: .4byte gUnknown_0859ADC8
+
+.align 2, 0 @ align with 0

--- a/asm/code_801E2E0.s
+++ b/asm/code_801E2E0.s
@@ -1,0 +1,268 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ These three functions seem to be generally unrelated to whatever is before and after them
+	@ So I'll put them here until someone decides on a better name/split
+	@ -Stan
+
+	THUMB_FUNC_START sub_801E2E0
+sub_801E2E0: @ 0x0801E2E0
+	push {r4, lr}
+	adds r4, r0, #0
+	cmp r4, #0
+	bge _0801E2F6
+	ldr r0, _0801E318  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xe]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	bl GetROMChapterStruct
+	ldrb r4, [r0, #0xc]
+_0801E2F6:
+	bl sub_8019CBC
+	ldr r0, _0801E318  @ gUnknown_0202BCF0
+	strb r4, [r0, #0xd]
+	bl RefreshFogAndUnitMaps
+	bl SMS_UpdateFromGameData
+	bl UpdateGameTilesGraphics
+	movs r0, #1
+	bl NewBMXFADE
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801E318: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START sub_801E31C
+sub_801E31C: @ 0x0801E31C
+	push {lr}
+	adds r1, r0, #0
+	cmp r1, #0
+	bge _0801E332
+	ldr r0, _0801E348  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xe]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	bl GetROMChapterStruct
+	ldrb r1, [r0, #0xc]
+_0801E332:
+	ldr r0, _0801E348  @ gUnknown_0202BCF0
+	strb r1, [r0, #0xd]
+	bl RefreshFogAndUnitMaps
+	bl SMS_UpdateFromGameData
+	bl UpdateGameTilesGraphics
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801E348: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START FillWarpRangeMap
+FillWarpRangeMap: @ 0x0801E34C
+	push {r4, r5, r6, r7, lr}
+	mov r7, r9
+	mov r6, r8
+	push {r6, r7}
+	mov r9, r0
+	mov r8, r1
+	ldr r6, _0801E418  @ gUnknown_0202E4E0
+	ldr r0, [r6]
+	movs r1, #1
+	negs r1, r1
+	bl ClearMapWith
+	ldr r0, _0801E41C  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r0, [r6]
+	bl SetSubjectMap
+	mov r0, r8
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	mov r0, r9
+	bl GetUnitMagBy2Range
+	adds r3, r0, #0
+	lsls r3, r3, #0x10
+	asrs r3, r3, #0x10
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #1
+	bl FillRangeMap
+	ldr r0, _0801E420  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xd]
+	cmp r0, #0
+	bne _0801E430
+	ldr r0, _0801E424  @ gUnknown_0202E4D4
+	movs r1, #2
+	ldrsh r0, [r0, r1]
+	subs r3, r0, #1
+	adds r2, r6, #0
+	cmp r3, #0
+	bge _0801E3AC
+	b _0801E4B4
+_0801E3AC:
+	ldr r0, _0801E424  @ gUnknown_0202E4D4
+	movs r1, #0
+	ldrsh r0, [r0, r1]
+	subs r4, r0, #1
+	subs r7, r3, #1
+	cmp r4, #0
+	blt _0801E40E
+	ldr r6, _0801E418  @ gUnknown_0202E4E0
+	lsls r5, r3, #2
+_0801E3BE:
+	ldr r0, [r6]
+	adds r0, r5, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0x78
+	bhi _0801E408
+	ldr r0, _0801E428  @ gUnknown_0202E4DC
+	ldr r0, [r0]
+	adds r0, r5, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r1, [r0]
+	mov r0, r8
+	bl CanUnitCrossTerrain
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0801E3F6
+	ldr r0, _0801E42C  @ gUnknown_0202E4D8
+	ldr r0, [r0]
+	adds r0, r5, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	ldr r2, _0801E418  @ gUnknown_0202E4E0
+	cmp r0, #0
+	beq _0801E408
+_0801E3F6:
+	ldr r0, [r6]
+	adds r0, r5, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	movs r2, #1
+	negs r2, r2
+	adds r1, r2, #0
+	strb r1, [r0]
+	ldr r2, _0801E418  @ gUnknown_0202E4E0
+_0801E408:
+	subs r4, #1
+	cmp r4, #0
+	bge _0801E3BE
+_0801E40E:
+	adds r3, r7, #0
+	cmp r3, #0
+	bge _0801E3AC
+	b _0801E4B4
+	.align 2, 0
+_0801E418: .4byte gUnknown_0202E4E0
+_0801E41C: .4byte gUnknown_0202E4E4
+_0801E420: .4byte gUnknown_0202BCF0
+_0801E424: .4byte gUnknown_0202E4D4
+_0801E428: .4byte gUnknown_0202E4DC
+_0801E42C: .4byte gUnknown_0202E4D8
+_0801E430:
+	ldr r0, _0801E4E0  @ gUnknown_0202E4D4
+	movs r3, #2
+	ldrsh r0, [r0, r3]
+	subs r3, r0, #1
+	adds r2, r6, #0
+	cmp r3, #0
+	blt _0801E4B4
+_0801E43E:
+	ldr r0, _0801E4E0  @ gUnknown_0202E4D4
+	movs r1, #0
+	ldrsh r0, [r0, r1]
+	subs r4, r0, #1
+	subs r7, r3, #1
+	cmp r4, #0
+	blt _0801E4AE
+	lsls r5, r3, #2
+_0801E44E:
+	ldr r0, [r2]
+	adds r0, r5, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0x78
+	bhi _0801E4A8
+	ldr r0, _0801E4E4  @ gUnknown_0202E4DC
+	ldr r0, [r0]
+	adds r0, r5, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r1, [r0]
+	mov r0, r8
+	bl CanUnitCrossTerrain
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0801E496
+	ldr r0, _0801E4E8  @ gUnknown_0202E4D8
+	ldr r0, [r0]
+	adds r0, r5, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0
+	bne _0801E496
+	ldr r0, _0801E4EC  @ gUnknown_0202E4E8
+	ldr r0, [r0]
+	adds r0, r5, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	ldr r2, _0801E4F0  @ gUnknown_0202E4E0
+	cmp r0, #0
+	bne _0801E4A8
+_0801E496:
+	ldr r2, _0801E4F0  @ gUnknown_0202E4E0
+	ldr r0, [r2]
+	adds r0, r5, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	movs r3, #1
+	negs r3, r3
+	adds r1, r3, #0
+	strb r1, [r0]
+_0801E4A8:
+	subs r4, #1
+	cmp r4, #0
+	bge _0801E44E
+_0801E4AE:
+	adds r3, r7, #0
+	cmp r3, #0
+	bge _0801E43E
+_0801E4B4:
+	mov r1, r9
+	movs r0, #0x11
+	ldrsb r0, [r1, r0]
+	ldr r1, [r2]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	mov r2, r9
+	movs r1, #0x10
+	ldrsb r1, [r2, r1]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	movs r3, #1
+	negs r3, r3
+	adds r1, r3, #0
+	strb r1, [r0]
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801E4E0: .4byte gUnknown_0202E4D4
+_0801E4E4: .4byte gUnknown_0202E4DC
+_0801E4E8: .4byte gUnknown_0202E4D8
+_0801E4EC: .4byte gUnknown_0202E4E8
+_0801E4F0: .4byte gUnknown_0202E4E0
+
+.align 2, 0 @ align with 0

--- a/asm/code_801F50C.s
+++ b/asm/code_801F50C.s
@@ -1,0 +1,31 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	THUMB_FUNC_START ChangeActiveUnitFacing
+ChangeActiveUnitFacing: @ 0x0801F50C
+	push {lr}
+	adds r2, r0, #0
+	adds r3, r1, #0
+	ldr r0, _0801F538  @ gUnknown_03004E50
+	ldr r1, [r0]
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	ldrb r1, [r1, #0x11]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl GetFacingDirection
+	adds r0, #5
+	ldr r1, _0801F53C  @ gUnknown_02033EFC
+	strb r0, [r1]
+	movs r0, #4
+	strb r0, [r1, #1]
+	adds r0, r1, #0
+	bl _MOVEUNIT6C_ChangeFutureMovement
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F538: .4byte gUnknown_03004E50
+_0801F53C: .4byte gUnknown_02033EFC
+
+.align 2, 0

--- a/asm/convoymenu.s
+++ b/asm/convoymenu.s
@@ -1,0 +1,415 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	THUMB_FUNC_START sub_801DF94
+sub_801DF94: @ 0x0801DF94
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	ldr r5, _0801DFC0  @ gUnknown_02001F70
+	bl GetConvoyItemCount
+	strb r0, [r5]
+	movs r0, #4
+	bl LoadIconPalettes
+	bl HasConvoyAccess
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0801DFC8
+	ldrb r0, [r5]
+	cmp r0, #0x63
+	bhi _0801DFC8
+	ldr r0, _0801DFC4  @ gUnknown_0859D0D0
+	adds r1, r4, #0
+	bl NewMenu_DefaultChild
+	b _0801DFD0
+	.align 2, 0
+_0801DFC0: .4byte gUnknown_02001F70
+_0801DFC4: .4byte gUnknown_0859D0D0
+_0801DFC8:
+	ldr r0, _0801DFD8  @ gUnknown_0859D0AC
+	adds r1, r4, #0
+	bl NewMenu_DefaultChild
+_0801DFD0:
+	movs r0, #0
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0801DFD8: .4byte gUnknown_0859D0AC
+
+	THUMB_FUNC_START sub_801DFDC
+sub_801DFDC: @ 0x0801DFDC
+	push {r4, lr}
+	adds r4, r0, #0
+	bl DeleteEach6CBB
+	bl sub_801EA54
+	ldr r0, _0801DFF4  @ gUnknown_0202BCB0
+	ldrh r0, [r0, #0x2e]
+	cmp r0, #0
+	beq _0801DFF8
+	movs r0, #0
+	b _0801E002
+	.align 2, 0
+_0801DFF4: .4byte gUnknown_0202BCB0
+_0801DFF8:
+	adds r0, r4, #0
+	movs r1, #0x63
+	bl Proc_GotoLabel
+	movs r0, #1
+_0801E002:
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_801E008
+sub_801E008: @ 0x0801E008
+	push {lr}
+	adds r1, r0, #0
+	movs r0, #0
+	bl sub_809EB58
+	movs r0, #0
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_801E018
+sub_801E018: @ 0x0801E018
+	push {lr}
+	ldr r0, _0801E028  @ gUnknown_0202BCB0
+	ldrh r0, [r0, #0x2e]
+	bl AddItemToConvoy
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0801E028: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_801E02C
+sub_801E02C: @ 0x0801E02C
+	push {lr}
+	ldr r0, _0801E040  @ gUnknown_0203A958
+	ldrb r0, [r0, #0xc]
+	bl GetUnitStruct
+	ldr r1, _0801E044  @ gUnknown_03004E50
+	str r0, [r1]
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801E040: .4byte gUnknown_0203A958
+_0801E044: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_801E048
+sub_801E048: @ 0x0801E048
+	push {r4, lr}
+	adds r4, r0, #0
+	bl HasConvoyAccess
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0801E084
+	ldr r0, _0801E06C  @ gUnknown_02001F70
+	ldrb r0, [r0]
+	cmp r0, #0x63
+	bhi _0801E074
+	ldr r0, _0801E070  @ gUnknown_0203A958
+	ldrh r1, [r0, #6]
+	adds r0, r4, #0
+	bl sub_801FD80
+	b _0801E08E
+	.align 2, 0
+_0801E06C: .4byte gUnknown_02001F70
+_0801E070: .4byte gUnknown_0203A958
+_0801E074:
+	ldr r0, _0801E080  @ gUnknown_0203A958
+	ldrh r1, [r0, #6]
+	adds r0, r4, #0
+	bl sub_801FD70
+	b _0801E08E
+	.align 2, 0
+_0801E080: .4byte gUnknown_0203A958
+_0801E084:
+	ldr r0, _0801E094  @ gUnknown_0203A958
+	ldrh r1, [r0, #6]
+	adds r0, r4, #0
+	bl sub_801FD70
+_0801E08E:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801E094: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START HandleNewItemGetFromDrop
+HandleNewItemGetFromDrop: @ 0x0801E098
+	push {r4, r5, r6, lr}
+	sub sp, #4
+	adds r4, r0, #0
+	adds r5, r1, #0
+	adds r6, r2, #0
+	bl UnitAddItem
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0801E128
+	ldr r0, _0801E100  @ gUnknown_03004E50
+	str r4, [r0]
+	ldr r0, _0801E104  @ gUnknown_0202BCB0
+	strh r5, [r0, #0x2c]
+	adds r0, r4, #0
+	bl GetUnitPortraitId
+	adds r1, r0, #0
+	movs r0, #2
+	str r0, [sp]
+	movs r0, #0
+	movs r2, #0xb0
+	movs r3, #4
+	bl NewFace
+	movs r0, #0
+	movs r1, #5
+	bl sub_8006458
+	adds r0, r6, #0
+	adds r1, r4, #0
+	movs r2, #0xf
+	movs r3, #0xa
+	bl sub_801E684
+	bl HasConvoyAccess
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0801E10C
+	bl GetConvoyItemCount
+	cmp r0, #0x63
+	bgt _0801E10C
+	ldr r0, _0801E108  @ 0x00000867
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r6, #0
+	bl NewBottomHelpText
+	b _0801E11A
+	.align 2, 0
+_0801E100: .4byte gUnknown_03004E50
+_0801E104: .4byte gUnknown_0202BCB0
+_0801E108: .4byte 0x00000867
+_0801E10C:
+	ldr r0, _0801E130  @ 0x00000866
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r6, #0
+	bl NewBottomHelpText
+_0801E11A:
+	movs r0, #2
+	bl sub_8008A0C
+	ldr r0, _0801E134  @ gUnknown_0859AE38
+	adds r1, r6, #0
+	bl Proc_CreateBlockingChild
+_0801E128:
+	add sp, #4
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801E130: .4byte 0x00000866
+_0801E134: .4byte gUnknown_0859AE38
+
+	THUMB_FUNC_START SendToConvoyMenu_Draw
+SendToConvoyMenu_Draw: @ 0x0801E138
+	push {lr}
+	bl ItemSelectMenu_TextDraw
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START MenuCommand_DrawExtraItem
+MenuCommand_DrawExtraItem: @ 0x0801E144
+	push {r4, r5, r6, lr}
+	adds r4, r1, #0
+	ldr r0, _0801E180  @ gUnknown_0202BCB0
+	ldrh r6, [r0, #0x2c]
+	adds r5, r4, #0
+	adds r5, #0x34
+	adds r0, r5, #0
+	movs r1, #2
+	bl Text_SetColorId
+	movs r0, #0x2c
+	ldrsh r2, [r4, r0]
+	lsls r2, r2, #5
+	movs r1, #0x2a
+	ldrsh r0, [r4, r1]
+	adds r2, r2, r0
+	lsls r2, r2, #1
+	ldr r0, _0801E184  @ gBG0TilemapBuffer
+	adds r2, r2, r0
+	adds r0, r5, #0
+	adds r1, r6, #0
+	bl DrawTextAndIconForItem
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0801E180: .4byte gUnknown_0202BCB0
+_0801E184: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START SendToConvoyMenu_NormalEffect
+SendToConvoyMenu_NormalEffect: @ 0x0801E188
+	push {r4, r5, lr}
+	adds r4, r1, #0
+	ldr r5, _0801E1D0  @ gUnknown_03004E50
+	ldr r1, [r5]
+	adds r4, #0x3c
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	lsls r0, r0, #1
+	adds r1, #0x1e
+	adds r1, r1, r0
+	ldrh r0, [r1]
+	bl AddItemToConvoy
+	ldr r3, _0801E1D4  @ gUnknown_0203A958
+	ldr r0, [r5]
+	movs r2, #0
+	ldrsb r2, [r4, r2]
+	lsls r2, r2, #1
+	adds r1, r0, #0
+	adds r1, #0x1e
+	adds r1, r1, r2
+	ldrh r1, [r1]
+	strh r1, [r3, #6]
+	movs r1, #0
+	ldrsb r1, [r4, r1]
+	bl UnitRemoveItem
+	ldr r0, [r5]
+	ldr r1, _0801E1D8  @ gUnknown_0202BCB0
+	ldrh r1, [r1, #0x2c]
+	bl UnitAddItem
+	movs r0, #0x37
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0801E1D0: .4byte gUnknown_03004E50
+_0801E1D4: .4byte gUnknown_0203A958
+_0801E1D8: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_801E1DC
+sub_801E1DC: @ 0x0801E1DC
+	push {r4, lr}
+	ldr r4, _0801E1F4  @ gUnknown_0202BCB0
+	ldrh r0, [r4, #0x2c]
+	bl AddItemToConvoy
+	ldr r1, _0801E1F8  @ gUnknown_0203A958
+	ldrh r0, [r4, #0x2c]
+	strh r0, [r1, #6]
+	movs r0, #0x37
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0801E1F4: .4byte gUnknown_0202BCB0
+_0801E1F8: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START sub_801E1FC
+sub_801E1FC: @ 0x0801E1FC
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	adds r4, r1, #0
+	ldr r2, _0801E244  @ gUnknown_0203A958
+	ldr r0, _0801E248  @ gUnknown_03004E50
+	ldr r1, [r0]
+	adds r4, #0x3c
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	lsls r0, r0, #1
+	adds r1, #0x1e
+	adds r1, r1, r0
+	ldrh r0, [r1]
+	strh r0, [r2, #6]
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	strh r0, [r2, #8]
+	movs r1, #1
+	negs r1, r1
+	movs r0, #0
+	bl LoadDialogueBoxGfx
+	movs r1, #0
+	ldrsb r1, [r4, r1]
+	lsls r1, r1, #4
+	adds r1, #0x20
+	ldr r2, _0801E24C  @ 0x0000084B
+	movs r0, #8
+	adds r3, r5, #0
+	bl sub_808AA04
+	movs r0, #0
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0801E244: .4byte gUnknown_0203A958
+_0801E248: .4byte gUnknown_03004E50
+_0801E24C: .4byte 0x0000084B
+
+	THUMB_FUNC_START sub_801E250
+sub_801E250: @ 0x0801E250
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	adds r4, r1, #0
+	ldr r1, _0801E288  @ gUnknown_0203A958
+	ldr r0, _0801E28C  @ gUnknown_0202BCB0
+	ldrh r0, [r0, #0x2c]
+	strh r0, [r1, #6]
+	movs r0, #5
+	strh r0, [r1, #8]
+	movs r1, #1
+	negs r1, r1
+	movs r0, #0
+	bl LoadDialogueBoxGfx
+	adds r4, #0x3c
+	movs r1, #0
+	ldrsb r1, [r4, r1]
+	lsls r1, r1, #4
+	adds r1, #0x20
+	ldr r2, _0801E290  @ 0x0000084B
+	movs r0, #8
+	adds r3, r5, #0
+	bl sub_808AA04
+	movs r0, #0
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0801E288: .4byte gUnknown_0203A958
+_0801E28C: .4byte gUnknown_0202BCB0
+_0801E290: .4byte 0x0000084B
+
+	THUMB_FUNC_START sub_801E294
+sub_801E294: @ 0x0801E294
+	push {r4, lr}
+	bl sub_8008A00
+	cmp r0, #1
+	beq _0801E2A2
+	movs r0, #0
+	b _0801E2C8
+_0801E2A2:
+	ldr r0, _0801E2D0  @ gKeyStatusPtr
+	ldr r1, [r0]
+	movs r0, #0
+	strh r0, [r1, #8]
+	ldr r1, _0801E2D4  @ gUnknown_0203A958
+	ldrh r0, [r1, #8]
+	cmp r0, #4
+	bhi _0801E2C6
+	ldr r4, _0801E2D8  @ gUnknown_03004E50
+	ldr r0, [r4]
+	ldrh r1, [r1, #8]
+	bl UnitRemoveItem
+	ldr r0, [r4]
+	ldr r1, _0801E2DC  @ gUnknown_0202BCB0
+	ldrh r1, [r1, #0x2c]
+	bl UnitAddItem
+_0801E2C6:
+	movs r0, #0x37
+_0801E2C8:
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0801E2D0: .4byte gKeyStatusPtr
+_0801E2D4: .4byte gUnknown_0203A958
+_0801E2D8: .4byte gUnknown_03004E50
+_0801E2DC: .4byte gUnknown_0202BCB0
+
+.align 2, 0

--- a/asm/koido.s
+++ b/asm/koido.s
@@ -1,0 +1,179 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	THUMB_FUNC_START GetSomeFacingDirection
+GetSomeFacingDirection: @ 0x0801DBD4
+	push {lr}
+	cmp r0, r2
+	bne _0801DBEA
+	cmp r1, r3
+	bge _0801DBE2
+	movs r0, #3
+	b _0801DBFC
+_0801DBE2:
+	cmp r1, r3
+	ble _0801DBEA
+	movs r0, #2
+	b _0801DBFC
+_0801DBEA:
+	cmp r1, r3
+	bne _0801DBFA
+	cmp r0, r2
+	blt _0801DBFA
+	cmp r0, r2
+	ble _0801DBFA
+	movs r0, #1
+	b _0801DBFC
+_0801DBFA:
+	movs r0, #0
+_0801DBFC:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START Make6CMOVEUNITForUnitBeingRescued
+Make6CMOVEUNITForUnitBeingRescued: @ 0x0801DC00
+	push {lr}
+	adds r3, r0, #0
+	ldr r0, [r3]
+	ldr r1, [r3, #4]
+	ldr r2, [r0, #0x28]
+	ldr r0, [r1, #0x28]
+	orrs r2, r0
+	movs r0, #1
+	ands r0, r2
+	cmp r0, #0
+	bne _0801DC1E
+	adds r0, r3, #0
+	bl MakeMOVEUNITForMapUnit
+	b _0801DC38
+_0801DC1E:
+	movs r0, #0x80
+	lsls r0, r0, #7
+	ands r2, r0
+	cmp r2, #0
+	bne _0801DC2E
+	adds r0, r3, #0
+	movs r1, #0x6f
+	b _0801DC32
+_0801DC2E:
+	adds r0, r3, #0
+	movs r1, #0x70
+_0801DC32:
+	movs r2, #0xc
+	bl Make6CMOVEUNITForUnit
+_0801DC38:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START Loop6C_KOIDO
+Loop6C_KOIDO: @ 0x0801DC3C
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	bl IsThereAMovingMoveunit
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0801DC76
+	adds r5, r4, #0
+	adds r5, #0x3c
+	movs r0, #0
+	ldrsb r0, [r5, r0]
+	cmp r0, #2
+	beq _0801DC5C
+	ldr r0, [r4, #0x34]
+	bl EndMoveunitMaybe
+_0801DC5C:
+	adds r0, r4, #0
+	bl Proc_ClearNativeCallback
+	movs r0, #0
+	ldrsb r0, [r5, r0]
+	cmp r0, #1
+	bne _0801DC76
+	bl RefreshFogAndUnitMaps
+	bl SMS_UpdateFromGameData
+	bl SMS_FlushIndirect
+_0801DC76:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START Make6CKOIDO
+Make6CKOIDO: @ 0x0801DC7C
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	adds r6, r0, #0
+	adds r4, r1, #0
+	mov r8, r2
+	adds r1, r3, #0
+	ldr r0, _0801DCCC  @ gUnknown_0859AD88
+	bl Proc_CreateBlockingChild
+	adds r7, r0, #0
+	str r6, [r7, #0x30]
+	str r4, [r7, #0x2c]
+	adds r5, r7, #0
+	adds r5, #0x38
+	movs r0, #0xe
+	strb r0, [r5]
+	adds r0, r7, #0
+	adds r0, #0x39
+	strb r4, [r0]
+	adds r1, r7, #0
+	adds r1, #0x3a
+	movs r0, #4
+	strb r0, [r1]
+	adds r0, r7, #0
+	adds r0, #0x3c
+	mov r1, r8
+	strb r1, [r0]
+	adds r0, r6, #0
+	bl Make6CMOVEUNITForUnitBeingRescued
+	str r0, [r7, #0x34]
+	adds r1, r5, #0
+	bl MOVEUNIT6C_ChangeFutureMovement
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801DCCC: .4byte gUnknown_0859AD88
+
+	THUMB_FUNC_START Make6CKOIDOAMM
+Make6CKOIDOAMM: @ 0x0801DCD0
+	push {r4, r5, r6, r7, lr}
+	adds r6, r0, #0
+	adds r4, r1, #0
+	ldr r0, _0801DD18  @ gUnknown_0859ADA0
+	movs r1, #3
+	bl Proc_Create
+	adds r7, r0, #0
+	str r6, [r7, #0x30]
+	str r4, [r7, #0x2c]
+	adds r5, r7, #0
+	adds r5, #0x38
+	movs r1, #0
+	movs r0, #0xe
+	strb r0, [r5]
+	adds r0, r7, #0
+	adds r0, #0x39
+	strb r4, [r0]
+	adds r2, r7, #0
+	adds r2, #0x3a
+	movs r0, #4
+	strb r0, [r2]
+	adds r0, r7, #0
+	adds r0, #0x3c
+	strb r1, [r0]
+	adds r0, r6, #0
+	bl Make6CMOVEUNITForUnitBeingRescued
+	str r0, [r7, #0x34]
+	adds r1, r5, #0
+	bl MOVEUNIT6C_ChangeFutureMovement
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801DD18: .4byte gUnknown_0859ADA0
+
+.align 2, 0 @ align with 0

--- a/asm/menuitempanel.s
+++ b/asm/menuitempanel.s
@@ -1,0 +1,668 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	THUMB_FUNC_START sub_801E4F4
+sub_801E4F4: @ 0x0801E4F4
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	adds r4, r0, #0
+	adds r0, #0x64
+	ldrb r0, [r0]
+	cmp r0, #0
+	bne _0801E506
+	b _0801E672
+_0801E506:
+	adds r0, r4, #0
+	adds r0, #0x33
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0
+	bge _0801E516
+	b _0801E672
+_0801E516:
+	ldr r6, _0801E67C  @ gUnknown_0203A4EC
+	movs r0, #0x5a
+	adds r0, r0, r6
+	mov r8, r0
+	ldr r5, _0801E680  @ gUnknown_0203A56C
+	adds r7, r5, #0
+	adds r7, #0x5a
+	movs r2, #0
+	ldrsh r1, [r0, r2]
+	movs r3, #0
+	ldrsh r0, [r7, r3]
+	cmp r1, r0
+	ble _0801E54A
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	lsls r0, r0, #3
+	adds r0, #0x33
+	adds r1, r4, #0
+	adds r1, #0x31
+	ldrb r1, [r1]
+	adds r1, #3
+	lsls r1, r1, #3
+	movs r2, #0
+	bl sub_8015BD4
+_0801E54A:
+	mov r0, r8
+	movs r2, #0
+	ldrsh r1, [r0, r2]
+	movs r3, #0
+	ldrsh r0, [r7, r3]
+	cmp r1, r0
+	bge _0801E572
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	lsls r0, r0, #3
+	adds r0, #0x33
+	adds r1, r4, #0
+	adds r1, #0x31
+	ldrb r1, [r1]
+	adds r1, #3
+	lsls r1, r1, #3
+	movs r2, #1
+	bl sub_8015BD4
+_0801E572:
+	adds r7, r6, #0
+	adds r7, #0x60
+	movs r0, #0x60
+	adds r0, r0, r5
+	mov r8, r0
+	movs r2, #0
+	ldrsh r1, [r7, r2]
+	movs r3, #0
+	ldrsh r0, [r0, r3]
+	cmp r1, r0
+	ble _0801E5A2
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	lsls r0, r0, #3
+	adds r0, #0x33
+	adds r1, r4, #0
+	adds r1, #0x31
+	ldrb r1, [r1]
+	adds r1, #5
+	lsls r1, r1, #3
+	movs r2, #0
+	bl sub_8015BD4
+_0801E5A2:
+	movs r0, #0
+	ldrsh r1, [r7, r0]
+	mov r2, r8
+	movs r3, #0
+	ldrsh r0, [r2, r3]
+	cmp r1, r0
+	bge _0801E5CA
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	lsls r0, r0, #3
+	adds r0, #0x33
+	adds r1, r4, #0
+	adds r1, #0x31
+	ldrb r1, [r1]
+	adds r1, #5
+	lsls r1, r1, #3
+	movs r2, #1
+	bl sub_8015BD4
+_0801E5CA:
+	adds r7, r6, #0
+	adds r7, #0x66
+	movs r0, #0x66
+	adds r0, r0, r5
+	mov r8, r0
+	movs r2, #0
+	ldrsh r1, [r7, r2]
+	movs r3, #0
+	ldrsh r0, [r0, r3]
+	cmp r1, r0
+	ble _0801E5FA
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	lsls r0, r0, #3
+	adds r0, #0x63
+	adds r1, r4, #0
+	adds r1, #0x31
+	ldrb r1, [r1]
+	adds r1, #3
+	lsls r1, r1, #3
+	movs r2, #0
+	bl sub_8015BD4
+_0801E5FA:
+	movs r0, #0
+	ldrsh r1, [r7, r0]
+	mov r2, r8
+	movs r3, #0
+	ldrsh r0, [r2, r3]
+	cmp r1, r0
+	bge _0801E622
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	lsls r0, r0, #3
+	adds r0, #0x63
+	adds r1, r4, #0
+	adds r1, #0x31
+	ldrb r1, [r1]
+	adds r1, #3
+	lsls r1, r1, #3
+	movs r2, #1
+	bl sub_8015BD4
+_0801E622:
+	adds r6, #0x62
+	adds r5, #0x62
+	movs r0, #0
+	ldrsh r1, [r6, r0]
+	movs r2, #0
+	ldrsh r0, [r5, r2]
+	cmp r1, r0
+	ble _0801E64C
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	lsls r0, r0, #3
+	adds r0, #0x63
+	adds r1, r4, #0
+	adds r1, #0x31
+	ldrb r1, [r1]
+	adds r1, #5
+	lsls r1, r1, #3
+	movs r2, #0
+	bl sub_8015BD4
+_0801E64C:
+	movs r3, #0
+	ldrsh r1, [r6, r3]
+	movs r2, #0
+	ldrsh r0, [r5, r2]
+	cmp r1, r0
+	bge _0801E672
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	lsls r0, r0, #3
+	adds r0, #0x63
+	adds r1, r4, #0
+	adds r1, #0x31
+	ldrb r1, [r1]
+	adds r1, #5
+	lsls r1, r1, #3
+	movs r2, #1
+	bl sub_8015BD4
+_0801E672:
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801E67C: .4byte gUnknown_0203A4EC
+_0801E680: .4byte gUnknown_0203A56C
+
+	THUMB_FUNC_START sub_801E684
+sub_801E684: @ 0x0801E684
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	adds r5, r0, #0
+	adds r6, r1, #0
+	adds r7, r2, #0
+	mov r8, r3
+	ldr r4, _0801E73C  @ gUnknown_0859AE88
+	adds r0, r4, #0
+	bl Proc_Find
+	cmp r0, #0
+	bne _0801E732
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl Proc_Create
+	adds r4, r0, #0
+	str r6, [r4, #0x2c]
+	adds r0, #0x30
+	strb r7, [r0]
+	adds r0, #1
+	mov r1, r8
+	strb r1, [r0]
+	adds r5, r4, #0
+	adds r5, #0x32
+	movs r0, #3
+	strb r0, [r5]
+	adds r0, r6, #0
+	bl GetUnitEquippedWeaponSlot
+	adds r1, r4, #0
+	adds r1, #0x33
+	strb r0, [r1]
+	adds r1, #0x31
+	movs r0, #1
+	strb r0, [r1]
+	adds r0, r4, #0
+	adds r0, #0x34
+	movs r1, #0xc
+	bl Text_Allocate
+	adds r0, r4, #0
+	adds r0, #0x3c
+	movs r1, #0xc
+	bl Text_Allocate
+	adds r0, r4, #0
+	adds r0, #0x44
+	movs r1, #0xc
+	bl Text_Allocate
+	ldrb r1, [r5]
+	movs r0, #1
+	bl LoadIconPalette
+	ldr r0, [r4, #0x2c]
+	movs r1, #1
+	negs r1, r1
+	bl SetupBattleStructFromUnitAndWeapon
+	ldr r3, _0801E740  @ gUnknown_0203A56C
+	ldr r2, _0801E744  @ gUnknown_0203A4EC
+	adds r0, r2, #0
+	adds r0, #0x5a
+	ldrh r0, [r0]
+	adds r1, r3, #0
+	adds r1, #0x5a
+	strh r0, [r1]
+	adds r0, r2, #0
+	adds r0, #0x60
+	ldrh r1, [r0]
+	adds r0, r3, #0
+	adds r0, #0x60
+	strh r1, [r0]
+	adds r0, r2, #0
+	adds r0, #0x66
+	ldrh r0, [r0]
+	adds r1, r3, #0
+	adds r1, #0x66
+	strh r0, [r1]
+	adds r0, r2, #0
+	adds r0, #0x62
+	ldrh r1, [r0]
+	adds r0, r3, #0
+	adds r0, #0x62
+	strh r1, [r0]
+_0801E732:
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801E73C: .4byte gUnknown_0859AE88
+_0801E740: .4byte gUnknown_0203A56C
+_0801E744: .4byte gUnknown_0203A4EC
+
+	THUMB_FUNC_START sub_801E748
+sub_801E748: @ 0x0801E748
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #0xc
+	adds r5, r0, #0
+	ldr r0, _0801E7C4  @ gUnknown_0859AE88
+	bl Proc_Find
+	adds r7, r0, #0
+	movs r0, #0
+	bl BG_GetMapBuffer
+	adds r4, r7, #0
+	adds r4, #0x30
+	ldrb r1, [r4]
+	lsls r1, r1, #1
+	adds r0, r0, r1
+	movs r1, #0x31
+	adds r1, r1, r7
+	mov r8, r1
+	ldrb r1, [r1]
+	lsls r1, r1, #6
+	adds r0, r0, r1
+	str r0, [sp, #4]
+	adds r6, r7, #0
+	adds r6, #0x34
+	ldr r2, [r7, #0x2c]
+	mov r9, r2
+	adds r0, r7, #0
+	adds r0, #0x32
+	ldrb r0, [r0]
+	str r0, [sp, #8]
+	adds r0, r6, #0
+	bl Text_Clear
+	adds r0, r7, #0
+	adds r0, #0x3c
+	bl Text_Clear
+	adds r0, r7, #0
+	adds r0, #0x44
+	bl Text_Clear
+	ldrb r0, [r4]
+	mov r2, r8
+	ldrb r1, [r2]
+	movs r2, #0
+	str r2, [sp]
+	movs r2, #0xe
+	movs r3, #8
+	bl MakeUIWindowTileMap_BG0BG1
+	cmp r5, #0
+	blt _0801E7E0
+	cmp r5, #4
+	ble _0801E7C8
+	cmp r5, #5
+	beq _0801E7D4
+	b _0801E7E0
+	.align 2, 0
+_0801E7C4: .4byte gUnknown_0859AE88
+_0801E7C8:
+	lsls r1, r5, #1
+	mov r0, r9
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r4, [r0]
+	b _0801E7E4
+_0801E7D4:
+	ldr r0, _0801E7DC  @ gUnknown_0202BCB0
+	ldrh r4, [r0, #0x2c]
+	b _0801E7E4
+	.align 2, 0
+_0801E7DC: .4byte gUnknown_0202BCB0
+_0801E7E0:
+	adds r4, r5, #0
+	movs r5, #8
+_0801E7E4:
+	adds r0, r4, #0
+	bl GetItemWType
+	cmp r0, #9
+	beq _0801E800
+	cmp r0, #9
+	bgt _0801E7F8
+	cmp r0, #4
+	beq _0801E800
+	b _0801E8A4
+_0801E7F8:
+	cmp r0, #0xc
+	bgt _0801E8A4
+	cmp r0, #0xb
+	blt _0801E8A4
+_0801E800:
+	adds r0, r4, #0
+	bl GetItemUseDescId
+	bl GetStringFromIndex
+	adds r4, r0, #0
+	movs r5, #0
+	ldr r7, [sp, #4]
+	adds r7, #0x42
+	movs r0, #8
+	adds r0, r0, r6
+	mov r8, r0
+	ldr r1, [sp, #4]
+	adds r1, #0xc2
+	mov r9, r1
+	movs r2, #0x10
+	adds r2, r2, r6
+	mov sl, r2
+	b _0801E82A
+_0801E826:
+	adds r4, #1
+	adds r5, #1
+_0801E82A:
+	lsls r0, r5, #3
+	adds r0, r6, r0
+	movs r1, #0
+	movs r2, #0
+	adds r3, r4, #0
+	bl Text_InsertString
+	adds r0, r4, #0
+	bl String_GetEnd
+	adds r4, r0, #0
+	ldrb r0, [r4]
+	cmp r0, #0
+	bne _0801E826
+	ldr r3, _0801E89C  @ gUnknown_0203A4EC
+	ldr r2, _0801E8A0  @ gUnknown_0203A56C
+	adds r0, r2, #0
+	adds r0, #0x5a
+	ldrh r0, [r0]
+	adds r1, r3, #0
+	adds r1, #0x5a
+	strh r0, [r1]
+	adds r0, r2, #0
+	adds r0, #0x60
+	ldrh r1, [r0]
+	adds r0, r3, #0
+	adds r0, #0x60
+	strh r1, [r0]
+	adds r0, r2, #0
+	adds r0, #0x66
+	ldrh r0, [r0]
+	adds r1, r3, #0
+	adds r1, #0x66
+	strh r0, [r1]
+	adds r0, r2, #0
+	adds r0, #0x62
+	ldrh r1, [r0]
+	adds r0, r3, #0
+	adds r0, #0x62
+	strh r1, [r0]
+	adds r0, r6, #0
+	adds r1, r7, #0
+	bl Text_Draw
+	mov r0, r8
+	mov r1, r9
+	bl Text_Draw
+	ldr r0, [sp, #4]
+	movs r2, #0xa1
+	lsls r2, r2, #1
+	adds r1, r0, r2
+	mov r0, sl
+	bl Text_Draw
+	b _0801EA1C
+	.align 2, 0
+_0801E89C: .4byte gUnknown_0203A4EC
+_0801E8A0: .4byte gUnknown_0203A56C
+_0801E8A4:
+	lsls r1, r5, #0x18
+	asrs r1, r1, #0x18
+	mov r0, r9
+	bl SetupBattleStructFromUnitAndWeapon
+	cmp r5, #8
+	bne _0801E8E6
+	ldr r3, _0801EA34  @ gUnknown_0203A56C
+	ldr r2, _0801EA38  @ gUnknown_0203A4EC
+	adds r0, r2, #0
+	adds r0, #0x5a
+	ldrh r0, [r0]
+	adds r1, r3, #0
+	adds r1, #0x5a
+	strh r0, [r1]
+	adds r0, r2, #0
+	adds r0, #0x60
+	ldrh r1, [r0]
+	adds r0, r3, #0
+	adds r0, #0x60
+	strh r1, [r0]
+	adds r0, r2, #0
+	adds r0, #0x66
+	ldrh r0, [r0]
+	adds r1, r3, #0
+	adds r1, #0x66
+	strh r0, [r1]
+	adds r0, r2, #0
+	adds r0, #0x62
+	ldrh r1, [r0]
+	adds r0, r3, #0
+	adds r0, #0x62
+	strh r1, [r0]
+_0801E8E6:
+	ldr r0, _0801EA38  @ gUnknown_0203A4EC
+	mov r8, r0
+	movs r1, #0x48
+	add r1, r8
+	mov sl, r1
+	ldrh r1, [r1]
+	mov r0, r9
+	bl CanUnitUseAsWeapon
+	lsls r0, r0, #0x18
+	movs r2, #1
+	mov r9, r2
+	cmp r0, #0
+	beq _0801E906
+	movs r0, #2
+	mov r9, r0
+_0801E906:
+	ldr r0, _0801EA3C  @ 0x000004F1
+	bl GetStringFromIndex
+	adds r3, r0, #0
+	adds r0, r6, #0
+	movs r1, #0x1c
+	movs r2, #0
+	bl Text_InsertString
+	adds r5, r6, #0
+	adds r5, #8
+	ldr r0, _0801EA40  @ 0x000004F3
+	bl GetStringFromIndex
+	adds r3, r0, #0
+	adds r0, r5, #0
+	movs r1, #2
+	movs r2, #0
+	bl Text_InsertString
+	adds r4, r6, #0
+	adds r4, #0x10
+	ldr r0, _0801EA44  @ 0x000004F4
+	bl GetStringFromIndex
+	adds r3, r0, #0
+	adds r0, r4, #0
+	movs r1, #2
+	movs r2, #0
+	bl Text_InsertString
+	ldr r0, _0801EA48  @ 0x00000501
+	bl GetStringFromIndex
+	adds r3, r0, #0
+	adds r0, r5, #0
+	movs r1, #0x32
+	movs r2, #0
+	bl Text_InsertString
+	ldr r0, _0801EA4C  @ 0x000004F5
+	bl GetStringFromIndex
+	adds r3, r0, #0
+	adds r0, r4, #0
+	movs r1, #0x32
+	movs r2, #0
+	bl Text_InsertString
+	mov r0, r8
+	adds r0, #0x5a
+	movs r1, #0
+	ldrsh r3, [r0, r1]
+	adds r0, r5, #0
+	movs r1, #0x24
+	mov r2, r9
+	bl Text_InsertNumberOr2Dashes
+	mov r0, r8
+	adds r0, #0x60
+	movs r2, #0
+	ldrsh r3, [r0, r2]
+	adds r0, r4, #0
+	movs r1, #0x24
+	mov r2, r9
+	bl Text_InsertNumberOr2Dashes
+	mov r0, r8
+	adds r0, #0x66
+	movs r1, #0
+	ldrsh r3, [r0, r1]
+	adds r0, r5, #0
+	movs r1, #0x54
+	mov r2, r9
+	bl Text_InsertNumberOr2Dashes
+	mov r0, r8
+	adds r0, #0x62
+	movs r2, #0
+	ldrsh r3, [r0, r2]
+	adds r0, r4, #0
+	movs r1, #0x54
+	mov r2, r9
+	bl Text_InsertNumberOr2Dashes
+	adds r0, r7, #0
+	adds r0, #0x34
+	adds r6, r7, #0
+	adds r6, #0x31
+	ldrb r1, [r6]
+	adds r1, #1
+	lsls r1, r1, #5
+	adds r1, #1
+	adds r5, r7, #0
+	adds r5, #0x30
+	ldrb r2, [r5]
+	adds r1, r1, r2
+	lsls r1, r1, #1
+	ldr r4, _0801EA50  @ gBG0TilemapBuffer
+	adds r1, r1, r4
+	bl Text_Draw
+	adds r0, r7, #0
+	adds r0, #0x3c
+	ldrb r1, [r6]
+	adds r1, #3
+	lsls r1, r1, #5
+	adds r1, #1
+	ldrb r2, [r5]
+	adds r1, r1, r2
+	lsls r1, r1, #1
+	adds r1, r1, r4
+	bl Text_Draw
+	adds r0, r7, #0
+	adds r0, #0x44
+	ldrb r1, [r6]
+	adds r1, #5
+	lsls r1, r1, #5
+	adds r1, #1
+	ldrb r2, [r5]
+	adds r1, r1, r2
+	lsls r1, r1, #1
+	adds r1, r1, r4
+	bl Text_Draw
+	ldr r4, [sp, #4]
+	adds r4, #0x50
+	mov r1, sl
+	ldrh r0, [r1]
+	bl GetItemWType
+	adds r1, r0, #0
+	adds r1, #0x70
+	ldr r0, [sp, #8]
+	lsls r2, r0, #0xc
+	adds r0, r4, #0
+	bl DrawIcon
+_0801EA1C:
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	add sp, #0xc
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801EA34: .4byte gUnknown_0203A56C
+_0801EA38: .4byte gUnknown_0203A4EC
+_0801EA3C: .4byte 0x000004F1
+_0801EA40: .4byte 0x000004F3
+_0801EA44: .4byte 0x000004F4
+_0801EA48: .4byte 0x00000501
+_0801EA4C: .4byte 0x000004F5
+_0801EA50: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_801EA54
+sub_801EA54: @ 0x0801EA54
+	push {lr}
+	ldr r0, _0801EA60  @ gUnknown_0859AE88
+	bl Proc_DeleteAllWithScript
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801EA60: .4byte gUnknown_0859AE88
+
+.align 2, 0 @ align with 0

--- a/asm/notifybox.s
+++ b/asm/notifybox.s
@@ -1,0 +1,461 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ It's like a popup but for some reason it's not
+
+	THUMB_FUNC_START sub_801F9CC
+sub_801F9CC: @ 0x0801F9CC
+	push {lr}
+	adds r2, r0, #0
+	adds r1, r2, #0
+	adds r1, #0x4c
+	ldrh r0, [r1]
+	subs r0, #1
+	strh r0, [r1]
+	lsls r0, r0, #0x10
+	cmp r0, #0
+	blt _0801F9EE
+	ldr r0, _0801F9F8  @ gKeyStatusPtr
+	ldr r0, [r0]
+	ldrh r1, [r0, #8]
+	movs r0, #3
+	ands r0, r1
+	cmp r0, #0
+	beq _0801F9F4
+_0801F9EE:
+	adds r0, r2, #0
+	bl Proc_ClearNativeCallback
+_0801F9F4:
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F9F8: .4byte gKeyStatusPtr
+
+	THUMB_FUNC_START sub_801F9FC
+sub_801F9FC: @ 0x0801F9FC
+	push {r4, r5, r6, r7, lr}
+	sub sp, #8
+	adds r7, r0, #0
+	adds r5, r1, #0
+	adds r6, r2, #0
+	adds r0, r6, #0
+	bl GetStringTextWidth
+	adds r2, r0, #0
+	cmp r5, #0
+	blt _0801FA14
+	adds r2, #0x10
+_0801FA14:
+	adds r2, #0x18
+	movs r0, #0xf0
+	subs r0, r0, r2
+	cmp r0, #0
+	bge _0801FA20
+	adds r0, #0xf
+_0801FA20:
+	asrs r4, r0, #4
+	adds r0, r2, #0
+	cmp r0, #0
+	bge _0801FA2A
+	adds r0, #7
+_0801FA2A:
+	asrs r2, r0, #3
+	movs r0, #0
+	str r0, [sp]
+	adds r0, r4, #0
+	movs r1, #8
+	movs r3, #4
+	bl MakeUIWindowTileMap_BG0BG1
+	cmp r5, #0
+	blt _0801FA5A
+	bl ResetIconGraphics_
+	movs r0, #4
+	bl LoadIconPalettes
+	lsls r0, r4, #1
+	ldr r1, _0801FA84  @ gUnknown_02022EEA
+	adds r0, r0, r1
+	movs r2, #0x80
+	lsls r2, r2, #7
+	adds r1, r5, #0
+	bl DrawIcon
+	adds r4, #2
+_0801FA5A:
+	bl sub_8003D20
+	lsls r1, r4, #1
+	ldr r0, _0801FA84  @ gUnknown_02022EEA
+	adds r1, r1, r0
+	movs r0, #0x14
+	str r0, [sp]
+	str r6, [sp, #4]
+	movs r0, #0
+	movs r2, #0
+	movs r3, #0
+	bl DrawTextInline
+	ldr r0, _0801FA88  @ gUnknown_0859B0C0
+	adds r1, r7, #0
+	bl Proc_CreateBlockingChild
+	add sp, #8
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801FA84: .4byte gUnknown_02022EEA
+_0801FA88: .4byte gUnknown_0859B0C0
+
+	THUMB_FUNC_START sub_801FA8C
+sub_801FA8C: @ 0x0801FA8C
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #0xc
+	mov sl, r0
+	adds r7, r1, #0
+	mov r8, r2
+	mov r9, r3
+	movs r4, #1
+	cmp r2, #0
+	beq _0801FAAE
+	mov r0, r8
+	bl GetStringTextWidth
+	adds r4, r0, #3
+_0801FAAE:
+	ldr r0, [sp, #0x2c]
+	cmp r0, #0
+	beq _0801FABC
+	bl GetStringTextWidth
+	adds r1, r4, #2
+	adds r4, r1, r0
+_0801FABC:
+	movs r5, #8
+	mov r0, r9
+	b _0801FAC4
+_0801FAC2:
+	adds r5, #8
+_0801FAC4:
+	movs r1, #0xa
+	bl __divsi3
+	cmp r0, #0
+	bne _0801FAC2
+	cmp r7, #0
+	blt _0801FAD4
+	adds r4, #0x10
+_0801FAD4:
+	adds r4, #0x18
+	movs r0, #0xf0
+	subs r0, r0, r4
+	cmp r0, #0
+	bge _0801FAE0
+	adds r0, #0xf
+_0801FAE0:
+	asrs r6, r0, #4
+	adds r4, r4, r5
+	adds r1, r4, #0
+	cmp r4, #0
+	bge _0801FAEC
+	adds r1, r4, #7
+_0801FAEC:
+	asrs r5, r1, #3
+	movs r0, #0
+	str r0, [sp]
+	adds r0, r6, #0
+	movs r1, #8
+	adds r2, r5, #0
+	movs r3, #4
+	bl MakeUIWindowTileMap_BG0BG1
+	cmp r7, #0
+	blt _0801FB1E
+	bl ResetIconGraphics_
+	movs r0, #4
+	bl LoadIconPalettes
+	lsls r0, r6, #1
+	ldr r1, _0801FBA4  @ gUnknown_02022EEA
+	adds r0, r0, r1
+	movs r2, #0x80
+	lsls r2, r2, #7
+	adds r1, r7, #0
+	bl DrawIcon
+	adds r6, #2
+_0801FB1E:
+	bl sub_8003D20
+	add r0, sp, #4
+	adds r1, r5, #0
+	bl Text_Init
+	add r0, sp, #4
+	movs r1, #1
+	bl Text_Advance
+	mov r0, r8
+	cmp r0, #0
+	beq _0801FB50
+	add r0, sp, #4
+	movs r1, #0
+	bl Text_SetColorId
+	add r0, sp, #4
+	mov r1, r8
+	bl Text_AppendString
+	add r0, sp, #4
+	movs r1, #2
+	bl Text_Advance
+_0801FB50:
+	add r0, sp, #4
+	movs r1, #2
+	bl Text_SetColorId
+	add r0, sp, #4
+	mov r1, r9
+	bl sub_80040C0
+	ldr r0, [sp, #0x2c]
+	cmp r0, #0
+	beq _0801FB7E
+	add r0, sp, #4
+	movs r1, #2
+	bl Text_Advance
+	add r0, sp, #4
+	movs r1, #0
+	bl Text_SetColorId
+	add r0, sp, #4
+	ldr r1, [sp, #0x2c]
+	bl Text_AppendString
+_0801FB7E:
+	lsls r1, r6, #1
+	ldr r0, _0801FBA4  @ gUnknown_02022EEA
+	adds r1, r1, r0
+	add r0, sp, #4
+	bl Text_Draw
+	ldr r0, _0801FBA8  @ gUnknown_0859B0C0
+	mov r1, sl
+	bl Proc_CreateBlockingChild
+	add sp, #0xc
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801FBA4: .4byte gUnknown_02022EEA
+_0801FBA8: .4byte gUnknown_0859B0C0
+
+	THUMB_FUNC_START sub_801FBAC
+sub_801FBAC: @ 0x0801FBAC
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	sub sp, #0xc
+	mov r8, r0
+	adds r7, r1, #0
+	adds r4, r2, #0
+	bl sub_8003D20
+	add r0, sp, #4
+	movs r1, #0x14
+	bl Text_Init
+	add r0, sp, #4
+	movs r1, #2
+	bl Text_SetColorId
+	adds r0, r7, #0
+	bl GetItemNameString
+	adds r1, r0, #0
+	add r0, sp, #4
+	bl Text_AppendString
+	add r0, sp, #4
+	movs r1, #2
+	bl Text_Advance
+	add r0, sp, #4
+	movs r1, #0
+	bl Text_SetColorId
+	adds r0, r4, #0
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	add r0, sp, #4
+	bl Text_AppendString
+	add r0, sp, #4
+	bl Text_GetXCursor
+	adds r2, r0, #0
+	adds r2, #0x28
+	movs r0, #0xf0
+	subs r0, r0, r2
+	cmp r0, #0
+	bge _0801FC0E
+	adds r0, #0xf
+_0801FC0E:
+	asrs r5, r0, #4
+	adds r0, r2, #0
+	cmp r0, #0
+	bge _0801FC18
+	adds r0, #7
+_0801FC18:
+	asrs r2, r0, #3
+	movs r0, #0
+	str r0, [sp]
+	adds r0, r5, #0
+	movs r1, #8
+	movs r3, #4
+	bl MakeUIWindowTileMap_BG0BG1
+	lsls r5, r5, #1
+	ldr r4, _0801FC60  @ gUnknown_02022EEA
+	adds r6, r5, r4
+	adds r0, r7, #0
+	bl GetItemIconId
+	adds r1, r0, #0
+	movs r2, #0x80
+	lsls r2, r2, #7
+	adds r0, r6, #0
+	bl DrawIcon
+	adds r4, #4
+	adds r5, r5, r4
+	add r0, sp, #4
+	adds r1, r5, #0
+	bl Text_Draw
+	ldr r0, _0801FC64  @ gUnknown_0859B0C0
+	mov r1, r8
+	bl Proc_CreateBlockingChild
+	add sp, #0xc
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801FC60: .4byte gUnknown_02022EEA
+_0801FC64: .4byte gUnknown_0859B0C0
+
+	THUMB_FUNC_START sub_801FC68
+sub_801FC68: @ 0x0801FC68
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	sub sp, #0xc
+	mov r8, r0
+	adds r7, r1, #0
+	adds r4, r2, #0
+	adds r5, r3, #0
+	bl sub_8003D20
+	add r0, sp, #4
+	movs r1, #0x14
+	bl Text_Init
+	cmp r4, #0
+	beq _0801FCA6
+	add r0, sp, #4
+	movs r1, #0
+	bl Text_SetColorId
+	adds r0, r4, #0
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	add r0, sp, #4
+	bl Text_AppendString
+	add r0, sp, #4
+	movs r1, #2
+	bl Text_Advance
+_0801FCA6:
+	add r0, sp, #4
+	movs r1, #2
+	bl Text_SetColorId
+	cmp r4, #0
+	beq _0801FCB8
+	adds r0, r7, #0
+	movs r1, #0
+	b _0801FCBC
+_0801FCB8:
+	adds r0, r7, #0
+	movs r1, #1
+_0801FCBC:
+	bl GetItemSomeString
+	adds r1, r0, #0
+	add r0, sp, #4
+	bl Text_AppendString
+	add r0, sp, #4
+	bl Text_GetXCursor
+	adds r1, r0, #7
+	cmp r1, #0
+	bge _0801FCD6
+	adds r1, #7
+_0801FCD6:
+	asrs r4, r1, #3
+	adds r1, r4, #2
+	lsls r1, r1, #3
+	add r0, sp, #4
+	bl Text_SetXCursor
+	add r0, sp, #4
+	movs r1, #0
+	bl Text_SetColorId
+	cmp r5, #0
+	beq _0801FCFC
+	adds r0, r5, #0
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	add r0, sp, #4
+	bl Text_AppendString
+_0801FCFC:
+	add r0, sp, #4
+	bl Text_GetXCursor
+	adds r2, r0, #0
+	adds r2, #0x18
+	movs r0, #0xf0
+	subs r0, r0, r2
+	cmp r0, #0
+	bge _0801FD10
+	adds r0, #0xf
+_0801FD10:
+	asrs r6, r0, #4
+	adds r0, r2, #0
+	cmp r0, #0
+	bge _0801FD1A
+	adds r0, #7
+_0801FD1A:
+	asrs r2, r0, #3
+	movs r0, #0
+	str r0, [sp]
+	adds r0, r6, #0
+	movs r1, #8
+	movs r3, #4
+	bl MakeUIWindowTileMap_BG0BG1
+	lsls r1, r6, #1
+	ldr r5, _0801FD68  @ gUnknown_02022EEA
+	adds r1, r1, r5
+	add r0, sp, #4
+	bl Text_Draw
+	adds r4, #1
+	adds r4, r6, r4
+	lsls r4, r4, #1
+	subs r5, #2
+	adds r4, r4, r5
+	adds r0, r7, #0
+	bl GetItemIconId
+	adds r1, r0, #0
+	movs r2, #0x80
+	lsls r2, r2, #7
+	adds r0, r4, #0
+	bl DrawIcon
+	ldr r0, _0801FD6C  @ gUnknown_0859B0C0
+	mov r1, r8
+	bl Proc_CreateBlockingChild
+	add sp, #0xc
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801FD68: .4byte gUnknown_02022EEA
+_0801FD6C: .4byte gUnknown_0859B0C0
+
+	THUMB_FUNC_START sub_801FD70
+sub_801FD70: @ 0x0801FD70
+	push {lr}
+	movs r2, #0xf
+	movs r3, #0x22
+	bl sub_801FC68
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_801FD80
+sub_801FD80: @ 0x0801FD80
+	push {lr}
+	movs r2, #0x10
+	movs r3, #0x11
+	bl sub_801FC68
+	pop {r0}
+	bx r0
+
+.align 2, 0 @ align with 0

--- a/asm/phasechangefx.s
+++ b/asm/phasechangefx.s
@@ -1,0 +1,1096 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	THUMB_FUNC_START sub_801EC64
+sub_801EC64: @ 0x0801EC64
+	push {lr}
+	ldr r1, _0801EC94  @ 0x04000050
+	ldr r2, _0801EC98  @ 0x00003C42
+	adds r0, r2, #0
+	strh r0, [r1]
+	ldr r2, _0801EC9C  @ 0x04000052
+	ldr r1, _0801ECA0  @ gUnknown_0202BCB0
+	adds r0, r1, #0
+	adds r0, #0x3a
+	ldrb r0, [r0]
+	strb r0, [r2]
+	adds r2, #1
+	adds r1, #0x3b
+	ldrb r0, [r1]
+	strb r0, [r2]
+	movs r0, #0x48
+	bl sub_8001308
+	ldr r0, _0801ECA4  @ sub_801ECA8
+	bl SetInterrupt_LCDVCountMatch
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801EC94: .4byte 0x04000050
+_0801EC98: .4byte 0x00003C42
+_0801EC9C: .4byte 0x04000052
+_0801ECA0: .4byte gUnknown_0202BCB0
+_0801ECA4: .4byte sub_801ECA8
+
+	THUMB_FUNC_START sub_801ECA8
+sub_801ECA8: @ 0x0801ECA8
+	push {lr}
+	ldr r1, _0801ECD8  @ 0x04000050
+	ldr r2, _0801ECDC  @ 0x00003E41
+	adds r0, r2, #0
+	strh r0, [r1]
+	ldr r2, _0801ECE0  @ 0x04000052
+	ldr r1, _0801ECE4  @ gUnknown_0202BCB0
+	adds r0, r1, #0
+	adds r0, #0x38
+	ldrb r0, [r0]
+	strb r0, [r2]
+	adds r2, #1
+	adds r1, #0x39
+	ldrb r0, [r1]
+	strb r0, [r2]
+	movs r0, #0x60
+	bl sub_8001308
+	ldr r0, _0801ECE8  @ sub_801ECEC
+	bl SetInterrupt_LCDVCountMatch
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801ECD8: .4byte 0x04000050
+_0801ECDC: .4byte 0x00003E41
+_0801ECE0: .4byte 0x04000052
+_0801ECE4: .4byte gUnknown_0202BCB0
+_0801ECE8: .4byte sub_801ECEC
+
+	THUMB_FUNC_START sub_801ECEC
+sub_801ECEC: @ 0x0801ECEC
+	push {lr}
+	ldr r1, _0801ED1C  @ 0x04000050
+	ldr r2, _0801ED20  @ 0x00003C42
+	adds r0, r2, #0
+	strh r0, [r1]
+	ldr r2, _0801ED24  @ 0x04000052
+	ldr r1, _0801ED28  @ gUnknown_0202BCB0
+	adds r0, r1, #0
+	adds r0, #0x3a
+	ldrb r0, [r0]
+	strb r0, [r2]
+	adds r2, #1
+	adds r1, #0x3b
+	ldrb r0, [r1]
+	strb r0, [r2]
+	movs r0, #0
+	bl sub_8001308
+	ldr r0, _0801ED2C  @ sub_801EC64
+	bl SetInterrupt_LCDVCountMatch
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801ED1C: .4byte 0x04000050
+_0801ED20: .4byte 0x00003C42
+_0801ED24: .4byte 0x04000052
+_0801ED28: .4byte gUnknown_0202BCB0
+_0801ED2C: .4byte sub_801EC64
+
+	THUMB_FUNC_START sub_801ED30
+sub_801ED30: @ 0x0801ED30
+	push {lr}
+	ldr r2, _0801ED50  @ gUnknown_02022EE8
+	movs r1, #0
+	ldr r0, _0801ED54  @ 0x00005140
+	adds r3, r0, #0
+_0801ED3A:
+	adds r0, r1, r3
+	strh r0, [r2]
+	adds r2, #2
+	adds r1, #1
+	cmp r1, #0x5f
+	ble _0801ED3A
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801ED50: .4byte gUnknown_02022EE8
+_0801ED54: .4byte 0x00005140
+
+	THUMB_FUNC_START sub_801ED58
+sub_801ED58: @ 0x0801ED58
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	bl Sound_GetCurrentSong
+	adds r4, r0, #0
+	bl GetCurrentMapMusicIndex
+	cmp r4, r0
+	beq _0801ED70
+	movs r0, #4
+	bl Sound_FadeOut800231C
+_0801ED70:
+	ldr r0, _0801ED90  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _0801ED82
+	movs r0, #0x73
+	bl m4aSongNumStart
+_0801ED82:
+	adds r1, r5, #0
+	adds r1, #0x4c
+	movs r0, #0xf
+	strh r0, [r1]
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801ED90: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START sub_801ED94
+sub_801ED94: @ 0x0801ED94
+	push {r4, r5, lr}
+	sub sp, #4
+	adds r5, r0, #0
+	bl CheckSomethingSomewhere
+	cmp r0, #0
+	beq _0801EDAA
+	movs r2, #0
+	movs r1, #0x14
+	negs r1, r1
+	b _0801EDB2
+_0801EDAA:
+	movs r2, #8
+	negs r2, r2
+	movs r1, #0x1c
+	negs r1, r1
+_0801EDB2:
+	adds r4, r5, #0
+	adds r4, #0x4c
+	movs r0, #0
+	ldrsh r3, [r4, r0]
+	movs r0, #0x10
+	str r0, [sp]
+	movs r0, #5
+	bl sub_8012DCC
+	adds r1, r0, #0
+	lsls r1, r1, #0x10
+	lsrs r1, r1, #0x10
+	movs r0, #0
+	movs r2, #0
+	bl BG_SetPosition
+	ldr r1, _0801EE04  @ gUnknown_0202BCB0
+	adds r2, r1, #0
+	adds r2, #0x38
+	ldrb r0, [r2]
+	adds r0, #1
+	strb r0, [r2]
+	adds r1, #0x39
+	ldrb r0, [r1]
+	subs r0, #1
+	strb r0, [r1]
+	ldrh r0, [r4]
+	subs r0, #1
+	strh r0, [r4]
+	lsls r0, r0, #0x10
+	cmp r0, #0
+	bge _0801EDFC
+	movs r0, #0xf
+	strh r0, [r4]
+	adds r0, r5, #0
+	bl Proc_ClearNativeCallback
+_0801EDFC:
+	add sp, #4
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801EE04: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_801EE08
+sub_801EE08: @ 0x0801EE08
+	push {r4, r5, lr}
+	sub sp, #4
+	adds r5, r0, #0
+	bl CheckSomethingSomewhere
+	cmp r0, #0
+	beq _0801EE20
+	movs r2, #0x14
+	negs r2, r2
+	movs r1, #0x30
+	negs r1, r1
+	b _0801EE28
+_0801EE20:
+	movs r2, #0x1c
+	negs r2, r2
+	movs r1, #0x38
+	negs r1, r1
+_0801EE28:
+	adds r4, r5, #0
+	adds r4, #0x4c
+	movs r0, #0
+	ldrsh r3, [r4, r0]
+	movs r0, #0x10
+	str r0, [sp]
+	movs r0, #2
+	bl sub_8012DCC
+	adds r1, r0, #0
+	lsls r1, r1, #0x10
+	lsrs r1, r1, #0x10
+	movs r0, #0
+	movs r2, #0
+	bl BG_SetPosition
+	ldr r1, _0801EE7C  @ gUnknown_0202BCB0
+	adds r2, r1, #0
+	adds r2, #0x38
+	ldrb r0, [r2]
+	subs r0, #1
+	strb r0, [r2]
+	adds r1, #0x39
+	ldrb r0, [r1]
+	adds r0, #1
+	strb r0, [r1]
+	ldrh r0, [r4]
+	subs r0, #1
+	strh r0, [r4]
+	lsls r0, r0, #0x10
+	cmp r0, #0
+	bge _0801EE72
+	movs r0, #0xf
+	strh r0, [r4]
+	adds r0, r5, #0
+	bl Proc_ClearNativeCallback
+_0801EE72:
+	add sp, #4
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801EE7C: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_801EE80
+sub_801EE80: @ 0x0801EE80
+	push {lr}
+	ldr r0, _0801EE94  @ gBG0TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801EE94: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_801EE98
+sub_801EE98: @ 0x0801EE98
+	adds r1, r0, #0
+	adds r1, #0x4c
+	movs r2, #0
+	strh r2, [r1]
+	adds r0, #0x4e
+	strh r2, [r0]
+	bx lr
+
+	THUMB_FUNC_START sub_801EEA8
+sub_801EEA8: @ 0x0801EEA8
+	push {r4, r5, r6, r7, lr}
+	mov r7, r9
+	mov r6, r8
+	push {r6, r7}
+	sub sp, #4
+	adds r6, r0, #0
+	movs r0, #0x4e
+	adds r0, r0, r6
+	mov r8, r0
+	movs r1, #0
+	ldrsh r5, [r0, r1]
+	cmp r5, #1
+	beq _0801EF02
+	cmp r5, #1
+	bgt _0801EECC
+	cmp r5, #0
+	beq _0801EED2
+	b _0801EF58
+_0801EECC:
+	cmp r5, #2
+	beq _0801EF28
+	b _0801EF58
+_0801EED2:
+	movs r2, #0x80
+	lsls r2, r2, #1
+	adds r4, r6, #0
+	adds r4, #0x4c
+	movs r0, #0
+	ldrsh r3, [r4, r0]
+	movs r0, #0xf
+	str r0, [sp]
+	movs r0, #4
+	movs r1, #0x10
+	bl sub_8012DCC
+	adds r7, r0, #0
+	ldrh r1, [r4]
+	movs r2, #0
+	ldrsh r0, [r4, r2]
+	cmp r0, #0xe
+	ble _0801EF4C
+	strh r5, [r4]
+	mov r3, r8
+	ldrh r0, [r3]
+	adds r0, #1
+	strh r0, [r3]
+	b _0801EF58
+_0801EF02:
+	movs r7, #0x80
+	lsls r7, r7, #1
+	adds r1, r6, #0
+	adds r1, #0x4c
+	ldrh r2, [r1]
+	movs r3, #0
+	ldrsh r0, [r1, r3]
+	cmp r0, #0x1d
+	bgt _0801EF1A
+	adds r0, r2, #1
+	strh r0, [r1]
+	b _0801EF58
+_0801EF1A:
+	movs r0, #0
+	strh r0, [r1]
+	mov r1, r8
+	ldrh r0, [r1]
+	adds r0, #1
+	strh r0, [r1]
+	b _0801EF58
+_0801EF28:
+	movs r1, #0x80
+	lsls r1, r1, #1
+	adds r4, r6, #0
+	adds r4, #0x4c
+	movs r2, #0
+	ldrsh r3, [r4, r2]
+	movs r0, #0xf
+	str r0, [sp]
+	movs r0, #2
+	movs r2, #0x10
+	bl sub_8012DCC
+	adds r7, r0, #0
+	ldrh r1, [r4]
+	movs r3, #0
+	ldrsh r0, [r4, r3]
+	cmp r0, #0xe
+	bgt _0801EF52
+_0801EF4C:
+	adds r0, r1, #1
+	strh r0, [r4]
+	b _0801EF58
+_0801EF52:
+	adds r0, r6, #0
+	bl Proc_ClearNativeCallback
+_0801EF58:
+	ldr r4, _0801EFE0  @ gSinLookup
+	movs r0, #0x80
+	adds r0, r0, r4
+	mov r9, r0
+	movs r1, #0
+	ldrsh r0, [r0, r1]
+	lsls r0, r0, #4
+	movs r2, #0x80
+	lsls r2, r2, #1
+	mov r8, r2
+	mov r1, r8
+	bl Div
+	adds r6, r0, #0
+	lsls r6, r6, #0x10
+	asrs r6, r6, #0x10
+	movs r3, #0
+	ldrsh r0, [r4, r3]
+	negs r0, r0
+	lsls r0, r0, #4
+	adds r1, r7, #0
+	bl Div
+	adds r5, r0, #0
+	lsls r5, r5, #0x10
+	asrs r5, r5, #0x10
+	movs r1, #0
+	ldrsh r0, [r4, r1]
+	lsls r0, r0, #4
+	mov r1, r8
+	bl Div
+	adds r4, r0, #0
+	lsls r4, r4, #0x10
+	asrs r4, r4, #0x10
+	mov r2, r9
+	movs r3, #0
+	ldrsh r0, [r2, r3]
+	lsls r0, r0, #4
+	adds r1, r7, #0
+	bl Div
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x10
+	str r0, [sp]
+	movs r0, #0
+	adds r1, r6, #0
+	adds r2, r5, #0
+	adds r3, r4, #0
+	bl WriteOAMRotScaleData
+	ldr r3, _0801EFE4  @ gUnknown_0859AEC8
+	movs r0, #0x98
+	lsls r0, r0, #6
+	str r0, [sp]
+	movs r0, #2
+	movs r1, #0
+	movs r2, #0x44
+	bl RegisterObjectAttributes
+	add sp, #4
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801EFE0: .4byte gSinLookup
+_0801EFE4: .4byte gUnknown_0859AEC8
+
+	THUMB_FUNC_START sub_801EFE8
+sub_801EFE8: @ 0x0801EFE8
+	adds r0, #0x4c
+	movs r1, #4
+	strh r1, [r0]
+	bx lr
+
+	THUMB_FUNC_START sub_801EFF0
+sub_801EFF0: @ 0x0801EFF0
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #4
+	mov sl, r0
+	movs r6, #9
+	movs r0, #0x4c
+	add r0, sl
+	mov r8, r0
+	ldr r1, _0801F0C0  @ gBG1TilemapBuffer
+	mov ip, r1
+_0801F00A:
+	movs r2, #0xe
+	str r2, [sp]
+	lsls r0, r6, #1
+	lsls r2, r6, #6
+	subs r3, r6, #1
+	mov r9, r3
+	adds r0, #1
+	lsls r1, r0, #5
+	adds r1, #0x1d
+	lsls r0, r0, #6
+	add r0, ip
+	adds r5, r0, #0
+	adds r5, #0x38
+	adds r2, #0x1d
+	lsls r0, r6, #7
+	add r0, ip
+	adds r4, r0, #0
+	adds r4, #0x38
+	lsls r2, r2, #1
+	add r2, ip
+	lsls r1, r1, #1
+	add r1, ip
+_0801F036:
+	mov r7, r8
+	movs r3, #0
+	ldrsh r0, [r7, r3]
+	ldr r7, [sp]
+	subs r0, r7, r0
+	adds r0, #0x15
+	subs r3, r0, r6
+	cmp r3, #0x10
+	ble _0801F04A
+	movs r3, #0x10
+_0801F04A:
+	cmp r3, #0
+	bge _0801F050
+	movs r3, #0
+_0801F050:
+	movs r0, #0x10
+	subs r3, r0, r3
+	movs r0, #0xfe
+	ands r3, r0
+	movs r7, #0xa2
+	lsls r7, r7, #7
+	adds r0, r7, #0
+	adds r0, r3, r0
+	strh r0, [r4]
+	adds r7, #1
+	adds r0, r7, #0
+	adds r0, r3, r0
+	strh r0, [r2]
+	adds r7, #0x1f
+	adds r0, r3, r7
+	strh r0, [r5]
+	adds r7, #1
+	adds r0, r3, r7
+	strh r0, [r1]
+	subs r1, #4
+	subs r5, #4
+	subs r2, #4
+	subs r4, #4
+	ldr r0, [sp]
+	subs r0, #1
+	str r0, [sp]
+	cmp r0, #0
+	bge _0801F036
+	mov r6, r9
+	cmp r6, #0
+	bge _0801F00A
+	mov r1, r8
+	ldrh r0, [r1]
+	adds r0, #1
+	strh r0, [r1]
+	movs r0, #2
+	bl BG_EnableSyncByMask
+	mov r2, r8
+	movs r3, #0
+	ldrsh r0, [r2, r3]
+	cmp r0, #0x22
+	bne _0801F0B0
+	movs r0, #0
+	strh r0, [r2]
+	mov r0, sl
+	bl Proc_ClearNativeCallback
+_0801F0B0:
+	add sp, #4
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F0C0: .4byte gBG1TilemapBuffer
+
+	THUMB_FUNC_START sub_801F0C4
+sub_801F0C4: @ 0x0801F0C4
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #4
+	mov sl, r0
+	movs r6, #9
+	movs r0, #0x4c
+	add r0, sl
+	mov r8, r0
+	ldr r1, _0801F190  @ gBG1TilemapBuffer
+	mov ip, r1
+_0801F0DE:
+	movs r2, #0xe
+	str r2, [sp]
+	lsls r0, r6, #1
+	lsls r2, r6, #6
+	subs r3, r6, #1
+	mov r9, r3
+	adds r0, #1
+	lsls r1, r0, #5
+	adds r1, #0x1d
+	lsls r0, r0, #6
+	add r0, ip
+	adds r5, r0, #0
+	adds r5, #0x38
+	adds r2, #0x1d
+	lsls r0, r6, #7
+	add r0, ip
+	adds r4, r0, #0
+	adds r4, #0x38
+	lsls r2, r2, #1
+	add r2, ip
+	lsls r1, r1, #1
+	add r1, ip
+_0801F10A:
+	mov r7, r8
+	movs r3, #0
+	ldrsh r0, [r7, r3]
+	ldr r7, [sp]
+	subs r0, r7, r0
+	adds r0, #0x15
+	subs r3, r0, r6
+	cmp r3, #0x10
+	ble _0801F11E
+	movs r3, #0x10
+_0801F11E:
+	cmp r3, #0
+	bge _0801F124
+	movs r3, #0
+_0801F124:
+	movs r0, #0xfe
+	ands r3, r0
+	ldr r7, _0801F194  @ 0x00005501
+	adds r0, r7, #0
+	adds r0, r3, r0
+	strh r0, [r4]
+	subs r7, #1
+	adds r0, r7, #0
+	adds r0, r3, r0
+	strh r0, [r2]
+	adds r7, #0x21
+	adds r0, r3, r7
+	strh r0, [r5]
+	subs r7, #1
+	adds r0, r3, r7
+	strh r0, [r1]
+	subs r1, #4
+	subs r5, #4
+	subs r2, #4
+	subs r4, #4
+	ldr r0, [sp]
+	subs r0, #1
+	str r0, [sp]
+	cmp r0, #0
+	bge _0801F10A
+	mov r6, r9
+	cmp r6, #0
+	bge _0801F0DE
+	mov r1, r8
+	ldrh r0, [r1]
+	adds r0, #1
+	strh r0, [r1]
+	movs r0, #2
+	bl BG_EnableSyncByMask
+	mov r2, r8
+	movs r3, #0
+	ldrsh r0, [r2, r3]
+	cmp r0, #0x24
+	bne _0801F17E
+	movs r0, #0
+	strh r0, [r2]
+	mov r0, sl
+	bl Proc_ClearNativeCallback
+_0801F17E:
+	add sp, #4
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F190: .4byte gBG1TilemapBuffer
+_0801F194: .4byte 0x00005501
+
+	THUMB_FUNC_START sub_801F198
+sub_801F198: @ 0x0801F198
+	adds r0, #0x4c
+	movs r1, #4
+	strh r1, [r0]
+	bx lr
+
+	THUMB_FUNC_START sub_801F1A0
+sub_801F1A0: @ 0x0801F1A0
+	push {r4, r5, r6, lr}
+	sub sp, #4
+	adds r6, r0, #0
+	adds r4, r6, #0
+	adds r4, #0x4c
+	movs r0, #0
+	ldrsh r3, [r4, r0]
+	movs r5, #0x20
+	str r5, [sp]
+	movs r0, #5
+	movs r1, #0x10
+	movs r2, #0x3c
+	bl sub_8012DCC
+	ldr r3, _0801F220  @ gLCDControlBuffer
+	adds r2, r3, #0
+	adds r2, #0x2d
+	movs r1, #0
+	strb r1, [r2]
+	adds r1, r0, #0
+	adds r1, #8
+	adds r2, #4
+	strb r1, [r2]
+	subs r2, #5
+	movs r1, #0xf0
+	strb r1, [r2]
+	movs r2, #0x60
+	negs r2, r2
+	adds r1, r2, #0
+	subs r1, r1, r0
+	adds r0, r3, #0
+	adds r0, #0x30
+	strb r1, [r0]
+	movs r0, #0
+	ldrsh r3, [r4, r0]
+	str r5, [sp]
+	movs r0, #0
+	movs r1, #0
+	movs r2, #7
+	bl sub_8012DCC
+	ldr r2, _0801F224  @ gUnknown_0202BCB0
+	adds r1, r2, #0
+	adds r1, #0x3a
+	strb r0, [r1]
+	movs r1, #0x10
+	subs r1, r1, r0
+	adds r2, #0x3b
+	strb r1, [r2]
+	ldrh r0, [r4]
+	adds r0, #1
+	strh r0, [r4]
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x10
+	cmp r0, #0x20
+	bne _0801F216
+	adds r0, r6, #0
+	bl Proc_ClearNativeCallback
+_0801F216:
+	add sp, #4
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F220: .4byte gLCDControlBuffer
+_0801F224: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_801F228
+sub_801F228: @ 0x0801F228
+	push {r4, r5, r6, lr}
+	sub sp, #4
+	adds r6, r0, #0
+	adds r4, r6, #0
+	adds r4, #0x4c
+	movs r0, #0
+	ldrsh r3, [r4, r0]
+	movs r5, #0x20
+	str r5, [sp]
+	movs r0, #5
+	movs r1, #0
+	movs r2, #0x3c
+	bl sub_8012DCC
+	ldr r3, _0801F2A4  @ gLCDControlBuffer
+	adds r2, r3, #0
+	adds r2, #0x2d
+	movs r1, #0
+	strb r1, [r2]
+	adds r1, r0, #0
+	adds r1, #8
+	adds r2, #4
+	strb r1, [r2]
+	subs r2, #5
+	movs r1, #0xf0
+	strb r1, [r2]
+	movs r2, #0x60
+	negs r2, r2
+	adds r1, r2, #0
+	subs r1, r1, r0
+	adds r0, r3, #0
+	adds r0, #0x30
+	strb r1, [r0]
+	movs r0, #0
+	ldrsh r3, [r4, r0]
+	str r5, [sp]
+	movs r0, #0
+	movs r1, #0
+	movs r2, #7
+	bl sub_8012DCC
+	ldr r2, _0801F2A8  @ gUnknown_0202BCB0
+	adds r1, r2, #0
+	adds r1, #0x3a
+	strb r0, [r1]
+	movs r1, #0x10
+	subs r1, r1, r0
+	adds r2, #0x3b
+	strb r1, [r2]
+	ldrh r0, [r4]
+	subs r0, #1
+	strh r0, [r4]
+	lsls r0, r0, #0x10
+	cmp r0, #0
+	bge _0801F29C
+	adds r0, r6, #0
+	bl Proc_ClearNativeCallback
+_0801F29C:
+	add sp, #4
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F2A4: .4byte gLCDControlBuffer
+_0801F2A8: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_801F2AC
+sub_801F2AC: @ 0x0801F2AC
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _0801F2C8  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xf]
+	bl GetPhaseAbleUnitCount
+	cmp r0, #0
+	bne _0801F2C2
+	adds r0, r4, #0
+	bl Proc_Delete
+_0801F2C2:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F2C8: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START sub_801F2CC
+sub_801F2CC: @ 0x0801F2CC
+	push {r4, lr}
+	ldr r0, _0801F310  @ gUnknown_0859F020
+	ldr r1, _0801F314  @ 0x06014000
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _0801F318  @ gUnknown_085A06D8
+	ldr r1, _0801F31C  @ 0x06002000
+	bl CopyDataWithPossibleUncomp
+	movs r0, #0
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	movs r0, #1
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	movs r0, #2
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	ldr r0, _0801F320  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xf]
+	cmp r0, #0x40
+	beq _0801F374
+	cmp r0, #0x40
+	bgt _0801F324
+	cmp r0, #0
+	beq _0801F32A
+	b _0801F394
+	.align 2, 0
+_0801F310: .4byte gUnknown_0859F020
+_0801F314: .4byte 0x06014000
+_0801F318: .4byte gUnknown_085A06D8
+_0801F31C: .4byte 0x06002000
+_0801F320: .4byte gUnknown_0202BCF0
+_0801F324:
+	cmp r0, #0x80
+	beq _0801F344
+	b _0801F394
+_0801F32A:
+	ldr r0, _0801F338  @ gUnknown_0859F3F8
+	ldr r1, _0801F33C  @ 0x06002800
+	bl CopyDataWithPossibleUncomp
+	ldr r4, _0801F340  @ gUnknown_0859FA2C
+	b _0801F34E
+	.align 2, 0
+_0801F338: .4byte gUnknown_0859F3F8
+_0801F33C: .4byte 0x06002800
+_0801F340: .4byte gUnknown_0859FA2C
+_0801F344:
+	ldr r0, _0801F368  @ gUnknown_0859FA4C
+	ldr r1, _0801F36C  @ 0x06002800
+	bl CopyDataWithPossibleUncomp
+	ldr r4, _0801F370  @ gUnknown_085A0068
+_0801F34E:
+	adds r0, r4, #0
+	movs r1, #0xa0
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	movs r1, #0x90
+	lsls r1, r1, #2
+	adds r0, r4, #0
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	b _0801F394
+	.align 2, 0
+_0801F368: .4byte gUnknown_0859FA4C
+_0801F36C: .4byte 0x06002800
+_0801F370: .4byte gUnknown_085A0068
+_0801F374:
+	ldr r0, _0801F39C  @ gUnknown_085A0088
+	ldr r1, _0801F3A0  @ 0x06002800
+	bl CopyDataWithPossibleUncomp
+	ldr r4, _0801F3A4  @ gUnknown_085A0698
+	adds r0, r4, #0
+	movs r1, #0xa0
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	movs r1, #0x90
+	lsls r1, r1, #2
+	adds r0, r4, #0
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+_0801F394:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F39C: .4byte gUnknown_085A0088
+_0801F3A0: .4byte 0x06002800
+_0801F3A4: .4byte gUnknown_085A0698
+
+	THUMB_FUNC_START sub_801F3A8
+sub_801F3A8: @ 0x0801F3A8
+	push {r4, r5, r6, lr}
+	mov r6, sl
+	mov r5, r9
+	mov r4, r8
+	push {r4, r5, r6}
+	sub sp, #4
+	ldr r6, _0801F484  @ gLCDControlBuffer
+	ldrb r0, [r6, #1]
+	movs r1, #0x20
+	mov r9, r1
+	mov r2, r9
+	orrs r0, r2
+	movs r1, #0x41
+	negs r1, r1
+	ands r0, r1
+	movs r1, #0x7f
+	ands r0, r1
+	strb r0, [r6, #1]
+	adds r0, r6, #0
+	adds r0, #0x2d
+	movs r4, #0
+	mov r8, r4
+	mov r1, r8
+	strb r1, [r0]
+	adds r0, #4
+	strb r1, [r0]
+	adds r1, r6, #0
+	adds r1, #0x2c
+	movs r0, #0xf0
+	strb r0, [r1]
+	adds r1, #4
+	movs r0, #0xa0
+	strb r0, [r1]
+	movs r2, #0x34
+	adds r2, r2, r6
+	mov sl, r2
+	ldrb r1, [r2]
+	movs r2, #1
+	orrs r1, r2
+	subs r0, #0xa3
+	ands r1, r0
+	movs r5, #4
+	orrs r1, r5
+	movs r4, #8
+	orrs r1, r4
+	movs r3, #0x10
+	orrs r1, r3
+	adds r6, #0x36
+	ldrb r0, [r6]
+	orrs r0, r2
+	movs r2, #2
+	orrs r0, r2
+	orrs r0, r5
+	orrs r0, r4
+	orrs r0, r3
+	mov r4, r9
+	orrs r1, r4
+	mov r2, sl
+	strb r1, [r2]
+	orrs r0, r4
+	strb r0, [r6]
+	ldr r2, _0801F488  @ gUnknown_0202BCB0
+	adds r0, r2, #0
+	adds r0, #0x3a
+	mov r4, r8
+	strb r4, [r0]
+	adds r3, r2, #0
+	adds r3, #0x3b
+	movs r1, #0x10
+	strb r1, [r3]
+	subs r0, #2
+	strb r4, [r0]
+	adds r0, #1
+	strb r1, [r0]
+	ldrb r2, [r3]
+	movs r0, #1
+	movs r1, #0
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	mov r0, r8
+	str r0, [sp]
+	movs r0, #0
+	movs r1, #1
+	movs r2, #0
+	movs r3, #0
+	bl sub_8001ED0
+	movs r0, #1
+	str r0, [sp]
+	movs r0, #0
+	movs r1, #0
+	movs r2, #1
+	movs r3, #1
+	bl sub_8001F0C
+	movs r0, #0
+	bl SetLCDVCountSetting
+	ldr r0, _0801F48C  @ sub_801EC64
+	bl SetInterrupt_LCDVCountMatch
+	add sp, #4
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F484: .4byte gLCDControlBuffer
+_0801F488: .4byte gUnknown_0202BCB0
+_0801F48C: .4byte sub_801EC64
+
+	THUMB_FUNC_START sub_801F490
+sub_801F490: @ 0x0801F490
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _0801F4FC  @ gUnknown_0202BCB0
+	adds r1, r0, #0
+	adds r1, #0x3a
+	ldrb r1, [r1]
+	adds r0, #0x3b
+	ldrb r2, [r0]
+	movs r0, #1
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	ldr r0, _0801F500  @ gUnknown_0859AEF8
+	bl Proc_Find
+	cmp r0, #0
+	bne _0801F4F4
+	ldr r0, _0801F504  @ gUnknown_0859AF40
+	bl Proc_Find
+	cmp r0, #0
+	bne _0801F4F4
+	ldr r0, _0801F508  @ gUnknown_0859AF60
+	bl Proc_Find
+	cmp r0, #0
+	bne _0801F4F4
+	bl ClearBG0BG1
+	movs r0, #0
+	bl SetInterrupt_LCDVCountMatch
+	movs r0, #0
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	movs r0, #1
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	movs r0, #2
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	adds r0, r4, #0
+	bl Proc_ClearNativeCallback
+_0801F4F4:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F4FC: .4byte gUnknown_0202BCB0
+_0801F500: .4byte gUnknown_0859AEF8
+_0801F504: .4byte gUnknown_0859AF40
+_0801F508: .4byte gUnknown_0859AF60
+
+.align 2, 0 @ align with 0

--- a/asm/playerphase.s
+++ b/asm/playerphase.s
@@ -1,0 +1,2341 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	THUMB_FUNC_START ClearActionAndSave
+ClearActionAndSave: @ 0x0801C894
+	push {lr}
+	ldr r1, _0801C8A8  @ gUnknown_0203A958
+	movs r0, #0
+	strb r0, [r1, #0x16]
+	movs r0, #3
+	bl SaveSuspendedGame
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801C8A8: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START HandlePlayerCursorMovement
+HandlePlayerCursorMovement: @ 0x0801C8AC
+	push {lr}
+	ldr r2, _0801C8DC  @ gKeyStatusPtr
+	ldr r3, [r2]
+	ldrh r1, [r3, #4]
+	movs r0, #2
+	ands r0, r1
+	cmp r0, #0
+	beq _0801C8E8
+	ldr r0, _0801C8E0  @ gUnknown_0202BCB0
+	ldr r0, [r0, #0x20]
+	ldr r1, _0801C8E4  @ 0x00070007
+	ands r0, r1
+	cmp r0, #0
+	bne _0801C8E8
+	ldrh r0, [r3, #0x10]
+	bl HandleCursorMovement
+	movs r0, #8
+	bl MoveCameraByStepMaybe
+	movs r0, #8
+	bl sub_801588C
+	b _0801C8FC
+	.align 2, 0
+_0801C8DC: .4byte gKeyStatusPtr
+_0801C8E0: .4byte gUnknown_0202BCB0
+_0801C8E4: .4byte 0x00070007
+_0801C8E8:
+	ldr r0, [r2]
+	ldrh r0, [r0, #6]
+	bl HandleCursorMovement
+	movs r0, #4
+	bl MoveCameraByStepMaybe
+	movs r0, #4
+	bl sub_801588C
+_0801C8FC:
+	ldr r1, _0801C91C  @ gUnknown_0202BCB0
+	ldrh r0, [r1, #0x20]
+	ldrh r1, [r1, #0x22]
+	orrs r0, r1
+	movs r1, #0xf
+	ands r0, r1
+	cmp r0, #0
+	beq _0801C918
+	ldr r0, _0801C920  @ gKeyStatusPtr
+	ldr r2, [r0]
+	ldrh r1, [r2, #8]
+	ldr r0, _0801C924  @ 0x0000FCF4
+	ands r0, r1
+	strh r0, [r2, #8]
+_0801C918:
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801C91C: .4byte gUnknown_0202BCB0
+_0801C920: .4byte gKeyStatusPtr
+_0801C924: .4byte 0x0000FCF4
+
+	THUMB_FUNC_START sub_801C928
+sub_801C928: @ 0x0801C928
+
+	@ r0 is an Unit*
+
+	push {lr}
+	ldr r0, [r0, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x62
+	beq _0801C936
+	cmp r0, #0x34
+	bne _0801C93A
+_0801C936:
+	movs r0, #0
+	b _0801C93C
+_0801C93A:
+	movs r0, #1
+_0801C93C:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START PlayerPhase_MainLoop
+PlayerPhase_MainLoop: @ 0x0801C940
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	bl HandlePlayerCursorMovement
+	ldr r4, _0801C97C  @ gKeyStatusPtr
+	ldr r0, [r4]
+	ldrh r1, [r0, #8]
+	movs r0, #0x80
+	lsls r0, r0, #2
+	ands r0, r1
+	cmp r0, #0
+	beq _0801C988
+	ldr r1, _0801C980  @ gUnknown_0202BCB0
+	movs r2, #0x14
+	ldrsh r0, [r1, r2]
+	movs r3, #0x16
+	ldrsh r1, [r1, r3]
+	bl sub_801DB4C
+	ldr r0, _0801C984  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	bge _0801C974
+	b _0801CB38
+_0801C974:
+	movs r0, #0x6b
+	bl m4aSongNumStart
+	b _0801CB38
+	.align 2, 0
+_0801C97C: .4byte gKeyStatusPtr
+_0801C980: .4byte gUnknown_0202BCB0
+_0801C984: .4byte gUnknown_0202BCF0
+_0801C988:
+	bl DoesBMXFADEExist
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0801C994
+	b _0801CB38
+_0801C994:
+	ldr r0, [r4]
+	ldrh r1, [r0, #8]
+	movs r0, #0x80
+	lsls r0, r0, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _0801CA0C
+	ldr r4, _0801CA04  @ gUnknown_0202BCB0
+	movs r1, #0x16
+	ldrsh r0, [r4, r1]
+	ldr r5, _0801CA08  @ gUnknown_0202E4D8
+	ldr r1, [r5]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r2, #0x14
+	ldrsh r1, [r4, r2]
+	ldr r0, [r0]
+	adds r1, r0, r1
+	ldrb r0, [r1]
+	cmp r0, #0
+	beq _0801CA0C
+	bl GetUnitStruct
+	bl sub_801C928
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0801CA0C
+	bl ClearMOVEUNITs
+	bl DeletePlayerPhaseInterface6Cs
+	movs r0, #0x1f
+	bl sub_8086DE4
+	movs r3, #0x16
+	ldrsh r0, [r4, r3]
+	ldr r1, [r5]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r2, #0x14
+	ldrsh r1, [r4, r2]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	bl GetUnitStruct
+	adds r1, r6, #0
+	bl sub_808894C
+	adds r0, r6, #0
+	movs r1, #5
+	bl Proc_GotoLabel
+	b _0801CB64
+	.align 2, 0
+_0801CA04: .4byte gUnknown_0202BCB0
+_0801CA08: .4byte gUnknown_0202E4D8
+_0801CA0C:
+	ldr r0, _0801CA4C  @ gKeyStatusPtr
+	ldr r0, [r0]
+	ldrh r1, [r0, #8]
+	movs r0, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _0801CAD4
+	ldr r5, _0801CA50  @ gUnknown_0202BCB0
+	movs r3, #0x16
+	ldrsh r0, [r5, r3]
+	ldr r1, _0801CA54  @ gUnknown_0202E4D8
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r2, #0x14
+	ldrsh r1, [r5, r2]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	bl GetUnitStruct
+	adds r4, r0, #0
+	bl GetUnitSelectionValueThing
+	cmp r0, #2
+	beq _0801CA9C
+	cmp r0, #2
+	ble _0801CA58
+	cmp r0, #3
+	beq _0801CABC
+	b _0801CAD4
+	.align 2, 0
+_0801CA4C: .4byte gKeyStatusPtr
+_0801CA50: .4byte gUnknown_0202BCB0
+_0801CA54: .4byte gUnknown_0202E4D8
+_0801CA58:
+	cmp r0, #0
+	blt _0801CAD4
+	bl DeletePlayerPhaseInterface6Cs
+	ldr r0, _0801CA94  @ gUnknown_0202BCF0
+	ldrh r1, [r5, #0x14]
+	strb r1, [r0, #0x12]
+	ldrh r1, [r5, #0x16]
+	strb r1, [r0, #0x13]
+	cmp r4, #0
+	beq _0801CA78
+	bl ClearMOVEUNITs
+	adds r0, r4, #0
+	bl ShowUnitSMS
+_0801CA78:
+	ldr r0, _0801CA98  @ gUnknown_0859D214
+	movs r3, #0x1c
+	ldrsh r1, [r5, r3]
+	movs r3, #0xc
+	ldrsh r2, [r5, r3]
+	subs r1, r1, r2
+	movs r2, #1
+	movs r3, #0x17
+	bl NewMenu_DefaultAdjusted
+	bl sub_80832CC
+	b _0801CB20
+	.align 2, 0
+_0801CA94: .4byte gUnknown_0202BCF0
+_0801CA98: .4byte gUnknown_0859D214
+_0801CA9C:
+	adds r0, r4, #0
+	bl SetupActiveUnit
+	ldr r0, _0801CAB8  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldr r0, [r0]
+	ldrb r0, [r0, #4]
+	bl BWL_IncrementMoveValue
+	adds r0, r6, #0
+	bl Proc_ClearNativeCallback
+	b _0801CB38
+	.align 2, 0
+_0801CAB8: .4byte gUnknown_03004E50
+_0801CABC:
+	adds r0, r4, #0
+	bl SetupActiveUnit
+	adds r1, r5, #0
+	adds r1, #0x3e
+	movs r0, #0
+	strb r0, [r1]
+	adds r0, r6, #0
+	movs r1, #0xb
+	bl Proc_GotoLabel
+	b _0801CB38
+_0801CAD4:
+	ldr r0, _0801CB2C  @ gKeyStatusPtr
+	ldr r2, [r0]
+	ldrh r1, [r2, #8]
+	movs r0, #8
+	ands r0, r1
+	cmp r0, #0
+	beq _0801CB38
+	ldrh r1, [r2, #4]
+	movs r0, #4
+	ands r0, r1
+	cmp r0, #0
+	bne _0801CB38
+	ldr r2, _0801CB30  @ gUnknown_0202BCB0
+	movs r1, #0x16
+	ldrsh r0, [r2, r1]
+	ldr r1, _0801CB34  @ gUnknown_0202E4D8
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r3, #0x14
+	ldrsh r1, [r2, r3]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	bl GetUnitStruct
+	adds r4, r0, #0
+	cmp r4, #0
+	beq _0801CB18
+	bl ClearMOVEUNITs
+	adds r0, r4, #0
+	bl ShowUnitSMS
+_0801CB18:
+	bl DeletePlayerPhaseInterface6Cs
+	bl sub_80A87C8
+_0801CB20:
+	adds r0, r6, #0
+	movs r1, #9
+	bl Proc_GotoLabel
+	b _0801CB64
+	.align 2, 0
+_0801CB2C: .4byte gKeyStatusPtr
+_0801CB30: .4byte gUnknown_0202BCB0
+_0801CB34: .4byte gUnknown_0202E4D8
+_0801CB38:
+	bl sub_8027A4C
+	ldr r1, _0801CB6C  @ gUnknown_0202BCB0
+	movs r0, #0x20
+	ldrsh r4, [r1, r0]
+	movs r2, #0x22
+	ldrsh r5, [r1, r2]
+	movs r3, #0x14
+	ldrsh r0, [r1, r3]
+	movs r2, #0x16
+	ldrsh r1, [r1, r2]
+	bl sub_8027B0C
+	lsls r0, r0, #0x18
+	movs r2, #0
+	cmp r0, #0
+	beq _0801CB5C
+	movs r2, #3
+_0801CB5C:
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl DisplayCursor
+_0801CB64:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801CB6C: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START DisplayUnitEffectRange
+DisplayUnitEffectRange: @ 0x0801CB70
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	movs r4, #1
+	ldr r5, _0801CBD8  @ gUnknown_03004E50
+	ldr r0, [r5]
+	ldr r1, [r0, #4]
+	ldrb r1, [r1, #0x12]
+	ldrb r2, [r0, #0x1d]
+	adds r1, r1, r2
+	ldr r2, _0801CBDC  @ gUnknown_0203A958
+	ldrb r2, [r2, #0x10]
+	subs r1, r1, r2
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl FillMovementMapForUnitAndMovement
+	ldr r0, [r5]
+	ldr r0, [r0, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _0801CC10
+	ldr r0, _0801CBE0  @ gUnknown_0202E4F0
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	adds r0, r6, #0
+	bl UnitHasMagicRank
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0801CBB8
+	movs r0, #1
+	bl sub_801B950
+_0801CBB8:
+	ldr r0, _0801CBE4  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r0, [r5]
+	bl GetUnitUseFlags
+	cmp r0, #2
+	beq _0801CBF8
+	cmp r0, #2
+	bgt _0801CBE8
+	cmp r0, #1
+	beq _0801CC08
+	b _0801CC10
+	.align 2, 0
+_0801CBD8: .4byte gUnknown_03004E50
+_0801CBDC: .4byte gUnknown_0203A958
+_0801CBE0: .4byte gUnknown_0202E4F0
+_0801CBE4: .4byte gUnknown_0202E4E4
+_0801CBE8:
+	cmp r0, #3
+	bne _0801CC10
+	ldr r0, _0801CC04  @ gUnknown_0202BCB0
+	adds r0, #0x3e
+	ldrb r0, [r0]
+	ands r4, r0
+	cmp r4, #0
+	beq _0801CC08
+_0801CBF8:
+	ldr r0, [r5]
+	bl FillMapStaffRangeForUnit
+	movs r4, #5
+	b _0801CC10
+	.align 2, 0
+_0801CC04: .4byte gUnknown_0202BCB0
+_0801CC08:
+	ldr r0, [r5]
+	bl FillMapAttackRangeForUnit
+	movs r4, #3
+_0801CC10:
+	adds r0, r4, #0
+	bl DisplayMoveRangeGraphics
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_801CC1C
+sub_801CC1C: @ 0x0801CC1C
+	push {r4, r5, lr}
+	ldr r5, _0801CC64  @ gUnknown_0202BCB0
+	ldrb r1, [r5, #4]
+	movs r0, #2
+	orrs r0, r1
+	strb r0, [r5, #4]
+	ldr r4, _0801CC68  @ gUnknown_03004E50
+	ldr r0, [r4]
+	bl DisplayUnitEffectRange
+	ldr r4, [r4]
+	movs r1, #0x10
+	ldrsb r1, [r4, r1]
+	movs r2, #0x14
+	ldrsh r0, [r5, r2]
+	cmp r1, r0
+	bne _0801CC70
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0x16
+	ldrsh r0, [r5, r2]
+	cmp r1, r0
+	bne _0801CC70
+	movs r0, #0
+	bl sub_8032E28
+	ldr r0, _0801CC6C  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _0801CC76
+	movs r0, #0x69
+	bl m4aSongNumStart
+	b _0801CC76
+	.align 2, 0
+_0801CC64: .4byte gUnknown_0202BCB0
+_0801CC68: .4byte gUnknown_03004E50
+_0801CC6C: .4byte gUnknown_0202BCF0
+_0801CC70:
+	movs r0, #1
+	bl sub_8032E28
+_0801CC76:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START DisplayActiveUnitEffectRange
+DisplayActiveUnitEffectRange: @ 0x0801CC7C
+	push {lr}
+	ldr r0, _0801CCA8  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _0801CC90
+	movs r0, #0x68
+	bl m4aSongNumStart
+_0801CC90:
+	ldr r2, _0801CCAC  @ gUnknown_0202BCB0
+	ldrb r1, [r2, #4]
+	movs r0, #0xfd
+	ands r0, r1
+	strb r0, [r2, #4]
+	ldr r0, _0801CCB0  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl DisplayUnitEffectRange
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801CCA8: .4byte gUnknown_0202BCF0
+_0801CCAC: .4byte gUnknown_0202BCB0
+_0801CCB0: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_801CCB4
+sub_801CCB4: @ 0x0801CCB4
+
+	@ DANGER ZONE
+
+	push {r4, r5, r6, lr}
+	ldr r4, _0801CD04  @ gUnknown_0202BCB0
+	adds r5, r4, #0
+	adds r5, #0x3e
+	ldrb r1, [r5]
+	movs r6, #1
+	adds r0, r6, #0
+	ands r0, r1
+	bl ApplyStuffToRangeMaps
+	ldr r0, _0801CD08  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	movs r1, #1
+	negs r1, r1
+	bl ClearMapWith
+	ldr r0, _0801CD0C  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _0801CCE6
+	movs r0, #0x68
+	bl m4aSongNumStart
+_0801CCE6:
+	ldrb r1, [r4, #4]
+	movs r0, #8
+	orrs r0, r1
+	movs r1, #0xfd
+	ands r0, r1
+	strb r0, [r4, #4]
+	ldrb r1, [r5]
+	adds r0, r6, #0
+	ands r0, r1
+	cmp r0, #0
+	beq _0801CD10
+	movs r0, #5
+	bl DisplayMoveRangeGraphics
+	b _0801CD16
+	.align 2, 0
+_0801CD04: .4byte gUnknown_0202BCB0
+_0801CD08: .4byte gUnknown_0202E4E0
+_0801CD0C: .4byte gUnknown_0202BCF0
+_0801CD10:
+	movs r0, #3
+	bl DisplayMoveRangeGraphics
+_0801CD16:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_801CD1C
+sub_801CD1C: @ 0x0801CD1C
+
+	@ Player Phase Proc Idle during range display?
+
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	movs r4, #0xff
+	bl HandlePlayerCursorMovement
+	ldr r0, _0801CD44  @ gKeyStatusPtr
+	ldr r0, [r0]
+	ldrh r1, [r0, #8]
+	movs r0, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _0801CD98
+	ldr r4, _0801CD48  @ gUnknown_03004E50
+	ldr r0, [r4]
+	cmp r0, #0
+	bne _0801CD4C
+	bl sub_8018BA0
+	b _0801CD76
+	.align 2, 0
+_0801CD44: .4byte gKeyStatusPtr
+_0801CD48: .4byte gUnknown_03004E50
+_0801CD4C:
+	bl sub_80844B0
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0801CD5A
+	movs r4, #5
+	b _0801CDE2
+_0801CD5A:
+	ldr r0, [r4]
+	bl GetUnitSelectionValueThing
+	cmp r0, #2
+	beq _0801CD80
+	ldr r2, [r4]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _0801CD80
+	adds r0, r2, #0
+	bl GetUnitUseFlags
+_0801CD76:
+	movs r4, #2
+	cmp r0, #3
+	bne _0801CDE2
+	movs r4, #6
+	b _0801CDE2
+_0801CD80:
+	ldr r1, _0801CDBC  @ gUnknown_0202BCB0
+	movs r2, #0x14
+	ldrsh r0, [r1, r2]
+	movs r3, #0x16
+	ldrsh r1, [r1, r3]
+	bl sub_801D5A8
+	lsls r0, r0, #0x18
+	movs r4, #0
+	cmp r0, #0
+	beq _0801CDE2
+	movs r4, #1
+_0801CD98:
+	ldr r0, _0801CDC0  @ gKeyStatusPtr
+	ldr r0, [r0]
+	ldrh r1, [r0, #8]
+	movs r0, #2
+	ands r0, r1
+	cmp r0, #0
+	beq _0801CDC8
+	ldr r0, _0801CDC4  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldr r0, [r0, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	movs r4, #2
+	cmp r0, #0
+	beq _0801CDE2
+	movs r4, #0
+	b _0801CDE2
+	.align 2, 0
+_0801CDBC: .4byte gUnknown_0202BCB0
+_0801CDC0: .4byte gKeyStatusPtr
+_0801CDC4: .4byte gUnknown_03004E50
+_0801CDC8:
+	movs r0, #0x80
+	lsls r0, r0, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _0801CDD6
+	movs r4, #3
+	b _0801CDE2
+_0801CDD6:
+	movs r0, #0x80
+	lsls r0, r0, #2
+	ands r0, r1
+	cmp r0, #0
+	beq _0801CDE2
+	movs r4, #4
+_0801CDE2:
+	cmp r4, #6
+	bls _0801CDE8
+	b _0801CFC0
+_0801CDE8:
+	lsls r0, r4, #2
+	ldr r1, _0801CDF4  @ _0801CDF8
+	adds r0, r0, r1
+	ldr r0, [r0]
+	mov pc, r0
+	.align 2, 0
+_0801CDF4: .4byte _0801CDF8
+_0801CDF8: @ jump table
+	.4byte _0801CE14 @ case 0
+	.4byte _0801CE30 @ case 1
+	.4byte _0801CE50 @ case 2
+	.4byte _0801CED4 @ case 3
+	.4byte _0801CF4C @ case 4
+	.4byte _0801CFC0 @ case 5
+	.4byte _0801CF90 @ case 6
+_0801CE14:
+	ldr r0, _0801CE2C  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	bge _0801CE22
+	b _0801CFC0
+_0801CE22:
+	movs r0, #0x6c
+	bl m4aSongNumStart
+	b _0801CFC0
+	.align 2, 0
+_0801CE2C: .4byte gUnknown_0202BCF0
+_0801CE30:
+	ldr r0, _0801CE4C  @ gUnknown_0202BE48
+	movs r2, #0
+	ldrsh r1, [r0, r2]
+	movs r3, #2
+	ldrsh r2, [r0, r3]
+	adds r0, r5, #0
+	bl EnsureCameraOntoPosition
+	bl HideMoveRangeGraphics
+	adds r0, r5, #0
+	bl Proc_ClearNativeCallback
+	b _0801CFE0
+	.align 2, 0
+_0801CE4C: .4byte gUnknown_0202BE48
+_0801CE50:
+	ldr r4, _0801CEC4  @ gUnknown_03004E50
+	ldr r0, [r4]
+	cmp r0, #0
+	beq _0801CE90
+	bl ClearMOVEUNITs
+	ldr r2, [r4]
+	ldr r0, [r2, #0xc]
+	movs r1, #2
+	negs r1, r1
+	ands r0, r1
+	str r0, [r2, #0xc]
+	movs r0, #0xb
+	ldrsb r0, [r2, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, #0
+	bne _0801CE90
+	ldr r4, _0801CEC8  @ gUnknown_0202BE48
+	movs r0, #0
+	ldrsh r1, [r4, r0]
+	movs r3, #2
+	ldrsh r2, [r4, r3]
+	adds r0, r5, #0
+	bl EnsureCameraOntoPosition
+	movs r1, #0
+	ldrsh r0, [r4, r1]
+	movs r2, #2
+	ldrsh r1, [r4, r2]
+	bl SetCursorMapPosition
+_0801CE90:
+	ldr r2, _0801CECC  @ gUnknown_0202BCB0
+	ldrb r1, [r2, #4]
+	movs r0, #0xf7
+	ands r0, r1
+	strb r0, [r2, #4]
+	bl HideMoveRangeGraphics
+	bl RefreshFogAndUnitMaps
+	bl SMS_UpdateFromGameData
+	ldr r0, _0801CED0  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _0801CEB8
+	movs r0, #0x6b
+	bl m4aSongNumStart
+_0801CEB8:
+	adds r0, r5, #0
+	movs r1, #9
+	bl Proc_GotoLabel
+	b _0801CFE0
+	.align 2, 0
+_0801CEC4: .4byte gUnknown_03004E50
+_0801CEC8: .4byte gUnknown_0202BE48
+_0801CECC: .4byte gUnknown_0202BCB0
+_0801CED0: .4byte gUnknown_0202BCF0
+_0801CED4:
+	bl EventEngineExists
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #1
+	beq _0801CFC0
+	ldr r2, _0801CF3C  @ gUnknown_0202BCB0
+	movs r3, #0x16
+	ldrsh r0, [r2, r3]
+	ldr r1, _0801CF40  @ gUnknown_0202E4D8
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r3, #0x14
+	ldrsh r1, [r2, r3]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	ldrb r4, [r0]
+	ldr r0, _0801CF44  @ gUnknown_0202BE48
+	ldr r1, [r0]
+	ldr r0, [r2, #0x14]
+	cmp r1, r0
+	bne _0801CF08
+	ldr r0, _0801CF48  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldrb r4, [r0, #0xb]
+_0801CF08:
+	cmp r4, #0
+	beq _0801CFC0
+	adds r0, r4, #0
+	bl GetUnitStruct
+	bl sub_801C928
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0801CFC0
+	bl ClearMOVEUNITs
+	movs r0, #0x1f
+	bl sub_8086DE4
+	adds r0, r4, #0
+	bl GetUnitStruct
+	adds r1, r5, #0
+	bl sub_808894C
+	adds r0, r5, #0
+	movs r1, #6
+	bl Proc_GotoLabel
+	b _0801CFE0
+	.align 2, 0
+_0801CF3C: .4byte gUnknown_0202BCB0
+_0801CF40: .4byte gUnknown_0202E4D8
+_0801CF44: .4byte gUnknown_0202BE48
+_0801CF48: .4byte gUnknown_03004E50
+_0801CF4C:
+	ldr r0, _0801CF84  @ gUnknown_03004E50
+	ldr r0, [r0]
+	cmp r0, #0
+	beq _0801CFC0
+	ldr r4, _0801CF88  @ gUnknown_0202BE48
+	movs r0, #0
+	ldrsh r1, [r4, r0]
+	movs r3, #2
+	ldrsh r2, [r4, r3]
+	adds r0, r5, #0
+	bl EnsureCameraOntoPosition
+	movs r1, #0
+	ldrsh r0, [r4, r1]
+	movs r2, #2
+	ldrsh r1, [r4, r2]
+	bl SetCursorMapPosition
+	ldr r0, _0801CF8C  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _0801CFC0
+	movs r0, #0x6b
+	bl m4aSongNumStart
+	b _0801CFC0
+	.align 2, 0
+_0801CF84: .4byte gUnknown_03004E50
+_0801CF88: .4byte gUnknown_0202BE48
+_0801CF8C: .4byte gUnknown_0202BCF0
+_0801CF90:
+	ldr r4, _0801CFB4  @ gUnknown_0202BCB0
+	adds r1, r4, #0
+	adds r1, #0x3e
+	ldrb r0, [r1]
+	adds r0, #1
+	strb r0, [r1]
+	bl HideMoveRangeGraphics
+	ldrb r1, [r4, #4]
+	movs r0, #8
+	ands r0, r1
+	cmp r0, #0
+	beq _0801CFB8
+	adds r0, r5, #0
+	movs r1, #0xc
+	bl Proc_GotoLabel
+	b _0801CFC0
+	.align 2, 0
+_0801CFB4: .4byte gUnknown_0202BCB0
+_0801CFB8:
+	adds r0, r5, #0
+	movs r1, #0xb
+	bl Proc_GotoLabel
+_0801CFC0:
+	ldr r0, _0801CFE8  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl GetUnitSelectionValueThing
+	cmp r0, #2
+	bne _0801CFD0
+	bl sub_8033248
+_0801CFD0:
+	ldr r1, _0801CFEC  @ gUnknown_0202BCB0
+	movs r3, #0x20
+	ldrsh r0, [r1, r3]
+	movs r2, #0x22
+	ldrsh r1, [r1, r2]
+	movs r2, #1
+	bl DisplayCursor
+_0801CFE0:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801CFE8: .4byte gUnknown_03004E50
+_0801CFEC: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_801CFF0
+sub_801CFF0: @ 0x0801CFF0
+
+	@ Player Phase Action Cancel
+
+	push {lr}
+	ldr r2, _0801D004  @ gUnknown_0203A958
+	movs r1, #0
+	strb r1, [r2, #0x11]
+	movs r1, #2
+	bl Proc_GotoLabel
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801D004: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START sub_801D008
+sub_801D008: @ 0x0801D008
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	ldr r4, _0801D050  @ gUnknown_03004E50
+	ldr r1, [r4]
+	ldr r2, _0801D054  @ gUnknown_0202BE48
+	ldrh r0, [r2]
+	strb r0, [r1, #0x10]
+	ldr r1, [r4]
+	ldrh r0, [r2, #2]
+	strb r0, [r1, #0x11]
+	ldr r0, [r4]
+	bl ApplyUnitMovement
+	ldr r2, [r4]
+	ldr r0, [r2, #0xc]
+	movs r1, #2
+	negs r1, r1
+	ands r0, r1
+	str r0, [r2, #0xc]
+	bl RefreshFogAndUnitMaps
+	bl UpdateGameTilesGraphics
+	bl SMS_UpdateFromGameData
+	ldr r4, [r4]
+	ldr r0, [r4, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _0801D058
+	adds r0, r4, #0
+	bl SetupActiveUnit
+	b _0801D05E
+	.align 2, 0
+_0801D050: .4byte gUnknown_03004E50
+_0801D054: .4byte gUnknown_0202BE48
+_0801D058:
+	adds r0, r4, #0
+	bl SetActiveUnit
+_0801D05E:
+	ldr r4, _0801D080  @ gUnknown_03004E50
+	ldr r0, [r4]
+	bl HideUnitSMS
+	bl ClearMOVEUNITs
+	ldr r0, [r4]
+	bl MakeMOVEUNITForMapUnit
+	adds r0, r5, #0
+	movs r1, #1
+	bl Proc_GotoLabel
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801D080: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START _6CE_PLAYERPAHSE_PrepareAction
+_6CE_PLAYERPAHSE_PrepareAction: @ 0x0801D084
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	ldr r4, _0801D0C4  @ gUnknown_0203A958
+	ldrb r0, [r4, #0xc]
+	bl GetUnitStruct
+	movs r5, #0x10
+	ldrsb r5, [r0, r5]
+	ldrb r0, [r4, #0xc]
+	bl GetUnitStruct
+	movs r2, #0x11
+	ldrsb r2, [r0, r2]
+	adds r0, r6, #0
+	adds r1, r5, #0
+	bl EnsureCameraOntoPosition
+	lsls r0, r0, #0x18
+	movs r1, #0x80
+	lsls r1, r1, #0x11
+	eors r1, r0
+	lsrs r5, r1, #0x18
+	ldrb r0, [r4, #0x11]
+	cmp r0, #0x22
+	bls _0801D0B8
+	b _0801D1C8
+_0801D0B8:
+	lsls r0, r0, #2
+	ldr r1, _0801D0C8  @ _0801D0CC
+	adds r0, r0, r1
+	ldr r0, [r0]
+	mov pc, r0
+	.align 2, 0
+_0801D0C4: .4byte gUnknown_0203A958
+_0801D0C8: .4byte _0801D0CC
+_0801D0CC: @ jump table
+	.4byte _0801D158 @ case 0
+	.4byte _0801D1C8 @ case 1
+	.4byte _0801D1C8 @ case 2
+	.4byte _0801D1C8 @ case 3
+	.4byte _0801D1C8 @ case 4
+	.4byte _0801D1C8 @ case 5
+	.4byte _0801D1C8 @ case 6
+	.4byte _0801D1C8 @ case 7
+	.4byte _0801D1C8 @ case 8
+	.4byte _0801D1C8 @ case 9
+	.4byte _0801D1C8 @ case 10
+	.4byte _0801D19C @ case 11
+	.4byte _0801D19C @ case 12
+	.4byte _0801D1C8 @ case 13
+	.4byte _0801D1C8 @ case 14
+	.4byte _0801D1C8 @ case 15
+	.4byte _0801D1C8 @ case 16
+	.4byte _0801D1C8 @ case 17
+	.4byte _0801D1C8 @ case 18
+	.4byte _0801D1C8 @ case 19
+	.4byte _0801D1C8 @ case 20
+	.4byte _0801D1C8 @ case 21
+	.4byte _0801D1C8 @ case 22
+	.4byte _0801D1C8 @ case 23
+	.4byte _0801D1C8 @ case 24
+	.4byte _0801D1C8 @ case 25
+	.4byte _0801D1C8 @ case 26
+	.4byte _0801D17E @ case 27
+	.4byte _0801D18C @ case 28
+	.4byte _0801D1B8 @ case 29
+	.4byte _0801D1C8 @ case 30
+	.4byte _0801D1C8 @ case 31
+	.4byte _0801D1C8 @ case 32
+	.4byte _0801D1AC @ case 33
+	.4byte _0801D1AC @ case 34
+_0801D158:
+	ldr r0, _0801D16C  @ gUnknown_0202BCB0
+	adds r0, #0x3d
+	ldrb r0, [r0]
+	cmp r0, #0
+	beq _0801D174
+	ldr r1, _0801D170  @ gUnknown_0203A958
+	movs r0, #0x1f
+	strb r0, [r1, #0x11]
+	b _0801D1C8
+	.align 2, 0
+_0801D16C: .4byte gUnknown_0202BCB0
+_0801D170: .4byte gUnknown_0203A958
+_0801D174:
+	adds r0, r6, #0
+	bl sub_801D008
+	movs r0, #1
+	b _0801D234
+_0801D17E:
+	ldr r0, _0801D188  @ gUnknown_0202BCB0
+	adds r0, #0x3d
+	ldrb r2, [r0]
+	movs r1, #2
+	b _0801D1B4
+	.align 2, 0
+_0801D188: .4byte gUnknown_0202BCB0
+_0801D18C:
+	ldr r0, _0801D198  @ gUnknown_0202BCB0
+	adds r0, #0x3d
+	ldrb r2, [r0]
+	movs r1, #4
+	b _0801D1B4
+	.align 2, 0
+_0801D198: .4byte gUnknown_0202BCB0
+_0801D19C:
+	ldr r0, _0801D1A8  @ gUnknown_0202BCB0
+	adds r0, #0x3d
+	ldrb r2, [r0]
+	movs r1, #1
+	b _0801D1B4
+	.align 2, 0
+_0801D1A8: .4byte gUnknown_0202BCB0
+_0801D1AC:
+	ldr r0, _0801D1C4  @ gUnknown_0202BCB0
+	adds r0, #0x3d
+	ldrb r2, [r0]
+	movs r1, #8
+_0801D1B4:
+	orrs r1, r2
+	strb r1, [r0]
+_0801D1B8:
+	adds r0, r6, #0
+	bl sub_801CFF0
+	movs r0, #1
+	b _0801D234
+	.align 2, 0
+_0801D1C4: .4byte gUnknown_0202BCB0
+_0801D1C8:
+	ldr r4, _0801D200  @ gUnknown_0203A958
+	ldrb r0, [r4, #0xc]
+	bl GetUnitStruct
+	ldrb r1, [r4, #0x12]
+	lsls r1, r1, #1
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r0, [r0]
+	bl GetItemIndex
+	adds r2, r0, #0
+	ldr r0, _0801D204  @ gUnknown_0203A4EC
+	adds r0, #0x7e
+	movs r1, #0
+	strb r1, [r0]
+	cmp r2, #0x8a
+	beq _0801D230
+	cmp r2, #0x8a
+	bgt _0801D208
+	cmp r2, #0x64
+	blt _0801D214
+	cmp r2, #0x68
+	ble _0801D230
+	cmp r2, #0x88
+	beq _0801D230
+	b _0801D214
+	.align 2, 0
+_0801D200: .4byte gUnknown_0203A958
+_0801D204: .4byte gUnknown_0203A4EC
+_0801D208:
+	cmp r2, #0x97
+	blt _0801D214
+	cmp r2, #0x99
+	ble _0801D230
+	cmp r2, #0xc1
+	beq _0801D230
+_0801D214:
+	ldr r1, _0801D23C  @ gUnknown_0203A958
+	ldrb r0, [r1, #0x11]
+	cmp r0, #1
+	beq _0801D230
+	ldr r0, _0801D240  @ gUnknown_0202BCB0
+	adds r0, #0x3c
+	ldrb r0, [r0]
+	cmp r0, #0
+	bne _0801D230
+	movs r0, #1
+	strb r0, [r1, #0x16]
+	movs r0, #3
+	bl SaveSuspendedGame
+_0801D230:
+	lsls r0, r5, #0x18
+	asrs r0, r0, #0x18
+_0801D234:
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0801D23C: .4byte gUnknown_0203A958
+_0801D240: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START TryMakeCantoUnit
+TryMakeCantoUnit: @ 0x0801D244
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	ldr r2, _0801D29C  @ gUnknown_03004E50
+	ldr r3, [r2]
+	ldr r0, [r3]
+	ldr r1, [r3, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	movs r1, #2
+	ands r0, r1
+	adds r4, r2, #0
+	cmp r0, #0
+	beq _0801D298
+	ldr r0, [r3, #0xc]
+	ldr r1, _0801D2A0  @ 0x00010044
+	ands r0, r1
+	cmp r0, #0
+	bne _0801D298
+	ldr r0, _0801D2A4  @ gUnknown_0203A958
+	ldrb r1, [r0, #0x11]
+	adds r2, r0, #0
+	cmp r1, #3
+	bgt _0801D278
+	cmp r1, #1
+	bge _0801D298
+_0801D278:
+	ldr r1, [r4]
+	movs r0, #0x1d
+	ldrsb r0, [r1, r0]
+	ldr r1, [r1, #4]
+	ldrb r1, [r1, #0x12]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	adds r0, r0, r1
+	ldrb r2, [r2, #0x10]
+	cmp r0, r2
+	ble _0801D298
+	bl CanUnitMove
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0801D2A8
+_0801D298:
+	movs r0, #0
+	b _0801D2FA
+	.align 2, 0
+_0801D29C: .4byte gUnknown_03004E50
+_0801D2A0: .4byte 0x00010044
+_0801D2A4: .4byte gUnknown_0203A958
+_0801D2A8:
+	ldr r0, _0801D2E8  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r0, [r4]
+	bl SetActiveUnit
+	ldr r2, [r4]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	orrs r0, r1
+	subs r1, #0x43
+	ands r0, r1
+	str r0, [r2, #0xc]
+	bl ClearMOVEUNITs
+	ldr r0, [r4]
+	bl MakeMOVEUNITForMapUnit
+	bl _MOVEUNIT6C_SetDefaultFacingDirection
+	ldr r0, _0801D2EC  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xd]
+	cmp r0, #0
+	beq _0801D2F0
+	adds r0, r5, #0
+	movs r1, #4
+	bl Proc_GotoLabel
+	b _0801D2F8
+	.align 2, 0
+_0801D2E8: .4byte gUnknown_0202E4E4
+_0801D2EC: .4byte gUnknown_0202BCF0
+_0801D2F0:
+	adds r0, r5, #0
+	movs r1, #1
+	bl Proc_GotoLabel
+_0801D2F8:
+	movs r0, #1
+_0801D2FA:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START RunPotentialWaitEvents
+RunPotentialWaitEvents: @ 0x0801D300
+	push {lr}
+	bl CheckForWaitEvents
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0801D310
+	movs r0, #1
+	b _0801D316
+_0801D310:
+	bl RunWaitEvents
+	movs r0, #0
+_0801D316:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START EnsureCameraOntoActiveUnitPosition
+EnsureCameraOntoActiveUnitPosition: @ 0x0801D31C
+	push {lr}
+	ldr r1, _0801D340  @ gUnknown_03004E50
+	ldr r2, [r1]
+	movs r1, #0x10
+	ldrsb r1, [r2, r1]
+	ldrb r2, [r2, #0x11]
+	lsls r2, r2, #0x18
+	asrs r2, r2, #0x18
+	bl EnsureCameraOntoPosition
+	movs r1, #0
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0801D33A
+	movs r1, #1
+_0801D33A:
+	adds r0, r1, #0
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0801D340: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_801D344
+sub_801D344: @ 0x0801D344
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	ldr r0, _0801D374  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xd]
+	cmp r0, #0
+	beq _0801D37C
+	bl sub_8019CBC
+	ldr r1, _0801D378  @ gUnknown_0203A958
+	ldrb r0, [r1, #0xe]
+	ldrb r1, [r1, #0xf]
+	bl MoveActiveUnit
+	bl RefreshFogAndUnitMaps
+	bl UpdateGameTilesGraphics
+	movs r0, #0
+	bl NewBMXFADE
+	bl SMS_UpdateFromGameData
+	b _0801D38E
+	.align 2, 0
+_0801D374: .4byte gUnknown_0202BCF0
+_0801D378: .4byte gUnknown_0203A958
+_0801D37C:
+	ldr r1, _0801D3C0  @ gUnknown_0203A958
+	ldrb r0, [r1, #0xe]
+	ldrb r1, [r1, #0xf]
+	bl MoveActiveUnit
+	bl RefreshFogAndUnitMaps
+	bl UpdateGameTilesGraphics
+_0801D38E:
+	ldr r4, _0801D3C4  @ gUnknown_03004E50
+	ldr r1, [r4]
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	ldrb r1, [r1, #0x11]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl SetCursorMapPosition
+	ldr r2, _0801D3C8  @ gUnknown_0202BCF0
+	ldr r1, _0801D3CC  @ gUnknown_0202BCB0
+	ldrh r0, [r1, #0x14]
+	strb r0, [r2, #0x12]
+	ldrh r0, [r1, #0x16]
+	strb r0, [r2, #0x13]
+	adds r0, r5, #0
+	bl TryMakeCantoUnit
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0801D3D0
+	ldr r0, [r4]
+	bl HideUnitSMS
+	b _0801D3FC
+	.align 2, 0
+_0801D3C0: .4byte gUnknown_0203A958
+_0801D3C4: .4byte gUnknown_03004E50
+_0801D3C8: .4byte gUnknown_0202BCF0
+_0801D3CC: .4byte gUnknown_0202BCB0
+_0801D3D0:
+	bl sub_8083250
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0801D3F8
+	bl ClearMOVEUNITs
+	bl RefreshFogAndUnitMaps
+	bl UpdateGameTilesGraphics
+	bl SMS_UpdateFromGameData
+	bl sub_808326C
+	adds r0, r5, #0
+	movs r1, #8
+	bl Proc_GotoLabel
+	b _0801D3FC
+_0801D3F8:
+	bl ClearMOVEUNITs
+_0801D3FC:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_801D404
+sub_801D404: @ 0x0801D404
+	push {lr}
+	ldr r0, _0801D42C  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xf]
+	cmp r0, #0
+	bne _0801D428
+	ldr r1, _0801D430  @ gUnknown_0203A958
+	ldrb r0, [r1, #0xe]
+	ldrb r1, [r1, #0xf]
+	bl MoveActiveUnit
+	bl RefreshFogAndUnitMaps
+	bl UpdateGameTilesGraphics
+	bl SMS_UpdateFromGameData
+	bl ClearMOVEUNITs
+_0801D428:
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801D42C: .4byte gUnknown_0202BCF0
+_0801D430: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START sub_801D434
+sub_801D434: @ 0x0801D434
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _0801D464  @ gUnknown_0203A958
+	ldrb r0, [r0, #0x11]
+	cmp r0, #0x1e
+	beq _0801D456
+	ldr r0, _0801D468  @ gUnknown_0859D1F0
+	ldr r2, _0801D46C  @ gUnknown_0202BCB0
+	movs r3, #0x1c
+	ldrsh r1, [r2, r3]
+	movs r3, #0xc
+	ldrsh r2, [r2, r3]
+	subs r1, r1, r2
+	movs r2, #1
+	movs r3, #0x16
+	bl NewMenu_AndDoSomethingCommands
+_0801D456:
+	adds r0, r4, #0
+	bl Proc_ClearNativeCallback
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801D464: .4byte gUnknown_0203A958
+_0801D468: .4byte gUnknown_0859D1F0
+_0801D46C: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START PlayerPhase_ApplyUnitMovement
+PlayerPhase_ApplyUnitMovement: @ 0x0801D470
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	ldr r4, _0801D4D4  @ gUnknown_03004E50
+	ldr r1, [r4]
+	ldr r5, _0801D4D8  @ gUnknown_0203A958
+	ldrb r0, [r5, #0xe]
+	strb r0, [r1, #0x10]
+	ldr r1, [r4]
+	ldrb r0, [r5, #0xf]
+	strb r0, [r1, #0x11]
+	ldr r0, [r4]
+	bl ApplyUnitMovement
+	ldr r0, [r4]
+	ldr r0, [r0, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _0801D4BA
+	ldrb r0, [r5, #0x11]
+	cmp r0, #0
+	bne _0801D4BA
+	ldr r0, _0801D4DC  @ gUnknown_0202BCB0
+	adds r0, #0x3d
+	ldrb r0, [r0]
+	cmp r0, #0
+	bne _0801D4BA
+	ldrb r0, [r5, #0xf]
+	ldr r1, _0801D4E0  @ gUnknown_0202E4E0
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	ldrb r1, [r5, #0xe]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	strb r0, [r5, #0x10]
+_0801D4BA:
+	bl sub_8003D20
+	bl sub_8084508
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #1
+	bne _0801D4E4
+	adds r0, r6, #0
+	bl sub_801D434
+	b _0801D508
+	.align 2, 0
+_0801D4D4: .4byte gUnknown_03004E50
+_0801D4D8: .4byte gUnknown_0203A958
+_0801D4DC: .4byte gUnknown_0202BCB0
+_0801D4E0: .4byte gUnknown_0202E4E0
+_0801D4E4:
+	ldr r0, _0801D510  @ gUnknown_0203A958
+	ldrb r0, [r0, #0x11]
+	cmp r0, #0x1e
+	beq _0801D502
+	ldr r0, _0801D514  @ gUnknown_0859D1F0
+	ldr r2, _0801D518  @ gUnknown_0202BCB0
+	movs r3, #0x1c
+	ldrsh r1, [r2, r3]
+	movs r3, #0xc
+	ldrsh r2, [r2, r3]
+	subs r1, r1, r2
+	movs r2, #1
+	movs r3, #0x16
+	bl NewMenu_AndDoSomethingCommands
+_0801D502:
+	adds r0, r6, #0
+	bl Proc_ClearNativeCallback
+_0801D508:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801D510: .4byte gUnknown_0203A958
+_0801D514: .4byte gUnknown_0859D1F0
+_0801D518: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START GetUnitSelectionValueThing
+GetUnitSelectionValueThing: @ 0x0801D51C
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _0801D548  @ gUnknown_0202BCF0
+	ldrb r2, [r0, #0xf]
+	cmp r4, #0
+	beq _0801D556
+	ldr r0, _0801D54C  @ gUnknown_0202BCB0
+	ldrb r1, [r0, #4]
+	movs r0, #0x10
+	ands r0, r1
+	cmp r0, #0
+	beq _0801D552
+	ldr r0, [r4]
+	ldrb r0, [r0, #4]
+	bl CanCharacterBePrepMoved
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0801D550
+	movs r0, #4
+	b _0801D5A0
+	.align 2, 0
+_0801D548: .4byte gUnknown_0202BCF0
+_0801D54C: .4byte gUnknown_0202BCB0
+_0801D550:
+	movs r2, #0
+_0801D552:
+	cmp r4, #0
+	bne _0801D55A
+_0801D556:
+	movs r0, #0
+	b _0801D5A0
+_0801D55A:
+	movs r0, #0xb
+	ldrsb r0, [r4, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, r2
+	bne _0801D59E
+	ldr r0, [r4, #0xc]
+	movs r1, #2
+	ands r0, r1
+	cmp r0, #0
+	bne _0801D584
+	ldr r0, [r4]
+	ldr r1, [r4, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #0xd
+	ands r0, r1
+	cmp r0, #0
+	beq _0801D588
+_0801D584:
+	movs r0, #1
+	b _0801D5A0
+_0801D588:
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #2
+	beq _0801D59E
+	cmp r1, #4
+	beq _0801D59E
+	movs r0, #2
+	b _0801D5A0
+_0801D59E:
+	movs r0, #3
+_0801D5A0:
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_801D5A8
+sub_801D5A8: @ 0x0801D5A8
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	ldr r0, _0801D60C  @ gUnknown_0202E4D8
+	ldr r0, [r0]
+	lsls r1, r5, #2
+	adds r0, r1, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0
+	bne _0801D606
+	ldr r0, _0801D610  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	adds r0, r1, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0x77
+	bhi _0801D606
+	ldr r0, _0801D614  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldr r0, [r0, #0xc]
+	movs r1, #0x80
+	lsls r1, r1, #4
+	ands r0, r1
+	cmp r0, #0
+	beq _0801D61C
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl GetTrapAt
+	adds r2, r0, #0
+	ldr r1, _0801D618  @ gUnknown_0202BE48
+	movs r3, #0
+	ldrsh r0, [r1, r3]
+	cmp r4, r0
+	bne _0801D5FC
+	movs r3, #2
+	ldrsh r0, [r1, r3]
+	cmp r5, r0
+	beq _0801D61C
+_0801D5FC:
+	cmp r2, #0
+	beq _0801D61C
+	ldrb r0, [r2, #2]
+	cmp r0, #1
+	bne _0801D61C
+_0801D606:
+	movs r0, #0
+	b _0801D61E
+	.align 2, 0
+_0801D60C: .4byte gUnknown_0202E4D8
+_0801D610: .4byte gUnknown_0202E4E0
+_0801D614: .4byte gUnknown_03004E50
+_0801D618: .4byte gUnknown_0202BE48
+_0801D61C:
+	movs r0, #1
+_0801D61E:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_801D624
+sub_801D624: @ 0x0801D624
+	push {lr}
+	bl sub_8032C88
+	ldr r0, _0801D644  @ gUnknown_03004E50
+	ldr r0, [r0]
+	movs r1, #0x10
+	ldrsb r1, [r0, r1]
+	movs r2, #0x11
+	ldrsb r2, [r0, r2]
+	bl sub_801A82C
+	ldr r0, _0801D648  @ gUnknown_02033EFC
+	bl _MOVEUNIT6C_ChangeFutureMovement
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801D644: .4byte gUnknown_03004E50
+_0801D648: .4byte gUnknown_02033EFC
+
+	THUMB_FUNC_START PlayerPhase_WaitForUnitMovement
+PlayerPhase_WaitForUnitMovement: @ 0x0801D64C
+	push {r4, lr}
+	adds r4, r0, #0
+	bl IsThereAMovingMoveunit
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0801D660
+	adds r0, r4, #0
+	bl Proc_ClearNativeCallback
+_0801D660:
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_801D668
+sub_801D668: @ 0x0801D668
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	ldr r5, _0801D684  @ gUnknown_03004E50
+	ldr r2, [r5]
+	cmp r2, #0
+	bne _0801D688
+	bl sub_80311A8
+	adds r0, r6, #0
+	movs r1, #0xc
+	bl Proc_GotoLabel
+	b _0801D6F4
+	.align 2, 0
+_0801D684: .4byte gUnknown_03004E50
+_0801D688:
+	movs r0, #0x11
+	ldrsb r0, [r2, r0]
+	ldr r4, _0801D6E0  @ gUnknown_0202E4D8
+	ldr r1, [r4]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r1, #0x10
+	ldrsb r1, [r2, r1]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	ldrb r1, [r2, #0xb]
+	strb r1, [r0]
+	ldr r2, [r5]
+	ldr r0, [r2, #0xc]
+	movs r1, #2
+	negs r1, r1
+	ands r0, r1
+	str r0, [r2, #0xc]
+	bl sub_80311A8
+	ldr r2, [r5]
+	movs r0, #0x11
+	ldrsb r0, [r2, r0]
+	ldr r1, [r4]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r1, #0x10
+	ldrsb r1, [r2, r1]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	movs r1, #0
+	strb r1, [r0]
+	ldr r0, [r5]
+	ldr r1, [r0, #0xc]
+	movs r2, #1
+	orrs r1, r2
+	str r1, [r0, #0xc]
+	bl GetUnitSelectionValueThing
+	cmp r0, #2
+	beq _0801D6E4
+	cmp r0, #3
+	beq _0801D6EC
+	b _0801D6F4
+	.align 2, 0
+_0801D6E0: .4byte gUnknown_0202E4D8
+_0801D6E4:
+	ldr r0, [r5]
+	bl HideUnitSMS
+	b _0801D6F4
+_0801D6EC:
+	adds r0, r6, #0
+	movs r1, #0xb
+	bl Proc_GotoLabel
+_0801D6F4:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_801D6FC
+sub_801D6FC: @ 0x0801D6FC
+	push {lr}
+	bl sub_80311A8
+	bl SetDefaultColorEffects
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START MakeMoveunitForActiveUnit
+MakeMoveunitForActiveUnit: @ 0x0801D70C
+	push {r4, lr}
+	bl DoesMoveunitExist
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0801D74A
+	ldr r4, _0801D754  @ gUnknown_03004E50
+	ldr r2, [r4]
+	movs r0, #0xb
+	ldrsb r0, [r2, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	ldr r1, _0801D758  @ gUnknown_0202BCF0
+	ldrb r1, [r1, #0xf]
+	cmp r0, r1
+	bne _0801D74A
+	adds r0, r2, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #2
+	beq _0801D74A
+	cmp r1, #4
+	beq _0801D74A
+	adds r0, r2, #0
+	bl MakeMOVEUNITForMapUnit
+	ldr r0, [r4]
+	bl HideUnitSMS
+_0801D74A:
+	bl _MOVEUNIT6C_SetDefaultFacingDirection
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801D754: .4byte gUnknown_03004E50
+_0801D758: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START ClearActiveUnit
+ClearActiveUnit: @ 0x0801D75C
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	ldr r0, _0801D7D8  @ gUnknown_0859AAD8
+	bl Proc_Find
+	cmp r0, #0
+	beq _0801D7D2
+	movs r1, #9
+	bl Proc_GotoLabel
+	ldr r4, _0801D7DC  @ gUnknown_03004E50
+	ldr r0, [r4]
+	cmp r0, #0
+	beq _0801D788
+	bl ClearMOVEUNITs
+	ldr r0, [r4]
+	ldr r1, [r0, #0xc]
+	movs r2, #2
+	negs r2, r2
+	ands r1, r2
+	str r1, [r0, #0xc]
+_0801D788:
+	ldr r2, _0801D7E0  @ gUnknown_0202BCB0
+	ldrb r1, [r2, #4]
+	movs r0, #0xf7
+	ands r0, r1
+	strb r0, [r2, #4]
+	bl HideMoveRangeGraphics
+	bl RefreshFogAndUnitMaps
+	bl SMS_UpdateFromGameData
+	adds r0, r5, #0
+	bl SetupActiveUnit
+	ldr r2, [r4]
+	ldr r0, [r2, #0xc]
+	movs r1, #2
+	negs r1, r1
+	ands r0, r1
+	str r0, [r2, #0xc]
+	ldr r1, _0801D7E4  @ gUnknown_0202BE48
+	movs r0, #0x10
+	ldrsb r0, [r2, r0]
+	strh r0, [r1]
+	movs r0, #0x11
+	ldrsb r0, [r2, r0]
+	strh r0, [r1, #2]
+	movs r2, #0
+	ldrsh r0, [r1, r2]
+	movs r2, #2
+	ldrsh r1, [r1, r2]
+	bl SetCursorMapPosition
+	bl RefreshFogAndUnitMaps
+	bl SMS_UpdateFromGameData
+_0801D7D2:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801D7D8: .4byte gUnknown_0859AAD8
+_0801D7DC: .4byte gUnknown_03004E50
+_0801D7E0: .4byte gUnknown_0202BCB0
+_0801D7E4: .4byte gUnknown_0202BE48
+
+	THUMB_FUNC_START sub_801D7E8
+sub_801D7E8: @ 0x0801D7E8
+	push {lr}
+	ldr r0, _0801D80C  @ gUnknown_0859AAD8
+	bl Proc_Find
+	adds r2, r0, #0
+	cmp r2, #0
+	beq _0801D806
+	ldr r1, [r2, #0xc]
+	ldr r0, _0801D810  @ sub_801CD1C
+	cmp r1, r0
+	bne _0801D806
+	ldr r1, _0801D814  @ sub_801D818
+	adds r0, r2, #0
+	bl Proc_SetNativeFunc
+_0801D806:
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801D80C: .4byte gUnknown_0859AAD8
+_0801D810: .4byte sub_801CD1C
+_0801D814: .4byte sub_801D818
+
+	THUMB_FUNC_START sub_801D818
+sub_801D818: @ 0x0801D818
+	push {lr}
+	ldr r1, _0801D830  @ gKeyStatusPtr
+	ldr r2, [r1]
+	movs r3, #0
+	movs r1, #1
+	strh r1, [r2, #8]
+	strh r3, [r2, #6]
+	bl sub_801CD1C
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801D830: .4byte gKeyStatusPtr
+
+	THUMB_FUNC_START sub_801D834
+sub_801D834: @ 0x0801D834
+	push {r4, r5, lr}
+	ldr r5, _0801D890  @ gUnknown_03004E50
+	ldr r2, [r5]
+	ldr r0, [r2]
+	ldr r3, [r2, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r3, #0x28]
+	orrs r0, r1
+	movs r1, #2
+	ands r0, r1
+	cmp r0, #0
+	beq _0801D888
+	ldr r0, [r2, #0xc]
+	ldr r1, _0801D894  @ 0x00010044
+	ands r0, r1
+	cmp r0, #0
+	bne _0801D888
+	ldr r4, _0801D898  @ gUnknown_0203A958
+	ldrb r0, [r4, #0x11]
+	subs r0, #2
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+	cmp r0, #1
+	bls _0801D888
+	movs r0, #0x1d
+	ldrsb r0, [r2, r0]
+	movs r1, #0x12
+	ldrsb r1, [r3, r1]
+	adds r0, r0, r1
+	ldrb r4, [r4, #0x10]
+	cmp r0, r4
+	ble _0801D888
+	bl CanUnitMove
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0801D888
+	ldr r0, [r5]
+	ldr r1, [r0, #0xc]
+	movs r2, #0x40
+	orrs r1, r2
+	str r1, [r0, #0xc]
+_0801D888:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801D890: .4byte gUnknown_03004E50
+_0801D894: .4byte 0x00010044
+_0801D898: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START Load6CRangeDisplaySquareGfx
+Load6CRangeDisplaySquareGfx: @ 0x0801D89C
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	ldr r5, _0801D8C4  @ gUnknown_08A02EB4
+	ldr r1, _0801D8C8  @ 0x06005080
+	adds r0, r5, #0
+	movs r2, #0x80
+	bl RegisterTileGraphics
+	ldr r0, _0801D8CC  @ gUnknown_0202BCB0
+	ldrb r1, [r0, #4]
+	movs r0, #1
+	ands r0, r1
+	cmp r0, #0
+	bne _0801D8D0
+	adds r1, r4, #0
+	adds r1, #0x4c
+	movs r0, #2
+	strh r0, [r1]
+	b _0801D8E0
+	.align 2, 0
+_0801D8C4: .4byte gUnknown_08A02EB4
+_0801D8C8: .4byte 0x06005080
+_0801D8CC: .4byte gUnknown_0202BCB0
+_0801D8D0:
+	ldr r1, _0801D8E8  @ 0x06005000
+	adds r0, r5, #0
+	movs r2, #0x80
+	bl RegisterTileGraphics
+	adds r0, r4, #0
+	bl Proc_Delete
+_0801D8E0:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801D8E8: .4byte 0x06005000
+
+	THUMB_FUNC_START Loop6C_MLVCHC
+Loop6C_MLVCHC: @ 0x0801D8EC
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	ldr r1, _0801D924  @ gUnknown_0859AD08
+	adds r4, r5, #0
+	adds r4, #0x4c
+	movs r2, #0
+	ldrsh r0, [r4, r2]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	ldr r0, [r0]
+	ldr r1, _0801D928  @ 0x06005000
+	movs r2, #0x80
+	bl RegisterTileGraphics
+	ldrh r0, [r4]
+	adds r0, #1
+	strh r0, [r4]
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x10
+	cmp r0, #8
+	bne _0801D91C
+	adds r0, r5, #0
+	bl Proc_ClearNativeCallback
+_0801D91C:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801D924: .4byte gUnknown_0859AD08
+_0801D928: .4byte 0x06005000
+
+	THUMB_FUNC_START Setup6CRangeDisplayGfx
+Setup6CRangeDisplayGfx: @ 0x0801D92C
+	push {r4, r5, r6, r7, lr}
+	sub sp, #4
+	ldr r2, _0801D9D0  @ gLCDControlBuffer
+	ldrb r1, [r2, #1]
+	movs r0, #0x21
+	negs r0, r0
+	ands r0, r1
+	movs r1, #0x41
+	negs r1, r1
+	ands r0, r1
+	movs r1, #0x7f
+	ands r0, r1
+	strb r0, [r2, #1]
+	ldr r4, _0801D9D4  @ gUnknown_0202BCB0
+	ldrb r1, [r4, #4]
+	movs r0, #1
+	orrs r0, r1
+	strb r0, [r4, #4]
+	bl UpdateGameTilesGraphics
+	movs r5, #9
+	adds r7, r4, #0
+_0801D958:
+	movs r4, #0xe
+	subs r6, r5, #1
+_0801D95C:
+	movs r0, #0x24
+	ldrsh r1, [r7, r0]
+	adds r1, r1, r4
+	movs r0, #0x26
+	ldrsh r2, [r7, r0]
+	adds r2, r2, r5
+	str r5, [sp]
+	ldr r0, _0801D9D8  @ gBG2TilemapBuffer
+	adds r3, r4, #0
+	bl sub_8019B8C
+	subs r4, #1
+	cmp r4, #0
+	bge _0801D95C
+	adds r5, r6, #0
+	cmp r5, #0
+	bge _0801D958
+	movs r0, #4
+	bl BG_EnableSyncByMask
+	movs r0, #2
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	movs r0, #1
+	movs r1, #0xa
+	movs r2, #6
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	movs r0, #0
+	str r0, [sp]
+	movs r1, #0
+	movs r2, #1
+	movs r3, #0
+	bl sub_8001ED0
+	movs r0, #0
+	bl sub_8001F48
+	movs r0, #1
+	str r0, [sp]
+	movs r0, #0
+	movs r1, #0
+	movs r2, #0
+	movs r3, #1
+	bl sub_8001F0C
+	movs r0, #1
+	bl sub_8001F64
+	bl SetupBackgroundForWeatherMaybe
+	add sp, #4
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801D9D0: .4byte gLCDControlBuffer
+_0801D9D4: .4byte gUnknown_0202BCB0
+_0801D9D8: .4byte gBG2TilemapBuffer
+
+	THUMB_FUNC_START Loop6C_MoveLimitView
+Loop6C_MoveLimitView: @ 0x0801D9DC
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	bl GetGameClock
+	lsrs r5, r0, #1
+	movs r0, #0x1f
+	ands r5, r0
+	adds r4, #0x4a
+	ldrh r1, [r4]
+	movs r0, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _0801DA04
+	lsls r0, r5, #1
+	ldr r1, _0801DA54  @ gUnknown_08A02F34
+	adds r0, r0, r1
+	movs r1, #0x82
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+_0801DA04:
+	ldrh r1, [r4]
+	movs r0, #2
+	ands r0, r1
+	cmp r0, #0
+	beq _0801DA1C
+	lsls r0, r5, #1
+	ldr r1, _0801DA58  @ gUnknown_08A02F94
+	adds r0, r0, r1
+	movs r1, #0xa2
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+_0801DA1C:
+	ldrh r1, [r4]
+	movs r0, #4
+	ands r0, r1
+	cmp r0, #0
+	beq _0801DA34
+	lsls r0, r5, #1
+	ldr r1, _0801DA5C  @ gUnknown_08A02FF4
+	adds r0, r0, r1
+	movs r1, #0xa2
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+_0801DA34:
+	ldrh r1, [r4]
+	movs r0, #0x10
+	ands r0, r1
+	cmp r0, #0
+	beq _0801DA4C
+	lsls r0, r5, #1
+	ldr r1, _0801DA54  @ gUnknown_08A02F34
+	adds r0, r0, r1
+	movs r1, #0xa2
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+_0801DA4C:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801DA54: .4byte gUnknown_08A02F34
+_0801DA58: .4byte gUnknown_08A02F94
+_0801DA5C: .4byte gUnknown_08A02FF4
+
+	THUMB_FUNC_START DestructMoveLimitView
+DestructMoveLimitView: @ 0x0801DA60
+	push {lr}
+	adds r0, #0x4a
+	ldrh r1, [r0]
+	movs r0, #0x11
+	ands r0, r1
+	cmp r0, #0
+	beq _0801DA7C
+	ldr r0, _0801DA90  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #4
+	bl BG_EnableSyncByMask
+_0801DA7C:
+	ldr r2, _0801DA94  @ gUnknown_0202BCB0
+	ldrb r1, [r2, #4]
+	movs r0, #0xfc
+	ands r0, r1
+	strb r0, [r2, #4]
+	bl SetupBackgroundForWeatherMaybe
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801DA90: .4byte gBG2TilemapBuffer
+_0801DA94: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START DisplayMoveRangeGraphics
+DisplayMoveRangeGraphics: @ 0x0801DA98
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	ldr r4, _0801DAB4  @ gUnknown_0859AD50
+	adds r0, r4, #0
+	bl Proc_Find
+	cmp r0, #0
+	beq _0801DAB8
+	bl Setup6CRangeDisplayGfx
+	movs r0, #0
+	bl Load6CRangeDisplaySquareGfx
+	b _0801DAC4
+	.align 2, 0
+_0801DAB4: .4byte gUnknown_0859AD50
+_0801DAB8:
+	adds r0, r4, #0
+	movs r1, #4
+	bl Proc_Create
+	adds r0, #0x4a
+	strh r5, [r0]
+_0801DAC4:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START HideMoveRangeGraphics
+HideMoveRangeGraphics: @ 0x0801DACC
+	push {lr}
+	ldr r0, _0801DAD8  @ gUnknown_0859AD50
+	bl Proc_DeleteAllWithScript
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801DAD8: .4byte gUnknown_0859AD50
+
+	THUMB_FUNC_START sub_801DADC
+sub_801DADC: @ 0x0801DADC
+	push {r4, lr}
+	bl GetUnitStruct
+	adds r4, r0, #0
+	cmp r4, #0
+	beq _0801DB0A
+	ldr r0, [r4]
+	cmp r0, #0
+	beq _0801DB0A
+	ldr r0, [r4, #0xc]
+	ldr r1, _0801DB10  @ 0x00010007
+	ands r0, r1
+	cmp r0, #0
+	bne _0801DB0A
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #4
+	beq _0801DB0A
+	cmp r1, #2
+	bne _0801DB14
+_0801DB0A:
+	movs r0, #0
+	b _0801DB3E
+	.align 2, 0
+_0801DB10: .4byte 0x00010007
+_0801DB14:
+	ldr r0, _0801DB44  @ gUnknown_0859AAD8
+	bl Proc_Find
+	cmp r0, #0
+	bne _0801DB24
+	ldr r0, _0801DB48  @ gUnknown_0859DBBC
+	bl Proc_Find
+_0801DB24:
+	movs r1, #0x10
+	ldrsb r1, [r4, r1]
+	movs r2, #0x11
+	ldrsb r2, [r4, r2]
+	bl EnsureCameraOntoPosition
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	bl SetCursorMapPosition
+	movs r0, #1
+_0801DB3E:
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0801DB44: .4byte gUnknown_0859AAD8
+_0801DB48: .4byte gUnknown_0859DBBC
+
+	THUMB_FUNC_START sub_801DB4C
+sub_801DB4C: @ 0x0801DB4C
+	push {r4, r5, lr}
+	ldr r2, _0801DBA0  @ gUnknown_0202E4D8
+	ldr r2, [r2]
+	lsls r1, r1, #2
+	adds r1, r1, r2
+	ldr r1, [r1]
+	adds r1, r1, r0
+	ldrb r5, [r1]
+	movs r0, #0xc0
+	ands r0, r5
+	cmp r0, #0
+	beq _0801DB66
+	movs r5, #0
+_0801DB66:
+	adds r5, #1
+	adds r4, r5, #0
+	cmp r5, #0x3e
+	bgt _0801DB80
+_0801DB6E:
+	adds r0, r4, #0
+	bl sub_801DADC
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0801DB98
+	adds r4, #1
+	cmp r4, #0x3e
+	ble _0801DB6E
+_0801DB80:
+	movs r4, #1
+	cmp r4, r5
+	bgt _0801DB98
+_0801DB86:
+	adds r0, r4, #0
+	bl sub_801DADC
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0801DB98
+	adds r4, #1
+	cmp r4, r5
+	ble _0801DB86
+_0801DB98:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801DBA0: .4byte gUnknown_0202E4D8
+
+	THUMB_FUNC_START Goto3IfPhaseHasNoAbleUnits
+Goto3IfPhaseHasNoAbleUnits: @ 0x0801DBA4
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r1, _0801DBD0  @ gUnknown_0202BCF0
+	adds r0, r1, #0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x19
+	cmp r0, #0
+	blt _0801DBC8
+	ldrb r0, [r1, #0xf]
+	bl GetPhaseAbleUnitCount
+	cmp r0, #0
+	bne _0801DBC8
+	adds r0, r4, #0
+	movs r1, #3
+	bl Proc_GotoLabel
+_0801DBC8:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801DBD0: .4byte gUnknown_0202BCF0
+
+@ align with 0 (not nop)
+.align 2, 0

--- a/asm/trapfx.s
+++ b/asm/trapfx.s
@@ -1,0 +1,580 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	THUMB_FUNC_START sub_801F540
+sub_801F540: @ 0x0801F540
+	push {r4, r5, r6, r7, lr}
+	sub sp, #8
+	adds r5, r0, #0
+	movs r0, #0
+	movs r6, #0
+	movs r7, #0
+	adds r1, r5, #0
+	adds r1, #0x4a
+	movs r2, #0
+	ldrsh r1, [r1, r2]
+	cmp r1, #1
+	beq _0801F598
+	cmp r1, #1
+	bgt _0801F562
+	cmp r1, #0
+	beq _0801F588
+	b _0801F59C
+_0801F562:
+	cmp r1, #2
+	beq _0801F578
+	cmp r1, #3
+	bne _0801F59C
+	ldr r0, _0801F570  @ gUnknown_085A1510
+	ldr r6, _0801F574  @ gUnknown_085A0FF8
+	b _0801F59C
+	.align 2, 0
+_0801F570: .4byte gUnknown_085A1510
+_0801F574: .4byte gUnknown_085A0FF8
+_0801F578:
+	ldr r0, _0801F580  @ gUnknown_085A1510
+	ldr r6, _0801F584  @ gUnknown_085A0FF8
+	movs r7, #1
+	b _0801F59C
+	.align 2, 0
+_0801F580: .4byte gUnknown_085A1510
+_0801F584: .4byte gUnknown_085A0FF8
+_0801F588:
+	ldr r0, _0801F590  @ gUnknown_085A1AF8
+	ldr r6, _0801F594  @ gUnknown_085A129C
+	movs r7, #1
+	b _0801F59C
+	.align 2, 0
+_0801F590: .4byte gUnknown_085A1AF8
+_0801F594: .4byte gUnknown_085A129C
+_0801F598:
+	ldr r0, _0801F5EC  @ gUnknown_085A1AF8
+	ldr r6, _0801F5F0  @ gUnknown_085A129C
+_0801F59C:
+	ldr r1, _0801F5F4  @ 0x06014800
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _0801F5F8  @ gUnknown_085A206C
+	movs r1, #0x90
+	lsls r1, r1, #2
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	ldr r4, [r5, #0x2c]
+	lsls r4, r4, #4
+	ldr r1, _0801F5FC  @ gUnknown_0202BCB0
+	movs r3, #0xc
+	ldrsh r0, [r1, r3]
+	subs r0, #8
+	subs r4, r4, r0
+	ldr r2, [r5, #0x30]
+	lsls r2, r2, #4
+	movs r3, #0xe
+	ldrsh r0, [r1, r3]
+	subs r0, #8
+	subs r2, r2, r0
+	movs r3, #0x99
+	lsls r3, r3, #6
+	str r7, [sp]
+	movs r0, #0
+	str r0, [sp, #4]
+	adds r0, r6, #0
+	adds r1, r4, #0
+	bl APProc_Create
+	adds r4, #8
+	movs r0, #0xba
+	adds r1, r4, #0
+	bl PlaySpacialSoundMaybe
+	add sp, #8
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F5EC: .4byte gUnknown_085A1AF8
+_0801F5F0: .4byte gUnknown_085A129C
+_0801F5F4: .4byte 0x06014800
+_0801F5F8: .4byte gUnknown_085A206C
+_0801F5FC: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_801F600
+sub_801F600: @ 0x0801F600
+	push {r4, r5, r6, lr}
+	mov r6, r8
+	push {r6}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	adds r6, r2, #0
+	mov r8, r3
+	ldr r0, _0801F62C  @ gUnknown_0859AFC8
+	adds r1, r4, #0
+	bl Proc_CreateBlockingChild
+	str r5, [r0, #0x2c]
+	str r6, [r0, #0x30]
+	adds r0, #0x4a
+	mov r1, r8
+	strh r1, [r0]
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F62C: .4byte gUnknown_0859AFC8
+
+	THUMB_FUNC_START sub_801F630
+sub_801F630: @ 0x0801F630
+	push {r4, r5, lr}
+	sub sp, #8
+	adds r5, r0, #0
+	ldr r0, _0801F67C  @ gUnknown_085A2940
+	ldr r1, _0801F680  @ 0x06014800
+	bl CopyDataWithPossibleUncomp
+	ldr r4, [r5, #0x2c]
+	lsls r4, r4, #4
+	ldr r1, _0801F684  @ gUnknown_0202BCB0
+	movs r2, #0xc
+	ldrsh r0, [r1, r2]
+	subs r0, #8
+	subs r4, r4, r0
+	ldr r2, [r5, #0x30]
+	lsls r2, r2, #4
+	movs r3, #0xe
+	ldrsh r0, [r1, r3]
+	subs r0, #8
+	subs r2, r2, r0
+	movs r3, #0x99
+	lsls r3, r3, #6
+	ldr r0, _0801F688  @ gUnknown_085A2DFC
+	movs r1, #0
+	str r1, [sp]
+	str r1, [sp, #4]
+	adds r1, r4, #0
+	bl APProc_Create
+	adds r4, #8
+	movs r0, #0xbf
+	adds r1, r4, #0
+	bl PlaySpacialSoundMaybe
+	add sp, #8
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F67C: .4byte gUnknown_085A2940
+_0801F680: .4byte 0x06014800
+_0801F684: .4byte gUnknown_0202BCB0
+_0801F688: .4byte gUnknown_085A2DFC
+
+	THUMB_FUNC_START sub_801F68C
+sub_801F68C: @ 0x0801F68C
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	adds r6, r2, #0
+	ldr r0, _0801F6B4  @ gUnknown_085A2DDC
+	movs r1, #0x90
+	lsls r1, r1, #2
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	ldr r0, _0801F6B8  @ gUnknown_0859AFE8
+	adds r1, r4, #0
+	bl Proc_CreateBlockingChild
+	str r5, [r0, #0x2c]
+	str r6, [r0, #0x30]
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F6B4: .4byte gUnknown_085A2DDC
+_0801F6B8: .4byte gUnknown_0859AFE8
+
+	THUMB_FUNC_START sub_801F6BC
+sub_801F6BC: @ 0x0801F6BC
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	adds r6, r2, #0
+	ldr r0, _0801F6E4  @ gUnknown_085A3490
+	movs r1, #0x90
+	lsls r1, r1, #2
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	ldr r0, _0801F6E8  @ gUnknown_0859AFE8
+	adds r1, r4, #0
+	bl Proc_CreateBlockingChild
+	str r5, [r0, #0x2c]
+	str r6, [r0, #0x30]
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F6E4: .4byte gUnknown_085A3490
+_0801F6E8: .4byte gUnknown_0859AFE8
+
+	THUMB_FUNC_START sub_801F6EC
+sub_801F6EC: @ 0x0801F6EC
+	push {r4, r5, lr}
+	sub sp, #8
+	adds r5, r0, #0
+	ldr r1, [r5, #0x2c]
+	lsls r1, r1, #4
+	ldr r3, _0801F748  @ gUnknown_0202BCB0
+	movs r2, #0xc
+	ldrsh r0, [r3, r2]
+	subs r0, #8
+	subs r1, r1, r0
+	ldr r0, _0801F74C  @ 0x000001FF
+	ands r1, r0
+	ldr r2, [r5, #0x30]
+	lsls r2, r2, #4
+	movs r4, #0xe
+	ldrsh r0, [r3, r4]
+	subs r0, #8
+	subs r2, r2, r0
+	movs r0, #0xff
+	ands r2, r0
+	movs r3, #0x99
+	lsls r3, r3, #6
+	ldr r0, _0801F750  @ gUnknown_089A6FD8
+	movs r4, #0
+	str r4, [sp]
+	str r4, [sp, #4]
+	bl APProc_Create
+	ldr r0, [r5, #0x5c]
+	subs r0, #1
+	str r0, [r5, #0x5c]
+	cmp r0, #0
+	bgt _0801F736
+	adds r0, r5, #0
+	movs r1, #0x64
+	bl Proc_GotoLabel
+_0801F736:
+	ldr r0, [r5, #0x58]
+	cmp r0, #1
+	beq _0801F772
+	cmp r0, #1
+	bgt _0801F754
+	cmp r0, #0
+	beq _0801F76C
+	b _0801F778
+	.align 2, 0
+_0801F748: .4byte gUnknown_0202BCB0
+_0801F74C: .4byte 0x000001FF
+_0801F750: .4byte gUnknown_089A6FD8
+_0801F754:
+	cmp r0, #2
+	beq _0801F764
+	cmp r0, #3
+	bne _0801F778
+	ldr r0, [r5, #0x30]
+	subs r0, #1
+	str r0, [r5, #0x30]
+	b _0801F778
+_0801F764:
+	ldr r0, [r5, #0x30]
+	adds r0, #1
+	str r0, [r5, #0x30]
+	b _0801F778
+_0801F76C:
+	ldr r0, [r5, #0x2c]
+	subs r0, #1
+	b _0801F776
+_0801F772:
+	ldr r0, [r5, #0x2c]
+	adds r0, #1
+_0801F776:
+	str r0, [r5, #0x2c]
+_0801F778:
+	add sp, #8
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_801F780
+sub_801F780: @ 0x0801F780
+	push {r4, r5, r6, lr}
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6}
+	adds r4, r0, #0
+	mov r8, r1
+	mov r9, r2
+	adds r5, r3, #0
+	ldr r6, [sp, #0x18]
+	ldr r0, _0801F7C8  @ gUnknown_089ADA80
+	ldr r1, _0801F7CC  @ 0x06014800
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _0801F7D0  @ gUnknown_089ADD0C
+	movs r1, #0x90
+	lsls r1, r1, #2
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	ldr r0, _0801F7D4  @ gUnknown_0859B008
+	adds r1, r4, #0
+	bl Proc_CreateBlockingChild
+	str r5, [r0, #0x58]
+	str r6, [r0, #0x5c]
+	mov r1, r8
+	str r1, [r0, #0x2c]
+	mov r1, r9
+	str r1, [r0, #0x30]
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F7C8: .4byte gUnknown_089ADA80
+_0801F7CC: .4byte 0x06014800
+_0801F7D0: .4byte gUnknown_089ADD0C
+_0801F7D4: .4byte gUnknown_0859B008
+
+	THUMB_FUNC_START sub_801F7D8
+sub_801F7D8: @ 0x0801F7D8
+	push {r4, r5, lr}
+	sub sp, #8
+	adds r5, r0, #0
+	ldr r0, _0801F830  @ gUnknown_085A20AC
+	ldr r1, _0801F834  @ 0x06014800
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _0801F838  @ gUnknown_085A208C
+	movs r1, #0x90
+	lsls r1, r1, #2
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	ldr r4, [r5, #0x2c]
+	lsls r4, r4, #4
+	ldr r0, _0801F83C  @ gUnknown_0202BCB0
+	movs r1, #0xc
+	ldrsh r0, [r0, r1]
+	subs r0, #8
+	subs r4, r4, r0
+	movs r3, #0x99
+	lsls r3, r3, #6
+	ldr r0, _0801F840  @ gUnknown_085A2384
+	movs r1, #0
+	str r1, [sp]
+	str r1, [sp, #4]
+	adds r1, r4, #0
+	movs r2, #0x50
+	bl APProc_Create
+	adds r4, #8
+	movs r0, #0xbc
+	adds r1, r4, #0
+	bl PlaySpacialSoundMaybe
+	ldr r1, [r5, #0x2c]
+	adds r0, r5, #0
+	movs r2, #0x1f
+	bl EnsureCameraOntoPosition
+	add sp, #8
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F830: .4byte gUnknown_085A20AC
+_0801F834: .4byte 0x06014800
+_0801F838: .4byte gUnknown_085A208C
+_0801F83C: .4byte gUnknown_0202BCB0
+_0801F840: .4byte gUnknown_085A2384
+
+	THUMB_FUNC_START sub_801F844
+sub_801F844: @ 0x0801F844
+	push {r4, lr}
+	adds r2, r0, #0
+	adds r4, r1, #0
+	ldr r0, _0801F85C  @ gUnknown_0859B048
+	adds r1, r2, #0
+	bl Proc_CreateBlockingChild
+	str r4, [r0, #0x2c]
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F85C: .4byte gUnknown_0859B048
+
+	THUMB_FUNC_START sub_801F860
+sub_801F860: @ 0x0801F860
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	ldr r0, [r5, #0x2c]
+	bl GetMapChangesPointerById
+	ldrb r4, [r0, #3]
+	lsrs r4, r4, #1
+	ldrb r1, [r0, #1]
+	adds r4, r4, r1
+	ldrb r2, [r0, #4]
+	lsrs r2, r2, #1
+	ldrb r0, [r0, #2]
+	adds r2, r2, r0
+	adds r0, r5, #0
+	adds r1, r4, #0
+	bl EnsureCameraOntoPosition
+	str r4, [r5, #0x34]
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_801F88C
+sub_801F88C: @ 0x0801F88C
+	push {r4, lr}
+	adds r4, r0, #0
+	bl sub_8019CBC
+	bl sub_8019778
+	bl UpdateGameTilesGraphics
+	movs r0, #0
+	bl NewBMXFADE
+	ldr r0, [r4, #0x30]
+	movs r2, #0xbd
+	cmp r0, #0
+	beq _0801F8AC
+	movs r2, #0xbe
+_0801F8AC:
+	ldr r0, _0801F8C4  @ gUnknown_0202BCB0
+	movs r1, #0xc
+	ldrsh r0, [r0, r1]
+	ldr r1, [r4, #0x34]
+	subs r1, r1, r0
+	adds r0, r2, #0
+	bl PlaySpacialSoundMaybe
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F8C4: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_801F8C8
+sub_801F8C8: @ 0x0801F8C8
+	push {r4, r5, lr}
+	adds r1, r0, #0
+	adds r4, r2, #0
+	ldr r0, _0801F8F0  @ gUnknown_0859B070
+	bl Proc_CreateBlockingChild
+	adds r5, r0, #0
+	adds r0, r4, #0
+	bl GetTrap
+	adds r2, r0, #0
+	ldrb r0, [r2, #3]
+	movs r1, #1
+	eors r0, r1
+	strb r0, [r2, #3]
+	cmp r0, #0
+	beq _0801F8F4
+	ldrb r0, [r2, #1]
+	b _0801F8F6
+	.align 2, 0
+_0801F8F0: .4byte gUnknown_0859B070
+_0801F8F4:
+	ldrb r0, [r2]
+_0801F8F6:
+	str r0, [r5, #0x2c]
+	ldrb r0, [r2, #3]
+	str r0, [r5, #0x30]
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_801F904
+sub_801F904: @ 0x0801F904
+	push {r4, r5, r6, lr}
+	sub sp, #8
+	adds r5, r0, #0
+	ldr r0, _0801F964  @ gUnknown_085A34B0
+	ldr r1, _0801F968  @ 0x06014800
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _0801F96C  @ gUnknown_085A3944
+	movs r1, #0x90
+	lsls r1, r1, #2
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	ldr r4, [r5, #0x2c]
+	lsls r4, r4, #4
+	ldr r1, _0801F970  @ gUnknown_0202BCB0
+	movs r2, #0xc
+	ldrsh r0, [r1, r2]
+	subs r0, #8
+	subs r4, r4, r0
+	ldr r2, [r5, #0x30]
+	lsls r2, r2, #4
+	movs r3, #0xe
+	ldrsh r0, [r1, r3]
+	subs r0, #8
+	subs r2, r2, r0
+	movs r3, #0x99
+	lsls r3, r3, #6
+	ldr r0, _0801F974  @ gUnknown_085A3730
+	adds r5, #0x4a
+	movs r6, #0
+	ldrsh r1, [r5, r6]
+	str r1, [sp]
+	movs r1, #0
+	str r1, [sp, #4]
+	adds r1, r4, #0
+	bl APProc_Create
+	adds r4, #8
+	movs r0, #0xbb
+	adds r1, r4, #0
+	bl PlaySpacialSoundMaybe
+	add sp, #8
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801F964: .4byte gUnknown_085A34B0
+_0801F968: .4byte 0x06014800
+_0801F96C: .4byte gUnknown_085A3944
+_0801F970: .4byte gUnknown_0202BCB0
+_0801F974: .4byte gUnknown_085A3730
+
+	THUMB_FUNC_START sub_801F978
+sub_801F978: @ 0x0801F978
+	push {r4, r5, r6, r7, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	adds r6, r2, #0
+	adds r7, r3, #0
+	ldr r0, _0801F99C  @ gUnknown_0859B0A0
+	adds r1, r4, #0
+	bl Proc_CreateBlockingChild
+	str r5, [r0, #0x2c]
+	str r6, [r0, #0x30]
+	cmp r7, #1
+	beq _0801F9A6
+	cmp r7, #1
+	bgt _0801F9A0
+	cmp r7, #0
+	beq _0801F9AE
+	b _0801F9BE
+	.align 2, 0
+_0801F99C: .4byte gUnknown_0859B0A0
+_0801F9A0:
+	cmp r7, #3
+	beq _0801F9B6
+	b _0801F9BE
+_0801F9A6:
+	adds r1, r0, #0
+	adds r1, #0x4a
+	movs r0, #0
+	b _0801F9BC
+_0801F9AE:
+	adds r1, r0, #0
+	adds r1, #0x4a
+	movs r0, #1
+	b _0801F9BC
+_0801F9B6:
+	adds r1, r0, #0
+	adds r1, #0x4a
+	movs r0, #2
+_0801F9BC:
+	strh r0, [r1]
+_0801F9BE:
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_801F9C4
+sub_801F9C4: @ 0x0801F9C4
+	adds r0, #0x4c
+	movs r1, #0xf0
+	strh r1, [r0]
+	bx lr
+
+.align 2, 0

--- a/asm/unitswapfx.s
+++ b/asm/unitswapfx.s
@@ -1,0 +1,268 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ FX for unit swapping when in prep screen
+
+
+	THUMB_FUNC_START sub_801EA64
+sub_801EA64: @ 0x0801EA64
+	push {r4, r5, r6, lr}
+	mov r6, r8
+	push {r6}
+	sub sp, #4
+	adds r4, r0, #0
+	ldr r1, [r4, #0x2c]
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	lsls r0, r0, #4
+	movs r2, #0
+	mov r8, r2
+	strh r0, [r4, #0x30]
+	movs r0, #0x11
+	ldrsb r0, [r1, r0]
+	lsls r0, r0, #4
+	strh r0, [r4, #0x32]
+	movs r3, #0x34
+	ldrsh r2, [r4, r3]
+	movs r1, #0x30
+	ldrsh r0, [r4, r1]
+	subs r2, r2, r0
+	movs r3, #0x36
+	ldrsh r1, [r4, r3]
+	movs r3, #0x32
+	ldrsh r0, [r4, r3]
+	subs r1, r1, r0
+	adds r0, r2, #0
+	muls r0, r2, r0
+	adds r2, r1, #0
+	muls r2, r1, r2
+	adds r1, r2, #0
+	adds r0, r0, r1
+	bl Sqrt
+	adds r5, r0, #0
+	lsls r5, r5, #0x10
+	lsrs r5, r5, #0x10
+	movs r1, #0x80
+	lsls r1, r1, #5
+	movs r2, #0x80
+	lsls r2, r2, #0xa
+	movs r6, #0x80
+	lsls r6, r6, #2
+	str r6, [sp]
+	movs r0, #0
+	adds r3, r5, #0
+	bl sub_8012DCC
+	str r0, [r4, #0x44]
+	str r6, [sp]
+	movs r0, #0
+	movs r1, #0xc
+	movs r2, #0x30
+	adds r3, r5, #0
+	bl sub_8012DCC
+	strh r0, [r4, #0x3e]
+	mov r3, r8
+	strh r3, [r4, #0x3c]
+	add sp, #4
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_801EAE8
+sub_801EAE8: @ 0x0801EAE8
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #0x10
+	adds r7, r0, #0
+	movs r2, #0x80
+	lsls r2, r2, #9
+	movs r0, #0x3c
+	ldrsh r3, [r7, r0]
+	movs r1, #0x3e
+	ldrsh r0, [r7, r1]
+	str r0, [sp]
+	movs r0, #0
+	movs r1, #0
+	bl sub_8012DCC
+	str r0, [sp, #4]
+	movs r2, #0x34
+	ldrsh r6, [r7, r2]
+	movs r1, #0x30
+	ldrsh r0, [r7, r1]
+	mov r9, r0
+	subs r6, r6, r0
+	movs r0, #0x36
+	ldrsh r2, [r7, r0]
+	mov r8, r2
+	movs r2, #0x32
+	ldrsh r1, [r7, r2]
+	str r1, [sp, #8]
+	mov r0, r8
+	subs r0, r0, r1
+	mov r8, r0
+	ldr r2, _0801EBDC  @ gSinLookup
+	ldr r1, [sp, #4]
+	asrs r0, r1, #9
+	movs r1, #0xff
+	ands r0, r1
+	lsls r0, r0, #1
+	adds r0, r0, r2
+	movs r2, #0
+	ldrsh r4, [r0, r2]
+	adds r0, r6, #0
+	muls r0, r4, r0
+	ldr r5, [r7, #0x44]
+	adds r1, r5, #0
+	bl __divsi3
+	mov sl, r0
+	mov r0, r8
+	muls r0, r4, r0
+	adds r1, r5, #0
+	bl __divsi3
+	ldr r2, [sp, #4]
+	adds r1, r6, #0
+	muls r1, r2, r1
+	asrs r1, r1, #0x10
+	adds r5, r1, r0
+	mov r0, r8
+	muls r0, r2, r0
+	asrs r0, r0, #0x10
+	mov r1, sl
+	subs r4, r0, r1
+	add r9, r5
+	ldr r1, _0801EBE0  @ gUnknown_0202BCB0
+	movs r2, #0xc
+	ldrsh r0, [r1, r2]
+	mov r2, r9
+	subs r5, r2, r0
+	ldr r0, [sp, #8]
+	adds r4, r4, r0
+	movs r2, #0xe
+	ldrsh r0, [r1, r2]
+	subs r4, r4, r0
+	adds r1, r5, #0
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	cmp r1, r0
+	bhi _0801EBB2
+	adds r0, r4, #0
+	adds r0, #0x20
+	cmp r0, #0xc0
+	bhi _0801EBB2
+	adds r2, r4, #0
+	subs r2, #0xc
+	ldr r3, _0801EBE4  @ gUnknown_08590F4C
+	movs r0, #6
+	str r0, [sp]
+	movs r0, #4
+	adds r1, r5, #0
+	bl RegisterObjectAttributes_SafeMaybe
+	ldr r3, [r7, #0x2c]
+	movs r0, #4
+	adds r1, r5, #0
+	adds r2, r4, #0
+	bl sub_8027B60
+_0801EBB2:
+	ldrh r0, [r7, #0x3c]
+	adds r0, #1
+	strh r0, [r7, #0x3c]
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x10
+	movs r2, #0x3e
+	ldrsh r1, [r7, r2]
+	cmp r0, r1
+	ble _0801EBCA
+	adds r0, r7, #0
+	bl Proc_ClearNativeCallback
+_0801EBCA:
+	add sp, #0x10
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801EBDC: .4byte gSinLookup
+_0801EBE0: .4byte gUnknown_0202BCB0
+_0801EBE4: .4byte gUnknown_08590F4C
+
+	THUMB_FUNC_START sub_801EBE8
+sub_801EBE8: @ 0x0801EBE8
+	push {lr}
+	adds r1, r0, #0
+	ldr r2, [r1, #0x2c]
+	movs r3, #0x34
+	ldrsh r0, [r1, r3]
+	cmp r0, #0
+	bge _0801EBF8
+	adds r0, #0xf
+_0801EBF8:
+	asrs r0, r0, #4
+	strb r0, [r2, #0x10]
+	ldr r2, [r1, #0x2c]
+	movs r3, #0x36
+	ldrsh r0, [r1, r3]
+	cmp r0, #0
+	bge _0801EC08
+	adds r0, #0xf
+_0801EC08:
+	asrs r0, r0, #4
+	strb r0, [r2, #0x11]
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_801EC10
+sub_801EC10: @ 0x0801EC10
+	push {r4, r5, r6, lr}
+	mov r6, r8
+	push {r6}
+	adds r6, r0, #0
+	mov r8, r1
+	adds r4, r2, #0
+	adds r5, r3, #0
+	ldr r0, _0801EC44  @ gUnknown_0859AEA0
+	adds r1, r6, #0
+	bl Proc_Create
+	mov r1, r8
+	str r1, [r0, #0x2c]
+	lsls r4, r4, #4
+	strh r4, [r0, #0x34]
+	lsls r5, r5, #4
+	strh r5, [r0, #0x36]
+	mov r0, r8
+	bl HideUnitSMS
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801EC44: .4byte gUnknown_0859AEA0
+
+	THUMB_FUNC_START sub_801EC48
+sub_801EC48: @ 0x0801EC48
+	push {lr}
+	ldr r0, _0801EC58  @ gUnknown_0859AEA0
+	bl Proc_Find
+	cmp r0, #0
+	bne _0801EC5C
+	movs r0, #0
+	b _0801EC5E
+	.align 2, 0
+_0801EC58: .4byte gUnknown_0859AEA0
+_0801EC5C:
+	movs r0, #1
+_0801EC5E:
+	pop {r1}
+	bx r1
+
+
+.align 2, 0 @ align with 0

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -64,6 +64,8 @@ SECTIONS
         asm/bmxfade.o(.text);
         asm/bmcamadjust.o(.text);
         asm/convoymenu.o(.text);
+        asm/code_801E2E0.o(.text);
+        asm/menuitempanel.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -67,6 +67,7 @@ SECTIONS
         asm/code_801E2E0.o(.text);
         asm/menuitempanel.o(.text);
         asm/unitswapfx.o(.text);
+        asm/phasechangefx.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -60,6 +60,7 @@ SECTIONS
         asm/bmidoten.o(.text);
         asm/bmdebug.o(.text);
         asm/playerphase.o(.text);
+        asm/koido.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -62,6 +62,7 @@ SECTIONS
         asm/playerphase.o(.text);
         asm/koido.o(.text);
         asm/bmxfade.o(.text);
+        asm/bmcamadjust.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -61,6 +61,7 @@ SECTIONS
         asm/bmdebug.o(.text);
         asm/playerphase.o(.text);
         asm/koido.o(.text);
+        asm/bmxfade.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -59,6 +59,7 @@ SECTIONS
         asm/bmmap.o(.text);
         asm/bmidoten.o(.text);
         asm/bmdebug.o(.text);
+        asm/playerphase.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -66,6 +66,7 @@ SECTIONS
         asm/convoymenu.o(.text);
         asm/code_801E2E0.o(.text);
         asm/menuitempanel.o(.text);
+        asm/unitswapfx.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -63,6 +63,7 @@ SECTIONS
         asm/koido.o(.text);
         asm/bmxfade.o(.text);
         asm/bmcamadjust.o(.text);
+        asm/convoymenu.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -64,10 +64,12 @@ SECTIONS
         asm/bmxfade.o(.text);
         asm/bmcamadjust.o(.text);
         asm/convoymenu.o(.text);
-        asm/code_801E2E0.o(.text);
+        asm/code_801E2E0.o(.text); /* 2 fog related functions and FillWarpRangeMap */
         asm/menuitempanel.o(.text);
         asm/unitswapfx.o(.text);
         asm/phasechangefx.o(.text);
+        asm/code_801F50C.o(.text); /* ChangeActiveUnitFacing */
+        asm/trapfx.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -70,6 +70,7 @@ SECTIONS
         asm/phasechangefx.o(.text);
         asm/code_801F50C.o(.text); /* ChangeActiveUnitFacing */
         asm/trapfx.o(.text);
+        asm/notifybox.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);


### PR DESCRIPTION
- end of `bmdebug.s`
- `playerphase.s` Player Phase proc code and related functions
- `koido.s` KOIDO and KOIDOAMM procs (rescue/drop/give/take map unit animations)
- `bmxfade.s` Tile Fading (for tile changes and such)
- `bmcamadjust.s` Misc Camera movement functions
- `convoymenu.s` "Send item to convoy" menus and related functions
- `menuitempanel.s` Item info panel in item selection menus
- `unitswapfx.s` Unit Swapping Animation/Effect (When you swap unit places in the prep screen)
- `phasechangefx.s` The nice phase changing thing and related procs/functions
- `trapfx.s` Various Graphical Effects related to activating traps
- `notifybox.s` Some kind of inferior popup (used for trap removing among other things)

Note: I'm assuming `bm` stands for "battle map".

There were some weird out of place functions here and there so I put those in their own (`code_xxxxxxx.s`) files for now.

Hopefully I didn't split *too* much. I tried to make sure the (ro)data had corresponding boundaries (no overlaps) as best as I could. If it happens to not match later I guess we'll have to merge some files together but for now I think it's okay.