### PR TITLE
Split even more files

### DIFF
--- a/asm/bmbattle.s
+++ b/asm/bmbattle.s
@@ -1,0 +1,6581 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ Battle logic
+	@ Huge
+
+	THUMB_FUNC_START sub_802A13C
+sub_802A13C: @ 0x0802A13C
+	push {r4, r5, r6, r7, lr}
+	mov r7, r9
+	mov r6, r8
+	push {r6, r7}
+	mov r8, r0
+	mov r9, r1
+	adds r4, r2, #0
+	adds r5, r3, #0
+	ldr r6, _0802A188  @ gUnknown_0203A4EC
+	adds r0, r6, #0
+	mov r1, r8
+	bl CopyUnitToBattleStruct
+	ldr r7, _0802A18C  @ gUnknown_0203A56C
+	adds r0, r7, #0
+	mov r1, r9
+	bl CopyUnitToBattleStruct
+	strb r4, [r6, #0x10]
+	strb r5, [r6, #0x11]
+	ldr r4, _0802A190  @ gUnknown_0203A4D4
+	movs r2, #0x10
+	ldrsb r2, [r6, r2]
+	movs r0, #0x10
+	ldrsb r0, [r7, r0]
+	subs r1, r2, r0
+	cmp r1, #0
+	bge _0802A176
+	subs r1, r0, r2
+_0802A176:
+	movs r3, #0x11
+	ldrsb r3, [r6, r3]
+	movs r0, #0x11
+	ldrsb r0, [r7, r0]
+	subs r2, r3, r0
+	cmp r2, #0
+	blt _0802A194
+	adds r0, r1, r2
+	b _0802A198
+	.align 2, 0
+_0802A188: .4byte gUnknown_0203A4EC
+_0802A18C: .4byte gUnknown_0203A56C
+_0802A190: .4byte gUnknown_0203A4D4
+_0802A194:
+	subs r0, r0, r3
+	adds r0, r1, r0
+_0802A198:
+	strb r0, [r4, #2]
+	ldr r0, _0802A1B0  @ gUnknown_0203A4D4
+	ldrh r1, [r0]
+	movs r0, #8
+	ands r0, r1
+	cmp r0, #0
+	beq _0802A1B8
+	ldr r0, _0802A1B4  @ gUnknown_0203A4EC
+	bl SetupBattleBallistaWeaponData
+	b _0802A1C0
+	.align 2, 0
+_0802A1B0: .4byte gUnknown_0203A4D4
+_0802A1B4: .4byte gUnknown_0203A4EC
+_0802A1B8:
+	ldr r0, _0802A204  @ gUnknown_0203A4EC
+	ldr r1, [sp, #0x1c]
+	bl SetupBattleWeaponData
+_0802A1C0:
+	ldr r4, _0802A208  @ gUnknown_0203A56C
+	movs r1, #1
+	negs r1, r1
+	adds r0, r4, #0
+	bl SetupBattleWeaponData
+	bl DoSomeBattleWeaponStuff
+	ldr r5, _0802A204  @ gUnknown_0203A4EC
+	adds r0, r5, #0
+	adds r1, r4, #0
+	bl BattleApplyWeaponTriangle
+	bl BattleSomethingTrapChangeTerrain
+	adds r0, r5, #0
+	bl BattleSetupTerrainData
+	adds r0, r4, #0
+	bl BattleSetupTerrainData
+	mov r0, r8
+	mov r1, r9
+	bl sub_802A398
+	bl NullAllLightRunesTerrain
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802A204: .4byte gUnknown_0203A4EC
+_0802A208: .4byte gUnknown_0203A56C
+
+	THUMB_FUNC_START sub_802A20C
+sub_802A20C: @ 0x0802A20C
+	push {r4, r5, r6, r7, lr}
+	adds r6, r0, #0
+	adds r7, r1, #0
+	ldr r5, _0802A24C  @ gUnknown_0203A4EC
+	adds r0, r5, #0
+	adds r1, r6, #0
+	bl CopyUnitToBattleStruct
+	ldr r4, _0802A250  @ gUnknown_0203A56C
+	adds r0, r4, #0
+	adds r1, r7, #0
+	bl CopyUnitToBattleStruct
+	ldr r0, _0802A254  @ gUnknown_0203A4D4
+	mov ip, r0
+	movs r2, #0x10
+	ldrsb r2, [r5, r2]
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	subs r1, r2, r0
+	cmp r1, #0
+	bge _0802A23A
+	subs r1, r0, r2
+_0802A23A:
+	movs r3, #0x11
+	ldrsb r3, [r5, r3]
+	movs r0, #0x11
+	ldrsb r0, [r4, r0]
+	subs r2, r3, r0
+	cmp r2, #0
+	blt _0802A258
+	adds r0, r1, r2
+	b _0802A25C
+	.align 2, 0
+_0802A24C: .4byte gUnknown_0203A4EC
+_0802A250: .4byte gUnknown_0203A56C
+_0802A254: .4byte gUnknown_0203A4D4
+_0802A258:
+	subs r0, r0, r3
+	adds r0, r1, r0
+_0802A25C:
+	mov r1, ip
+	strb r0, [r1, #2]
+	ldr r0, _0802A274  @ gUnknown_0203A4D4
+	ldrh r1, [r0]
+	movs r0, #8
+	ands r0, r1
+	cmp r0, #0
+	beq _0802A27C
+	ldr r0, _0802A278  @ gUnknown_0203A4EC
+	bl SetupBattleBallistaWeaponData
+	b _0802A286
+	.align 2, 0
+_0802A274: .4byte gUnknown_0203A4D4
+_0802A278: .4byte gUnknown_0203A4EC
+_0802A27C:
+	ldr r0, _0802A2EC  @ gUnknown_0203A4EC
+	movs r1, #1
+	negs r1, r1
+	bl SetupBattleWeaponData
+_0802A286:
+	ldr r4, _0802A2F0  @ gUnknown_0203A56C
+	movs r1, #1
+	negs r1, r1
+	adds r0, r4, #0
+	bl SetupBattleWeaponData
+	bl DoSomeBattleWeaponStuff
+	ldr r5, _0802A2EC  @ gUnknown_0203A4EC
+	adds r0, r5, #0
+	adds r1, r4, #0
+	bl BattleApplyWeaponTriangle
+	bl BattleSomethingTrapChangeTerrain
+	adds r0, r5, #0
+	bl BattleSetupTerrainData
+	adds r0, r4, #0
+	bl BattleSetupTerrainData
+	adds r0, r6, #0
+	adds r1, r7, #0
+	bl sub_802A398
+	bl NullAllLightRunesTerrain
+	adds r0, r4, #0
+	bl sub_802C740
+	adds r0, r4, #0
+	bl sub_802C6EC
+	movs r0, #0xb
+	ldrsb r0, [r4, r0]
+	cmp r0, #0
+	beq _0802A2E4
+	bl sub_802B92C
+	bl sub_80A4AA4
+	adds r0, r6, #0
+	bl sub_80A44C8
+	adds r0, r7, #0
+	bl sub_80A44C8
+_0802A2E4:
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802A2EC: .4byte gUnknown_0203A4EC
+_0802A2F0: .4byte gUnknown_0203A56C
+
+	THUMB_FUNC_START BATTLE_SaveFromBattle
+BATTLE_SaveFromBattle: @ 0x0802A2F4
+	push {lr}
+	bl SaveUnitsFromBattle
+	bl UpdateBallistaUsesFromBattle
+	ldr r0, _0802A310  @ gUnknown_0203A4EC
+	ldr r1, _0802A314  @ gUnknown_0203A56C
+	bl nullsub_11
+	bl sub_802CAFC
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802A310: .4byte gUnknown_0203A4EC
+_0802A314: .4byte gUnknown_0203A56C
+
+	THUMB_FUNC_START sub_802A318
+sub_802A318: @ 0x0802A318
+	push {r4, r5, lr}
+	sub sp, #4
+	adds r4, r0, #0
+	adds r5, r1, #0
+	cmp r2, #0
+	bge _0802A330
+	cmp r3, #0
+	bge _0802A330
+	movs r2, #0x10
+	ldrsb r2, [r4, r2]
+	movs r3, #0x11
+	ldrsb r3, [r4, r3]
+_0802A330:
+	ldr r0, _0802A34C  @ gUnknown_0203A4D4
+	movs r1, #2
+	strh r1, [r0]
+	ldr r0, [sp, #0x10]
+	str r0, [sp]
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl sub_802A13C
+	add sp, #4
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802A34C: .4byte gUnknown_0203A4D4
+
+	THUMB_FUNC_START sub_802A350
+sub_802A350: @ 0x0802A350
+	push {lr}
+	ldr r3, _0802A360  @ gUnknown_0203A4D4
+	movs r2, #1
+	strh r2, [r3]
+	bl sub_802A20C
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802A360: .4byte gUnknown_0203A4D4
+
+	THUMB_FUNC_START sub_802A364
+sub_802A364: @ 0x0802A364
+	push {r4, r5, r6, lr}
+	sub sp, #4
+	ldr r5, _0802A380  @ gUnknown_0203A4D4
+	movs r6, #0
+	movs r4, #0xa
+	strh r4, [r5]
+	str r6, [sp]
+	bl sub_802A13C
+	add sp, #4
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802A380: .4byte gUnknown_0203A4D4
+
+	THUMB_FUNC_START sub_802A384
+sub_802A384: @ 0x0802A384
+	push {lr}
+	ldr r3, _0802A394  @ gUnknown_0203A4D4
+	movs r2, #9
+	strh r2, [r3]
+	bl sub_802A20C
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802A394: .4byte gUnknown_0203A4D4
+
+	THUMB_FUNC_START sub_802A398
+sub_802A398: @ 0x0802A398
+	push {r4, r5, r6, lr}
+	adds r6, r1, #0
+	ldr r5, _0802A3E4  @ gUnknown_0203A4EC
+	ldr r4, _0802A3E8  @ gUnknown_0203A56C
+	adds r0, r5, #0
+	adds r1, r4, #0
+	bl FillPreBattleStats
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl FillPreBattleStats
+	adds r0, r5, #0
+	adds r1, r4, #0
+	bl FillBattleStats
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl FillBattleStats
+	cmp r6, #0
+	bne _0802A3C8
+	bl FillSnagBattleStats
+_0802A3C8:
+	ldr r0, _0802A3EC  @ gUnknown_0203A4D4
+	ldrh r1, [r0]
+	movs r0, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _0802A3F4
+	ldr r0, _0802A3F0  @ gUnknown_0203A958
+	ldr r0, [r0, #0x18]
+	cmp r0, #0
+	beq _0802A3F4
+	bl sub_802CF4C
+	b _0802A3F8
+	.align 2, 0
+_0802A3E4: .4byte gUnknown_0203A4EC
+_0802A3E8: .4byte gUnknown_0203A56C
+_0802A3EC: .4byte gUnknown_0203A4D4
+_0802A3F0: .4byte gUnknown_0203A958
+_0802A3F4:
+	bl MakeBattle
+_0802A3F8:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START SetupBattleStructFromUnitAndWeapon
+SetupBattleStructFromUnitAndWeapon: @ 0x0802A400
+	push {r4, r5, r6, r7, lr}
+	sub sp, #0x48
+	adds r7, r0, #0
+	lsls r1, r1, #0x18
+	lsrs r6, r1, #0x18
+	ldr r1, _0802A460  @ gUnknown_0203A4D4
+	movs r3, #0
+	movs r2, #0
+	movs r0, #4
+	strh r0, [r1]
+	ldr r0, _0802A464  @ gUnknown_0203A56C
+	mov ip, r0
+	adds r0, #0x48
+	strh r2, [r0]
+	mov r0, ip
+	str r2, [r0, #0x4c]
+	mov r1, ip
+	adds r1, #0x50
+	movs r0, #0xff
+	strb r0, [r1]
+	mov r0, ip
+	str r2, [r0, #4]
+	ldr r5, _0802A468  @ gUnknown_0203A4EC
+	adds r0, r5, #0
+	adds r0, #0x53
+	strb r3, [r0]
+	adds r0, #1
+	strb r3, [r0]
+	lsls r4, r6, #0x18
+	lsrs r0, r4, #0x18
+	cmp r0, #4
+	bhi _0802A46C
+	mov r0, sp
+	adds r1, r7, #0
+	movs r2, #0x48
+	bl memcpy
+	asrs r1, r4, #0x18
+	mov r0, sp
+	bl EquipUnitItemByIndex
+	movs r6, #0
+	adds r0, r5, #0
+	mov r1, sp
+	bl CopyUnitToBattleStruct
+	b _0802A474
+	.align 2, 0
+_0802A460: .4byte gUnknown_0203A4D4
+_0802A464: .4byte gUnknown_0203A56C
+_0802A468: .4byte gUnknown_0203A4EC
+_0802A46C:
+	adds r0, r5, #0
+	adds r1, r7, #0
+	bl CopyUnitToBattleStruct
+_0802A474:
+	ldr r0, _0802A48C  @ gUnknown_03005280
+	ldrb r1, [r0]
+	movs r0, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _0802A494
+	ldr r0, _0802A490  @ gUnknown_0203A4EC
+	movs r1, #0
+	bl WriteBattleStructTerrainBonuses
+	b _0802A49A
+	.align 2, 0
+_0802A48C: .4byte gUnknown_03005280
+_0802A490: .4byte gUnknown_0203A4EC
+_0802A494:
+	ldr r0, _0802A524  @ gUnknown_0203A4EC
+	bl BattleSetupTerrainData
+_0802A49A:
+	ldr r4, _0802A524  @ gUnknown_0203A4EC
+	lsls r1, r6, #0x18
+	asrs r1, r1, #0x18
+	adds r0, r4, #0
+	bl SetupBattleWeaponData
+	ldr r1, _0802A528  @ gUnknown_0203A56C
+	adds r0, r4, #0
+	bl FillPreBattleStats
+	adds r5, r4, #0
+	adds r5, #0x48
+	ldrh r0, [r5]
+	bl GetItemIndex
+	cmp r0, #0x11
+	bne _0802A4DC
+	adds r2, r4, #0
+	adds r2, #0x5a
+	movs r0, #0x14
+	ldrsb r0, [r4, r0]
+	lsrs r1, r0, #0x1f
+	adds r0, r0, r1
+	asrs r0, r0, #1
+	ldrh r1, [r2]
+	subs r1, r1, r0
+	movs r0, #0
+	strh r1, [r2]
+	adds r1, r4, #0
+	adds r1, #0x66
+	strh r0, [r1]
+	adds r1, #4
+	strh r0, [r1]
+_0802A4DC:
+	ldrh r0, [r5]
+	cmp r0, #0
+	bne _0802A4F2
+	adds r0, r4, #0
+	adds r0, #0x5a
+	movs r1, #0xff
+	strh r1, [r0]
+	adds r0, #6
+	strh r1, [r0]
+	adds r0, #6
+	strh r1, [r0]
+_0802A4F2:
+	ldrh r0, [r5]
+	bl GetItemWeaponEffect
+	cmp r0, #3
+	bne _0802A504
+	adds r1, r4, #0
+	adds r1, #0x5a
+	movs r0, #0xff
+	strh r0, [r1]
+_0802A504:
+	ldrh r0, [r5]
+	bl GetItemIndex
+	cmp r0, #0xb5
+	bne _0802A51A
+	adds r0, r4, #0
+	adds r0, #0x5a
+	movs r1, #0xff
+	strh r1, [r0]
+	adds r0, #0xc
+	strh r1, [r0]
+_0802A51A:
+	add sp, #0x48
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802A524: .4byte gUnknown_0203A4EC
+_0802A528: .4byte gUnknown_0203A56C
+
+	THUMB_FUNC_START RollRNIfBattleStarted
+RollRNIfBattleStarted: @ 0x0802A52C
+	push {lr}
+	lsls r0, r0, #0x10
+	lsrs r3, r0, #0x10
+	lsls r1, r1, #0x18
+	lsrs r2, r1, #0x18
+	ldr r0, _0802A54C  @ gUnknown_0203A4D4
+	ldrh r1, [r0]
+	movs r0, #2
+	ands r0, r1
+	cmp r0, #0
+	bne _0802A550
+	adds r0, r3, #0
+	bl Roll1RN
+	lsls r0, r0, #0x18
+	b _0802A552
+	.align 2, 0
+_0802A54C: .4byte gUnknown_0203A4D4
+_0802A550:
+	lsls r0, r2, #0x18
+_0802A552:
+	asrs r0, r0, #0x18
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START Roll2RNIfBattleStarted
+Roll2RNIfBattleStarted: @ 0x0802A558
+	push {lr}
+	lsls r0, r0, #0x10
+	lsrs r3, r0, #0x10
+	lsls r1, r1, #0x18
+	lsrs r2, r1, #0x18
+	ldr r0, _0802A578  @ gUnknown_0203A4D4
+	ldrh r1, [r0]
+	movs r0, #2
+	ands r0, r1
+	cmp r0, #0
+	bne _0802A57C
+	adds r0, r3, #0
+	bl Roll2RN
+	lsls r0, r0, #0x18
+	b _0802A57E
+	.align 2, 0
+_0802A578: .4byte gUnknown_0203A4D4
+_0802A57C:
+	lsls r0, r2, #0x18
+_0802A57E:
+	asrs r0, r0, #0x18
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START CopyUnitToBattleStruct
+CopyUnitToBattleStruct: @ 0x0802A584
+	push {r4, r5, r6, lr}
+	adds r5, r0, #0
+	adds r6, r1, #0
+	cmp r6, #0
+	beq _0802A65A
+	movs r2, #0x48
+	bl memcpy
+	adds r0, r6, #0
+	bl GetUnitMaxHP
+	movs r4, #0
+	strb r0, [r5, #0x12]
+	adds r0, r6, #0
+	bl GetUnitPower
+	strb r0, [r5, #0x14]
+	adds r0, r6, #0
+	bl GetUnitSkill
+	strb r0, [r5, #0x15]
+	adds r0, r6, #0
+	bl GetUnitSpeed
+	strb r0, [r5, #0x16]
+	adds r0, r6, #0
+	bl GetUnitDefense
+	strb r0, [r5, #0x17]
+	adds r0, r6, #0
+	bl GetUnitLuck
+	strb r0, [r5, #0x19]
+	adds r0, r6, #0
+	bl GetUnitResistance
+	strb r0, [r5, #0x18]
+	ldr r2, [r6, #4]
+	ldr r0, [r6]
+	ldrb r1, [r0, #0x13]
+	ldrb r0, [r2, #0x11]
+	adds r1, r1, r0
+	ldrb r0, [r6, #0x1a]
+	adds r0, r0, r1
+	strb r0, [r5, #0x1a]
+	ldrb r0, [r2, #0x12]
+	ldrb r6, [r6, #0x1d]
+	adds r0, r0, r6
+	strb r0, [r5, #0x1d]
+	ldrb r1, [r5, #8]
+	adds r0, r5, #0
+	adds r0, #0x70
+	strb r1, [r0]
+	ldrb r0, [r5, #9]
+	adds r1, r5, #0
+	adds r1, #0x71
+	strb r0, [r1]
+	ldrb r0, [r5, #0x13]
+	adds r1, #1
+	strb r0, [r1]
+	subs r1, #3
+	movs r0, #0xff
+	strb r0, [r1]
+	adds r0, r5, #0
+	adds r0, #0x73
+	strb r4, [r0]
+	adds r0, #1
+	strb r4, [r0]
+	adds r0, #1
+	strb r4, [r0]
+	adds r0, #1
+	strb r4, [r0]
+	adds r0, #1
+	strb r4, [r0]
+	adds r0, #1
+	strb r4, [r0]
+	adds r0, #1
+	strb r4, [r0]
+	adds r0, #1
+	strb r4, [r0]
+	ldr r2, _0802A660  @ gUnknown_0203A4EC
+	adds r0, r2, #0
+	adds r0, #0x7b
+	strb r4, [r0]
+	ldr r1, _0802A664  @ gUnknown_0203A56C
+	adds r0, r1, #0
+	adds r0, #0x7b
+	strb r4, [r0]
+	adds r0, r5, #0
+	adds r0, #0x53
+	strb r4, [r0]
+	adds r0, #1
+	strb r4, [r0]
+	adds r0, #0x28
+	strb r4, [r0]
+	adds r0, r2, #0
+	adds r0, #0x7d
+	strb r4, [r0]
+	adds r0, r1, #0
+	adds r0, #0x7d
+	strb r4, [r0]
+	adds r0, r2, #0
+	adds r0, #0x6e
+	strb r4, [r0]
+	adds r0, r1, #0
+	adds r0, #0x6e
+	strb r4, [r0]
+_0802A65A:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802A660: .4byte gUnknown_0203A4EC
+_0802A664: .4byte gUnknown_0203A56C
+
+	THUMB_FUNC_START CopyUnitToBattleStructRawStats
+CopyUnitToBattleStructRawStats: @ 0x0802A668
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	adds r4, r1, #0
+	bl CopyUnitToBattleStruct
+	ldrb r0, [r4, #0x12]
+	strb r0, [r5, #0x12]
+	ldrb r0, [r4, #0x14]
+	strb r0, [r5, #0x14]
+	ldrb r0, [r4, #0x15]
+	strb r0, [r5, #0x15]
+	ldrb r0, [r4, #0x16]
+	strb r0, [r5, #0x16]
+	ldrb r0, [r4, #0x17]
+	strb r0, [r5, #0x17]
+	ldrb r0, [r4, #0x19]
+	strb r0, [r5, #0x19]
+	ldrb r0, [r4, #0x18]
+	strb r0, [r5, #0x18]
+	ldr r1, [r4, #4]
+	ldr r0, [r4]
+	ldrb r0, [r0, #0x13]
+	ldrb r1, [r1, #0x11]
+	adds r0, r0, r1
+	strb r0, [r5, #0x1a]
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START WriteBattleStructTerrainBonuses
+WriteBattleStructTerrainBonuses: @ 0x0802A6A0
+	adds r2, r0, #0
+	adds r3, r2, #0
+	adds r3, #0x55
+	strb r1, [r3]
+	ldr r0, [r2, #4]
+	ldrb r1, [r3]
+	ldr r0, [r0, #0x44]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	adds r1, r2, #0
+	adds r1, #0x57
+	strb r0, [r1]
+	ldr r0, [r2, #4]
+	ldrb r1, [r3]
+	ldr r0, [r0, #0x48]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	adds r1, r2, #0
+	adds r1, #0x56
+	strb r0, [r1]
+	ldr r0, [r2, #4]
+	ldrb r1, [r3]
+	ldr r0, [r0, #0x4c]
+	adds r0, r0, r1
+	ldrb r1, [r0]
+	adds r0, r2, #0
+	adds r0, #0x58
+	strb r1, [r0]
+	bx lr
+
+	THUMB_FUNC_START BattleSetupTerrainData
+BattleSetupTerrainData: @ 0x0802A6DC
+	adds r2, r0, #0
+	movs r0, #0x11
+	ldrsb r0, [r2, r0]
+	ldr r1, _0802A72C  @ gUnknown_0202E4DC
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r1, #0x10
+	ldrsb r1, [r2, r1]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	adds r3, r2, #0
+	adds r3, #0x55
+	strb r0, [r3]
+	ldr r0, [r2, #4]
+	ldrb r1, [r3]
+	ldr r0, [r0, #0x44]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	adds r1, r2, #0
+	adds r1, #0x57
+	strb r0, [r1]
+	ldr r0, [r2, #4]
+	ldrb r1, [r3]
+	ldr r0, [r0, #0x48]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	adds r1, r2, #0
+	adds r1, #0x56
+	strb r0, [r1]
+	ldr r0, [r2, #4]
+	ldrb r1, [r3]
+	ldr r0, [r0, #0x4c]
+	adds r0, r0, r1
+	ldrb r1, [r0]
+	adds r0, r2, #0
+	adds r0, #0x58
+	strb r1, [r0]
+	bx lr
+	.align 2, 0
+_0802A72C: .4byte gUnknown_0202E4DC
+
+	THUMB_FUNC_START SetupBattleWeaponData
+SetupBattleWeaponData: @ 0x0802A730
+	push {r4, r5, r6, r7, lr}
+	mov r7, r9
+	mov r6, r8
+	push {r6, r7}
+	adds r5, r0, #0
+	adds r3, r1, #0
+	movs r0, #1
+	negs r0, r0
+	cmp r3, r0
+	bne _0802A74C
+	adds r0, r5, #0
+	bl GetUnitEquippedWeaponSlot
+	adds r3, r0, #0
+_0802A74C:
+	ldr r0, [r5, #0xc]
+	movs r1, #0x80
+	lsls r1, r1, #4
+	ands r0, r1
+	cmp r0, #0
+	beq _0802A75A
+	movs r3, #8
+_0802A75A:
+	adds r1, r5, #0
+	adds r1, #0x52
+	movs r0, #1
+	strb r0, [r1]
+	mov r9, r1
+	cmp r3, #8
+	bhi _0802A830
+	lsls r0, r3, #2
+	ldr r1, _0802A774  @ _0802A778
+	adds r0, r0, r1
+	ldr r0, [r0]
+	mov pc, r0
+	.align 2, 0
+_0802A774: .4byte _0802A778
+_0802A778: @ jump table
+	.4byte _0802A79C @ case 0
+	.4byte _0802A79C @ case 1
+	.4byte _0802A79C @ case 2
+	.4byte _0802A79C @ case 3
+	.4byte _0802A79C @ case 4
+	.4byte _0802A7B0 @ case 5
+	.4byte _0802A7CC @ case 6
+	.4byte _0802A7EC @ case 7
+	.4byte _0802A80C @ case 8
+_0802A79C:
+	adds r2, r5, #0
+	adds r2, #0x51
+	strb r3, [r2]
+	ldrb r1, [r2]
+	lsls r1, r1, #1
+	adds r0, r5, #0
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r0, [r0]
+	b _0802A7BC
+_0802A7B0:
+	adds r2, r5, #0
+	adds r2, #0x51
+	movs r0, #0xff
+	strb r0, [r2]
+	ldr r0, _0802A7C8  @ gUnknown_0202BCB0
+	ldrh r0, [r0, #0x2c]
+_0802A7BC:
+	adds r1, r5, #0
+	adds r1, #0x48
+	strh r0, [r1]
+	mov r8, r2
+	adds r4, r1, #0
+	b _0802A84A
+	.align 2, 0
+_0802A7C8: .4byte gUnknown_0202BCB0
+_0802A7CC:
+	adds r3, r5, #0
+	adds r3, #0x51
+	movs r0, #0
+	strb r0, [r3]
+	ldr r0, _0802A7E8  @ gUnknown_0203A8F0
+	ldrh r1, [r0, #0x1a]
+	adds r2, r5, #0
+	adds r2, #0x48
+	movs r0, #0
+	strh r1, [r2]
+	mov r1, r9
+	strb r0, [r1]
+	b _0802A846
+	.align 2, 0
+_0802A7E8: .4byte gUnknown_0203A8F0
+_0802A7EC:
+	adds r3, r5, #0
+	adds r3, #0x51
+	movs r0, #0
+	strb r0, [r3]
+	ldr r0, _0802A808  @ gUnknown_0203A8F0
+	ldrh r1, [r0, #0x1c]
+	adds r2, r5, #0
+	adds r2, #0x48
+	movs r0, #0
+	strh r1, [r2]
+	mov r1, r9
+	strb r0, [r1]
+	b _0802A846
+	.align 2, 0
+_0802A808: .4byte gUnknown_0203A8F0
+_0802A80C:
+	adds r4, r5, #0
+	adds r4, #0x51
+	movs r0, #0xff
+	strb r0, [r4]
+	movs r0, #0x10
+	ldrsb r0, [r5, r0]
+	movs r1, #0x11
+	ldrsb r1, [r5, r1]
+	bl GetBallistaItemAt
+	adds r2, r5, #0
+	adds r2, #0x48
+	movs r1, #0
+	strh r0, [r2]
+	mov r0, r9
+	strb r1, [r0]
+	mov r8, r4
+	b _0802A848
+_0802A830:
+	adds r3, r5, #0
+	adds r3, #0x51
+	movs r0, #0xff
+	strb r0, [r3]
+	adds r2, r5, #0
+	adds r2, #0x48
+	movs r1, #0
+	movs r0, #0
+	strh r0, [r2]
+	mov r0, r9
+	strb r1, [r0]
+_0802A846:
+	mov r8, r3
+_0802A848:
+	adds r4, r2, #0
+_0802A84A:
+	ldrh r0, [r4]
+	adds r1, r5, #0
+	adds r1, #0x4a
+	strh r0, [r1]
+	ldrh r0, [r4]
+	bl GetItemAttributes
+	str r0, [r5, #0x4c]
+	ldrh r0, [r4]
+	bl GetItemWType
+	adds r6, r5, #0
+	adds r6, #0x50
+	strb r0, [r6]
+	ldr r7, _0802A890  @ gUnknown_0203A4D4
+	ldrh r1, [r7]
+	movs r0, #4
+	ands r0, r1
+	cmp r0, #0
+	bne _0802A90A
+	ldr r0, [r5, #0x4c]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	beq _0802A8BC
+	ldrh r0, [r4]
+	bl GetItemIndex
+	cmp r0, #0x11
+	beq _0802A8B8
+	cmp r0, #0x11
+	bgt _0802A894
+	cmp r0, #0x10
+	beq _0802A8A2
+	b _0802A8BC
+	.align 2, 0
+_0802A890: .4byte gUnknown_0203A4D4
+_0802A894:
+	cmp r0, #0xa1
+	bne _0802A8BC
+	ldrb r0, [r7, #2]
+	cmp r0, #2
+	bne _0802A8AC
+	movs r0, #5
+	b _0802A8BA
+_0802A8A2:
+	ldrb r0, [r7, #2]
+	cmp r0, #2
+	bne _0802A8AC
+	movs r0, #6
+	b _0802A8BA
+_0802A8AC:
+	ldr r0, [r5, #0x4c]
+	movs r1, #0x41
+	negs r1, r1
+	ands r0, r1
+	str r0, [r5, #0x4c]
+	b _0802A8BC
+_0802A8B8:
+	movs r0, #7
+_0802A8BA:
+	strb r0, [r6]
+_0802A8BC:
+	ldrh r0, [r4]
+	ldr r1, _0802A8F8  @ gUnknown_0203A4D4
+	ldrb r1, [r1, #2]
+	bl IsItemCoveringRange
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802A8D4
+	mov r1, r8
+	ldrb r0, [r1]
+	cmp r0, #0xff
+	bne _0802A8DE
+_0802A8D4:
+	movs r1, #0
+	movs r0, #0
+	strh r0, [r4]
+	mov r0, r9
+	strb r1, [r0]
+_0802A8DE:
+	adds r0, r5, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1c
+	lsrs r0, r0, #0x1c
+	cmp r0, #0xb
+	beq _0802A900
+	cmp r0, #0xb
+	bgt _0802A8FC
+	cmp r0, #2
+	beq _0802A900
+	b _0802A90A
+	.align 2, 0
+_0802A8F8: .4byte gUnknown_0203A4D4
+_0802A8FC:
+	cmp r0, #0xd
+	bne _0802A90A
+_0802A900:
+	movs r1, #0
+	movs r0, #0
+	strh r0, [r4]
+	mov r0, r9
+	strb r1, [r0]
+_0802A90A:
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START SetupBattleBallistaWeaponData
+SetupBattleBallistaWeaponData: @ 0x0802A918
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	movs r0, #0x10
+	ldrsb r0, [r6, r0]
+	movs r1, #0x11
+	ldrsb r1, [r6, r1]
+	bl GetBallistaItemAt
+	adds r4, r6, #0
+	adds r4, #0x48
+	movs r5, #0
+	strh r0, [r4]
+	adds r1, r6, #0
+	adds r1, #0x4a
+	strh r0, [r1]
+	ldrh r0, [r4]
+	bl GetItemAttributes
+	str r0, [r6, #0x4c]
+	ldrh r0, [r4]
+	bl GetItemWType
+	adds r1, r6, #0
+	adds r1, #0x50
+	strb r0, [r1]
+	adds r0, r6, #0
+	adds r0, #0x52
+	strb r5, [r0]
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_802A958
+sub_802A958: @ 0x0802A958
+	bx lr
+
+	THUMB_FUNC_START FillPreBattleStats
+FillPreBattleStats: @ 0x0802A95C
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	bl BattleLoadDefense
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl BattleLoadAttack
+	adds r0, r4, #0
+	bl BattleLoadAS
+	adds r0, r4, #0
+	bl BattleLoadHit
+	adds r0, r4, #0
+	bl BattleLoadAvoid
+	adds r0, r4, #0
+	bl BattleLoadCrit
+	adds r0, r4, #0
+	bl BattleLoadDodge
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl BattleApplyMiscBonuses
+	adds r0, r4, #0
+	bl BattleApplySRankBonuses
+	adds r0, r4, #0
+	bl BattleComputeBuffStatus
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START FillBattleStats
+FillBattleStats: @ 0x0802A9A8
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	bl ComputeHit
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ComputeCrit
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ComputeLethalityChance
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ComputeSpecialWeapons
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START BattleApplyMiscBonuses
+BattleApplyMiscBonuses: @ 0x0802A9D0
+	push {r4, r5, lr}
+	sub sp, #8
+	adds r5, r0, #0
+	ldr r0, _0802AA3C  @ gUnknown_0203A4D4
+	ldrh r1, [r0]
+	movs r0, #0x20
+	ands r0, r1
+	cmp r0, #0
+	beq _0802A9EA
+	ldr r0, _0802AA40  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0x15]
+	cmp r0, #0
+	beq _0802AA34
+_0802A9EA:
+	mov r4, sp
+	adds r0, r5, #0
+	mov r1, sp
+	bl GetUnitSupportBonuses
+	adds r2, r5, #0
+	adds r2, #0x5a
+	ldrb r1, [r4, #1]
+	ldrh r0, [r2]
+	adds r0, r0, r1
+	strh r0, [r2]
+	adds r2, #2
+	ldrb r1, [r4, #2]
+	ldrh r0, [r2]
+	adds r0, r0, r1
+	strh r0, [r2]
+	adds r2, #4
+	ldrb r1, [r4, #3]
+	ldrh r0, [r2]
+	adds r0, r0, r1
+	strh r0, [r2]
+	adds r1, r5, #0
+	adds r1, #0x62
+	ldrh r0, [r1]
+	ldrb r2, [r4, #4]
+	adds r0, r0, r2
+	strh r0, [r1]
+	adds r1, #4
+	ldrh r0, [r1]
+	ldrb r2, [r4, #5]
+	adds r0, r0, r2
+	strh r0, [r1]
+	adds r1, #2
+	ldrh r0, [r1]
+	ldrb r4, [r4, #6]
+	adds r0, r0, r4
+	strh r0, [r1]
+_0802AA34:
+	add sp, #8
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802AA3C: .4byte gUnknown_0203A4D4
+_0802AA40: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START BattleLoadDefense
+BattleLoadDefense: @ 0x0802AA44
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	adds r5, #0x48
+	ldrh r0, [r5]
+	bl GetItemAttributes
+	movs r1, #0x40
+	ands r1, r0
+	cmp r1, #0
+	beq _0802AA6A
+	adds r0, r4, #0
+	adds r0, #0x58
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0x18
+	ldrsb r1, [r4, r1]
+	b _0802AA96
+_0802AA6A:
+	ldrh r0, [r5]
+	bl GetItemAttributes
+	movs r1, #2
+	ands r1, r0
+	cmp r1, #0
+	beq _0802AA88
+	adds r0, r4, #0
+	adds r0, #0x58
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0x18
+	ldrsb r1, [r4, r1]
+	b _0802AA96
+_0802AA88:
+	adds r0, r4, #0
+	adds r0, #0x56
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0x17
+	ldrsb r1, [r4, r1]
+_0802AA96:
+	adds r0, r0, r1
+	adds r1, r4, #0
+	adds r1, #0x5c
+	strh r0, [r1]
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START LoadRawDefense
+LoadRawDefense: @ 0x0802AAA4
+	adds r1, r0, #0
+	adds r1, #0x56
+	ldrb r1, [r1]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	movs r2, #0x17
+	ldrsb r2, [r0, r2]
+	adds r1, r1, r2
+	adds r0, #0x5c
+	strh r1, [r0]
+	bx lr
+
+	THUMB_FUNC_START BattleLoadAttack
+BattleLoadAttack: @ 0x0802AABC
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	adds r6, r0, #0
+	mov r8, r1
+	adds r7, r6, #0
+	adds r7, #0x48
+	ldrh r0, [r7]
+	bl GetItemMight
+	adds r1, r6, #0
+	adds r1, #0x54
+	ldrb r1, [r1]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	adds r1, r1, r0
+	adds r4, r6, #0
+	adds r4, #0x5a
+	strh r1, [r4]
+	ldrh r5, [r4]
+	adds r0, r6, #0
+	mov r1, r8
+	bl IsSlayerApplied
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #1
+	bne _0802AB00
+	movs r0, #0
+	ldrsh r1, [r4, r0]
+	lsls r0, r1, #1
+	adds r0, r0, r1
+	lsls r0, r0, #0x10
+	lsrs r5, r0, #0x10
+_0802AB00:
+	ldrh r0, [r7]
+	mov r1, r8
+	bl IsWeaponEffective
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #1
+	bne _0802AB4A
+	ldrh r5, [r4]
+	ldrh r0, [r7]
+	bl GetItemIndex
+	cmp r0, #0x87
+	beq _0802AB3A
+	cmp r0, #0x87
+	bgt _0802AB2A
+	cmp r0, #0x3e
+	beq _0802AB3A
+	cmp r0, #0x85
+	beq _0802AB3A
+	b _0802AB3E
+_0802AB2A:
+	cmp r0, #0x8e
+	beq _0802AB3A
+	cmp r0, #0x8e
+	blt _0802AB3E
+	cmp r0, #0x94
+	bgt _0802AB3E
+	cmp r0, #0x91
+	blt _0802AB3E
+_0802AB3A:
+	lsls r0, r5, #0x11
+	b _0802AB48
+_0802AB3E:
+	lsls r1, r5, #0x10
+	asrs r1, r1, #0x10
+	lsls r0, r1, #1
+	adds r0, r0, r1
+	lsls r0, r0, #0x10
+_0802AB48:
+	lsrs r5, r0, #0x10
+_0802AB4A:
+	adds r4, r6, #0
+	adds r4, #0x5a
+	strh r5, [r4]
+	movs r0, #0x14
+	ldrsb r0, [r6, r0]
+	adds r0, r5, r0
+	strh r0, [r4]
+	adds r0, r6, #0
+	adds r0, #0x48
+	ldrh r0, [r0]
+	bl GetItemIndex
+	cmp r0, #0xb5
+	bne _0802AB6A
+	movs r0, #0
+	strh r0, [r4]
+_0802AB6A:
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START BattleLoadAS
+BattleLoadAS: @ 0x0802AB74
+	push {r4, lr}
+	adds r4, r0, #0
+	adds r0, #0x4a
+	ldrh r0, [r0]
+	bl GetItemWeight
+	adds r1, r0, #0
+	movs r0, #0x1a
+	ldrsb r0, [r4, r0]
+	subs r1, r1, r0
+	cmp r1, #0
+	bge _0802AB8E
+	movs r1, #0
+_0802AB8E:
+	movs r0, #0x16
+	ldrsb r0, [r4, r0]
+	subs r0, r0, r1
+	adds r1, r4, #0
+	adds r1, #0x5e
+	strh r0, [r1]
+	lsls r0, r0, #0x10
+	cmp r0, #0
+	bge _0802ABA4
+	movs r0, #0
+	strh r0, [r1]
+_0802ABA4:
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START BattleLoadHit
+BattleLoadHit: @ 0x0802ABAC
+	push {r4, lr}
+	adds r4, r0, #0
+	adds r0, #0x48
+	ldrh r0, [r0]
+	bl GetItemHit
+	movs r2, #0x15
+	ldrsb r2, [r4, r2]
+	lsls r2, r2, #1
+	adds r2, r2, r0
+	movs r0, #0x19
+	ldrsb r0, [r4, r0]
+	lsrs r1, r0, #0x1f
+	adds r0, r0, r1
+	asrs r0, r0, #1
+	adds r0, r0, r2
+	adds r1, r4, #0
+	adds r1, #0x53
+	ldrb r1, [r1]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	adds r1, r1, r0
+	adds r0, r4, #0
+	adds r0, #0x60
+	strh r1, [r0]
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START BattleLoadAvoid
+BattleLoadAvoid: @ 0x0802ABE4
+	push {lr}
+	adds r2, r0, #0
+	adds r0, #0x5e
+	movs r1, #0
+	ldrsh r0, [r0, r1]
+	lsls r0, r0, #1
+	adds r1, r2, #0
+	adds r1, #0x57
+	ldrb r1, [r1]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	adds r1, r1, r0
+	movs r0, #0x19
+	ldrsb r0, [r2, r0]
+	adds r0, r0, r1
+	adds r1, r2, #0
+	adds r1, #0x62
+	strh r0, [r1]
+	lsls r0, r0, #0x10
+	cmp r0, #0
+	bge _0802AC12
+	movs r0, #0
+	strh r0, [r1]
+_0802AC12:
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START BattleLoadCrit
+BattleLoadCrit: @ 0x0802AC18
+	push {r4, lr}
+	adds r4, r0, #0
+	adds r0, #0x48
+	ldrh r0, [r0]
+	bl GetItemCrit
+	movs r1, #0x15
+	ldrsb r1, [r4, r1]
+	lsrs r2, r1, #0x1f
+	adds r1, r1, r2
+	asrs r1, r1, #1
+	adds r2, r1, r0
+	adds r3, r4, #0
+	adds r3, #0x66
+	strh r2, [r3]
+	ldr r0, [r4]
+	ldr r1, [r4, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	beq _0802AC4E
+	adds r0, r2, #0
+	adds r0, #0xf
+	strh r0, [r3]
+_0802AC4E:
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START BattleLoadDodge
+BattleLoadDodge: @ 0x0802AC54
+	movs r1, #0x19
+	ldrsb r1, [r0, r1]
+	adds r0, #0x68
+	strh r1, [r0]
+	bx lr
+
+	THUMB_FUNC_START ComputeHit
+ComputeHit: @ 0x0802AC60
+	push {lr}
+	adds r2, r0, #0
+	adds r2, #0x60
+	adds r1, #0x62
+	ldrh r2, [r2]
+	ldrh r1, [r1]
+	subs r2, r2, r1
+	adds r1, r0, #0
+	adds r1, #0x64
+	strh r2, [r1]
+	lsls r2, r2, #0x10
+	asrs r2, r2, #0x10
+	cmp r2, #0x64
+	ble _0802AC80
+	movs r0, #0x64
+	strh r0, [r1]
+_0802AC80:
+	movs r2, #0
+	ldrsh r0, [r1, r2]
+	cmp r0, #0
+	bge _0802AC8C
+	movs r0, #0
+	strh r0, [r1]
+_0802AC8C:
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START ComputeCrit
+ComputeCrit: @ 0x0802AC90
+	push {r4, r5, r6, lr}
+	adds r2, r0, #0
+	adds r6, r1, #0
+	adds r1, r2, #0
+	adds r1, #0x66
+	adds r0, r6, #0
+	adds r0, #0x68
+	ldrh r1, [r1]
+	ldrh r0, [r0]
+	subs r1, r1, r0
+	adds r5, r2, #0
+	adds r5, #0x6a
+	movs r4, #0
+	strh r1, [r5]
+	adds r0, r2, #0
+	adds r0, #0x48
+	ldrh r0, [r0]
+	bl GetItemIndex
+	cmp r0, #0xb5
+	bne _0802ACBC
+	strh r4, [r5]
+_0802ACBC:
+	movs r1, #0
+	ldrsh r0, [r5, r1]
+	cmp r0, #0
+	bge _0802ACC6
+	strh r4, [r5]
+_0802ACC6:
+	movs r4, #0
+	b _0802ACCC
+_0802ACCA:
+	adds r4, #1
+_0802ACCC:
+	cmp r4, #4
+	bgt _0802ACF0
+	lsls r1, r4, #1
+	adds r0, r6, #0
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r0, [r0]
+	cmp r0, #0
+	beq _0802ACF0
+	bl GetItemAttributes
+	movs r1, #0x80
+	lsls r1, r1, #8
+	ands r1, r0
+	cmp r1, #0
+	beq _0802ACCA
+	movs r0, #0
+	strh r0, [r5]
+_0802ACF0:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START ComputeLethalityChance
+ComputeLethalityChance: @ 0x0802ACF8
+	push {r4, lr}
+	adds r3, r0, #0
+	adds r4, r1, #0
+	ldr r0, [r3]
+	ldr r1, [r3, #4]
+	ldr r2, [r0, #0x28]
+	ldr r0, [r1, #0x28]
+	orrs r2, r0
+	movs r0, #0x80
+	lsls r0, r0, #0x12
+	ands r2, r0
+	cmp r2, #0
+	bne _0802AD1A
+	adds r0, r3, #0
+	adds r0, #0x6c
+	strh r2, [r0]
+	b _0802AD4E
+_0802AD1A:
+	adds r2, r3, #0
+	adds r2, #0x6c
+	movs r0, #0x32
+	strh r0, [r2]
+	ldr r3, [r4]
+	ldr r4, [r4, #4]
+	ldr r0, [r3, #0x28]
+	ldr r1, [r4, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #8
+	ands r0, r1
+	cmp r0, #0
+	beq _0802AD3A
+	movs r0, #0x19
+	strh r0, [r2]
+_0802AD3A:
+	ldr r0, [r3, #0x28]
+	ldr r1, [r4, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #0x11
+	ands r0, r1
+	cmp r0, #0
+	beq _0802AD4E
+	movs r0, #0
+	strh r0, [r2]
+_0802AD4E:
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START BattleApplySRankBonuses
+BattleApplySRankBonuses: @ 0x0802AD54
+	push {r4, lr}
+	adds r4, r0, #0
+	adds r1, r4, #0
+	adds r1, #0x48
+	ldrh r0, [r1]
+	cmp r0, #0
+	beq _0802AD8A
+	bl GetItemWType
+	adds r1, r0, #0
+	cmp r1, #7
+	bgt _0802AD8A
+	adds r0, r4, #0
+	adds r0, #0x28
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	cmp r0, #0xfa
+	bls _0802AD8A
+	adds r1, r4, #0
+	adds r1, #0x60
+	ldrh r0, [r1]
+	adds r0, #5
+	strh r0, [r1]
+	adds r1, #6
+	ldrh r0, [r1]
+	adds r0, #5
+	strh r0, [r1]
+_0802AD8A:
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START BattleComputeBuffStatus
+BattleComputeBuffStatus: @ 0x0802AD90
+	push {lr}
+	adds r1, r0, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1c
+	lsrs r0, r0, #0x1c
+	cmp r0, #6
+	beq _0802ADB8
+	cmp r0, #6
+	bgt _0802ADAA
+	cmp r0, #5
+	beq _0802ADB4
+	b _0802ADC8
+_0802ADAA:
+	cmp r0, #7
+	beq _0802ADBC
+	cmp r0, #8
+	beq _0802ADC0
+	b _0802ADC8
+_0802ADB4:
+	adds r1, #0x5a
+	b _0802ADC2
+_0802ADB8:
+	adds r1, #0x5c
+	b _0802ADC2
+_0802ADBC:
+	adds r1, #0x66
+	b _0802ADC2
+_0802ADC0:
+	adds r1, #0x62
+_0802ADC2:
+	ldrh r0, [r1]
+	adds r0, #0xa
+	strh r0, [r1]
+_0802ADC8:
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START ComputeSpecialWeapons
+ComputeSpecialWeapons: @ 0x0802ADCC
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	adds r6, r1, #0
+	ldr r5, [r4, #0x4c]
+	movs r0, #0x40
+	ands r5, r0
+	cmp r5, #0
+	beq _0802AE14
+	adds r0, r4, #0
+	adds r0, #0x48
+	ldrh r0, [r0]
+	bl GetItemIndex
+	cmp r0, #0x10
+	blt _0802AE8A
+	cmp r0, #0x11
+	ble _0802ADF2
+	cmp r0, #0xa1
+	bne _0802AE8A
+_0802ADF2:
+	adds r3, r4, #0
+	adds r3, #0x5a
+	movs r0, #0x14
+	ldrsb r0, [r4, r0]
+	lsrs r1, r0, #0x1f
+	adds r0, r0, r1
+	asrs r0, r0, #1
+	ldrh r1, [r3]
+	subs r1, r1, r0
+	movs r2, #0
+	strh r1, [r3]
+	adds r0, r4, #0
+	adds r0, #0x66
+	strh r2, [r0]
+	adds r0, #4
+	strh r2, [r0]
+	b _0802AE8A
+_0802AE14:
+	adds r0, r4, #0
+	adds r0, #0x4a
+	ldrh r0, [r0]
+	bl GetItemWeaponEffect
+	cmp r0, #3
+	bne _0802AE48
+	movs r0, #0x13
+	ldrsb r0, [r6, r0]
+	adds r0, #1
+	asrs r0, r0, #1
+	adds r1, r4, #0
+	adds r1, #0x5a
+	strh r0, [r1]
+	cmp r0, #0
+	bne _0802AE38
+	movs r0, #1
+	strh r0, [r1]
+_0802AE38:
+	adds r0, r6, #0
+	adds r0, #0x5c
+	strh r5, [r0]
+	adds r0, r4, #0
+	adds r0, #0x66
+	strh r5, [r0]
+	adds r0, #4
+	strh r5, [r0]
+_0802AE48:
+	ldr r0, [r4, #0x4c]
+	movs r1, #0x80
+	lsls r1, r1, #0xa
+	ands r0, r1
+	cmp r0, #0
+	beq _0802AE5C
+	adds r1, r6, #0
+	adds r1, #0x5c
+	movs r0, #0
+	strh r0, [r1]
+_0802AE5C:
+	adds r0, r6, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r2, #0xf
+	ands r2, r0
+	cmp r2, #0xb
+	beq _0802AE6E
+	cmp r2, #0xd
+	bne _0802AE8A
+_0802AE6E:
+	adds r0, r4, #0
+	adds r0, #0x64
+	movs r2, #0x64
+	strh r2, [r0]
+	adds r1, r4, #0
+	adds r1, #0x6a
+	ldrh r0, [r1]
+	adds r0, #0x1e
+	strh r0, [r1]
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x10
+	cmp r0, #0x64
+	ble _0802AE8A
+	strh r2, [r1]
+_0802AE8A:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START ClearRounds
+ClearRounds: @ 0x0802AE90
+	push {r4, r5, r6, r7, lr}
+	ldr r7, _0802AEC4  @ gUnknown_0203A5EC
+	ldr r0, _0802AEC8  @ gUnknown_0203A608
+	mov ip, r0
+	ldr r5, _0802AECC  @ 0xFFF80000
+	movs r6, #7
+	movs r4, #0
+	adds r2, r7, #0
+	movs r3, #6
+_0802AEA2:
+	ldr r0, [r2]
+	ands r0, r5
+	str r0, [r2]
+	ldrb r1, [r2, #2]
+	adds r0, r6, #0
+	ands r0, r1
+	strb r0, [r2, #2]
+	strb r4, [r2, #3]
+	adds r2, #4
+	subs r3, #1
+	cmp r3, #0
+	bge _0802AEA2
+	mov r0, ip
+	str r7, [r0]
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802AEC4: .4byte gUnknown_0203A5EC
+_0802AEC8: .4byte gUnknown_0203A608
+_0802AECC: .4byte 0xFFF80000
+
+	THUMB_FUNC_START MakeBattle
+MakeBattle: @ 0x0802AED0
+	push {r4, r5, r6, lr}
+	sub sp, #8
+	bl ClearRounds
+	add r4, sp, #4
+	mov r0, sp
+	adds r1, r4, #0
+	bl GetBattleUnitPointers
+	ldr r6, _0802AF74  @ gUnknown_0203A608
+	ldr r3, [r6]
+	ldr r1, [r3]
+	lsls r1, r1, #8
+	lsrs r1, r1, #0x1b
+	movs r0, #1
+	orrs r1, r0
+	lsls r1, r1, #3
+	ldrb r2, [r3, #2]
+	movs r0, #7
+	ands r0, r2
+	orrs r0, r1
+	strb r0, [r3, #2]
+	ldr r0, [sp]
+	ldr r1, [sp, #4]
+	bl MakeBattleRound
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802AF50
+	ldr r3, [r6]
+	ldr r2, [r3]
+	lsls r1, r2, #0xd
+	lsrs r1, r1, #0xd
+	movs r0, #8
+	orrs r1, r0
+	ldr r5, _0802AF78  @ 0xFFF80000
+	adds r0, r5, #0
+	ands r0, r2
+	orrs r0, r1
+	str r0, [r3]
+	ldr r0, [sp, #4]
+	ldr r1, [sp]
+	bl MakeBattleRound
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802AF50
+	mov r0, sp
+	adds r1, r4, #0
+	bl BattleCheckDoubling
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802AF50
+	ldr r2, [r6]
+	ldr r0, [r2]
+	ands r0, r5
+	movs r1, #4
+	orrs r0, r1
+	str r0, [r2]
+	ldr r0, [sp]
+	ldr r1, [sp, #4]
+	bl MakeBattleRound
+_0802AF50:
+	ldr r0, _0802AF74  @ gUnknown_0203A608
+	ldr r3, [r0]
+	ldr r1, [r3]
+	lsls r1, r1, #8
+	lsrs r1, r1, #0x1b
+	movs r0, #0x10
+	orrs r1, r0
+	lsls r1, r1, #3
+	ldrb r2, [r3, #2]
+	movs r0, #7
+	ands r0, r2
+	orrs r0, r1
+	strb r0, [r3, #2]
+	add sp, #8
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802AF74: .4byte gUnknown_0203A608
+_0802AF78: .4byte 0xFFF80000
+
+	THUMB_FUNC_START GetBattleUnitPointers
+GetBattleUnitPointers: @ 0x0802AF7C
+	ldr r2, _0802AF88  @ gUnknown_0203A4EC
+	str r2, [r0]
+	ldr r0, _0802AF8C  @ gUnknown_0203A56C
+	str r0, [r1]
+	bx lr
+	.align 2, 0
+_0802AF88: .4byte gUnknown_0203A4EC
+_0802AF8C: .4byte gUnknown_0203A56C
+
+	THUMB_FUNC_START BattleCheckDoubling
+BattleCheckDoubling: @ 0x0802AF90
+	push {r4, r5, r6, r7, lr}
+	adds r4, r0, #0
+	adds r7, r1, #0
+	ldr r0, _0802AFC4  @ gUnknown_0203A56C
+	adds r2, r0, #0
+	adds r2, #0x5e
+	movs r3, #0
+	ldrsh r1, [r2, r3]
+	adds r6, r0, #0
+	cmp r1, #0xfa
+	bgt _0802B010
+	ldr r0, _0802AFC8  @ gUnknown_0203A4EC
+	adds r1, r0, #0
+	adds r1, #0x5e
+	movs r5, #0
+	ldrsh r3, [r1, r5]
+	movs r1, #0
+	ldrsh r2, [r2, r1]
+	subs r1, r3, r2
+	adds r5, r0, #0
+	cmp r1, #0
+	blt _0802AFCC
+	cmp r1, #3
+	ble _0802B010
+	b _0802AFD2
+	.align 2, 0
+_0802AFC4: .4byte gUnknown_0203A56C
+_0802AFC8: .4byte gUnknown_0203A4EC
+_0802AFCC:
+	subs r0, r2, r3
+	cmp r0, #3
+	ble _0802B010
+_0802AFD2:
+	adds r0, r5, #0
+	adds r0, #0x5e
+	adds r2, r6, #0
+	adds r2, #0x5e
+	movs r3, #0
+	ldrsh r1, [r0, r3]
+	movs r3, #0
+	ldrsh r0, [r2, r3]
+	cmp r1, r0
+	ble _0802AFEC
+	str r5, [r4]
+	str r6, [r7]
+	b _0802AFF0
+_0802AFEC:
+	str r6, [r4]
+	str r5, [r7]
+_0802AFF0:
+	ldr r0, [r4]
+	adds r0, #0x4a
+	ldrh r0, [r0]
+	bl GetItemWeaponEffect
+	cmp r0, #3
+	beq _0802B010
+	ldr r0, [r4]
+	adds r0, #0x48
+	ldrh r0, [r0]
+	bl GetItemIndex
+	cmp r0, #0xb5
+	beq _0802B010
+	movs r0, #1
+	b _0802B012
+_0802B010:
+	movs r0, #0
+_0802B012:
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START MakeBattleRound
+MakeBattleRound: @ 0x0802B018
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	adds r6, r0, #0
+	mov r8, r1
+	adds r0, #0x48
+	ldrh r0, [r0]
+	cmp r0, #0
+	bne _0802B030
+	b _0802B06C
+_0802B02C:
+	movs r0, #1
+	b _0802B06E
+_0802B030:
+	ldr r0, _0802B078  @ gUnknown_0203A608
+	ldr r0, [r0]
+	ldrh r7, [r0]
+	adds r0, r6, #0
+	bl GetBattleHitCount
+	adds r5, r0, #0
+	movs r4, #0
+	cmp r4, r5
+	bge _0802B06C
+_0802B044:
+	ldr r0, _0802B078  @ gUnknown_0203A608
+	ldr r3, [r0]
+	ldr r2, [r3]
+	lsls r1, r2, #0xd
+	lsrs r1, r1, #0xd
+	orrs r1, r7
+	ldr r0, _0802B07C  @ 0xFFF80000
+	ands r0, r2
+	orrs r0, r1
+	str r0, [r3]
+	adds r0, r6, #0
+	mov r1, r8
+	bl MakeNextBattleHitRound
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802B02C
+	adds r4, #1
+	cmp r4, r5
+	blt _0802B044
+_0802B06C:
+	movs r0, #0
+_0802B06E:
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0802B078: .4byte gUnknown_0203A608
+_0802B07C: .4byte 0xFFF80000
+
+	THUMB_FUNC_START GetBattleHitCount
+GetBattleHitCount: @ 0x0802B080
+	push {r4, lr}
+	movs r4, #1
+	bl BattleCheckBrave
+	lsls r4, r0
+	adds r0, r4, #0
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START BattleCheckBrave
+BattleCheckBrave: @ 0x0802B094
+	push {lr}
+	ldr r0, [r0, #0x4c]
+	movs r1, #0x20
+	ands r0, r1
+	cmp r0, #0
+	beq _0802B0C4
+	ldr r0, _0802B0BC  @ gUnknown_0203A608
+	ldr r3, [r0]
+	ldr r2, [r3]
+	lsls r1, r2, #0xd
+	lsrs r1, r1, #0xd
+	movs r0, #0x10
+	orrs r1, r0
+	ldr r0, _0802B0C0  @ 0xFFF80000
+	ands r0, r2
+	orrs r0, r1
+	str r0, [r3]
+	movs r0, #1
+	b _0802B0C6
+	.align 2, 0
+_0802B0BC: .4byte gUnknown_0203A608
+_0802B0C0: .4byte 0xFFF80000
+_0802B0C4:
+	movs r0, #0
+_0802B0C6:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START CheckForTriangleAttack
+CheckForTriangleAttack: @ 0x0802B0CC
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #0xc
+	adds r4, r0, #0
+	adds r5, r1, #0
+	ldr r1, _0802B188  @ gUnknown_080D7C38
+	mov r0, sp
+	movs r2, #8
+	bl memcpy
+	movs r7, #0
+	ldr r0, [r4]
+	ldr r1, [r4, #4]
+	ldr r6, [r0, #0x28]
+	ldr r0, [r1, #0x28]
+	orrs r6, r0
+	movs r0, #0xc0
+	lsls r0, r0, #0xf
+	ands r6, r0
+	movs r0, #0x10
+	ldrsb r0, [r5, r0]
+	mov sl, r0
+	ldrb r5, [r5, #0x11]
+	lsls r5, r5, #0x18
+	asrs r5, r5, #0x18
+	mov r9, r5
+	movs r3, #0xb
+	ldrsb r3, [r4, r3]
+	movs r0, #0xc0
+	ands r3, r0
+	ldr r0, _0802B18C  @ gUnknown_0203A4D4
+	str r7, [r0, #0x10]
+	str r7, [r0, #0x14]
+	mov r5, sp
+	movs r0, #3
+	mov r8, r0
+_0802B11A:
+	movs r0, #1
+	ldrsb r0, [r5, r0]
+	add r0, r9
+	ldr r1, _0802B190  @ gUnknown_0202E4D8
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r1, #0
+	ldrsb r1, [r5, r1]
+	ldr r0, [r0]
+	add r1, sl
+	adds r0, r0, r1
+	ldrb r4, [r0]
+	cmp r4, #0
+	beq _0802B19C
+	adds r0, r4, #0
+	str r3, [sp, #8]
+	bl GetUnitStruct
+	adds r2, r0, #0
+	movs r0, #0xc0
+	ands r4, r0
+	ldr r3, [sp, #8]
+	cmp r4, r3
+	bne _0802B19C
+	adds r0, r2, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #2
+	beq _0802B19C
+	cmp r1, #0xb
+	beq _0802B19C
+	cmp r1, #0xd
+	beq _0802B19C
+	ldr r1, [r2, #4]
+	ldrb r0, [r1, #4]
+	cmp r0, #0x24
+	beq _0802B19C
+	ldr r0, [r2]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	ands r0, r6
+	cmp r0, #0
+	beq _0802B19C
+	adds r7, #1
+	ldr r1, _0802B18C  @ gUnknown_0203A4D4
+	ldr r0, [r1, #0x10]
+	cmp r0, #0
+	bne _0802B194
+	str r2, [r1, #0x10]
+	b _0802B19C
+	.align 2, 0
+_0802B188: .4byte gUnknown_080D7C38
+_0802B18C: .4byte gUnknown_0203A4D4
+_0802B190: .4byte gUnknown_0202E4D8
+_0802B194:
+	ldr r0, [r1, #0x14]
+	cmp r0, #0
+	bne _0802B19C
+	str r2, [r1, #0x14]
+_0802B19C:
+	adds r5, #2
+	movs r0, #1
+	negs r0, r0
+	add r8, r0
+	mov r0, r8
+	cmp r0, #0
+	bge _0802B11A
+	movs r0, #0
+	cmp r7, #1
+	ble _0802B1B2
+	movs r0, #1
+_0802B1B2:
+	add sp, #0xc
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START UpdateBattleStats
+UpdateBattleStats: @ 0x0802B1C4
+	adds r3, r0, #0
+	ldr r2, _0802B1F0  @ gUnknown_0203A4D4
+	adds r0, #0x5a
+	ldrh r0, [r0]
+	strh r0, [r2, #6]
+	adds r1, #0x5c
+	ldrh r0, [r1]
+	strh r0, [r2, #8]
+	adds r0, r3, #0
+	adds r0, #0x64
+	ldrh r0, [r0]
+	strh r0, [r2, #0xa]
+	adds r0, r3, #0
+	adds r0, #0x6a
+	ldrh r0, [r0]
+	strh r0, [r2, #0xc]
+	adds r0, r3, #0
+	adds r0, #0x6c
+	ldrh r0, [r0]
+	strh r0, [r2, #0xe]
+	bx lr
+	.align 2, 0
+_0802B1F0: .4byte gUnknown_0203A4D4
+
+	THUMB_FUNC_START RollForSureShot
+RollForSureShot: @ 0x0802B1F4
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	ldr r6, _0802B270  @ gUnknown_0203A608
+	ldr r0, [r6]
+	ldr r0, [r0]
+	lsls r0, r0, #0xd
+	lsrs r1, r0, #0xd
+	movs r5, #0x80
+	lsls r5, r5, #7
+	adds r0, r1, #0
+	ands r0, r5
+	cmp r0, #0
+	bne _0802B268
+	movs r0, #0x80
+	lsls r0, r0, #9
+	ands r0, r1
+	cmp r0, #0
+	bne _0802B268
+	movs r0, #0x80
+	lsls r0, r0, #8
+	ands r1, r0
+	cmp r1, #0
+	bne _0802B268
+	ldr r0, [r4, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x1c
+	bgt _0802B268
+	cmp r0, #0x1b
+	blt _0802B268
+	adds r0, r4, #0
+	adds r0, #0x48
+	ldrh r0, [r0]
+	bl GetItemIndex
+	cmp r0, #0x37
+	bgt _0802B240
+	cmp r0, #0x35
+	bge _0802B268
+_0802B240:
+	movs r0, #8
+	ldrsb r0, [r4, r0]
+	lsls r0, r0, #0x10
+	lsrs r0, r0, #0x10
+	movs r1, #0
+	bl RollRNIfBattleStarted
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #1
+	bne _0802B268
+	ldr r3, [r6]
+	ldr r2, [r3]
+	lsls r1, r2, #0xd
+	lsrs r1, r1, #0xd
+	orrs r1, r5
+	ldr r0, _0802B274  @ 0xFFF80000
+	ands r0, r2
+	orrs r0, r1
+	str r0, [r3]
+_0802B268:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802B270: .4byte gUnknown_0203A608
+_0802B274: .4byte 0xFFF80000
+
+	THUMB_FUNC_START RollForPierce
+RollForPierce: @ 0x0802B278
+	push {r4, r5, lr}
+	adds r2, r0, #0
+	ldr r5, _0802B2E0  @ gUnknown_0203A608
+	ldr r0, [r5]
+	ldr r0, [r0]
+	lsls r0, r0, #0xd
+	lsrs r1, r0, #0xd
+	movs r0, #0x80
+	lsls r0, r0, #7
+	ands r0, r1
+	cmp r0, #0
+	bne _0802B2DA
+	movs r4, #0x80
+	lsls r4, r4, #9
+	adds r0, r1, #0
+	ands r0, r4
+	cmp r0, #0
+	bne _0802B2DA
+	movs r0, #0x80
+	lsls r0, r0, #8
+	ands r1, r0
+	cmp r1, #0
+	bne _0802B2DA
+	ldr r0, [r2, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x24
+	bgt _0802B2DA
+	cmp r0, #0x23
+	blt _0802B2DA
+	movs r0, #8
+	ldrsb r0, [r2, r0]
+	lsls r0, r0, #0x10
+	lsrs r0, r0, #0x10
+	movs r1, #0
+	bl RollRNIfBattleStarted
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #1
+	bne _0802B2DA
+	ldr r3, [r5]
+	ldr r2, [r3]
+	lsls r1, r2, #0xd
+	lsrs r1, r1, #0xd
+	orrs r1, r4
+	ldr r0, _0802B2E4  @ 0xFFF80000
+	ands r0, r2
+	orrs r0, r1
+	str r0, [r3]
+_0802B2DA:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802B2E0: .4byte gUnknown_0203A608
+_0802B2E4: .4byte 0xFFF80000
+
+	THUMB_FUNC_START RollForGreatShield
+RollForGreatShield: @ 0x0802B2E8
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	adds r5, r0, #0
+	adds r6, r1, #0
+	ldr r4, _0802B384  @ gUnknown_0203A608
+	ldr r0, [r4]
+	ldr r0, [r0]
+	lsls r0, r0, #0xd
+	lsrs r1, r0, #0xd
+	movs r7, #2
+	adds r0, r1, #0
+	ands r0, r7
+	cmp r0, #0
+	bne _0802B378
+	movs r0, #0x80
+	lsls r0, r0, #7
+	ands r0, r1
+	cmp r0, #0
+	bne _0802B378
+	movs r0, #0x80
+	lsls r0, r0, #9
+	ands r0, r1
+	cmp r0, #0
+	bne _0802B378
+	movs r0, #0x80
+	lsls r0, r0, #8
+	mov r8, r0
+	ands r1, r0
+	cmp r1, #0
+	bne _0802B378
+	adds r0, r5, #0
+	adds r0, #0x48
+	ldrh r0, [r0]
+	bl GetItemWeaponEffect
+	cmp r0, #1
+	beq _0802B378
+	ldr r0, [r4]
+	ldr r0, [r0]
+	lsls r0, r0, #0xd
+	lsrs r0, r0, #0xd
+	ands r0, r7
+	cmp r0, #0
+	bne _0802B378
+	ldr r0, [r6, #4]
+	ldrb r1, [r0, #4]
+	cmp r1, #0xc
+	bgt _0802B378
+	cmp r1, #0xb
+	blt _0802B378
+	movs r0, #8
+	ldrsb r0, [r5, r0]
+	lsls r0, r0, #0x10
+	lsrs r0, r0, #0x10
+	movs r1, #0
+	bl RollRNIfBattleStarted
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #1
+	bne _0802B378
+	ldr r3, [r4]
+	ldr r2, [r3]
+	lsls r1, r2, #0xd
+	lsrs r1, r1, #0xd
+	mov r0, r8
+	orrs r1, r0
+	ldr r0, _0802B388  @ 0xFFF80000
+	ands r0, r2
+	orrs r0, r1
+	str r0, [r3]
+_0802B378:
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802B384: .4byte gUnknown_0203A608
+_0802B388: .4byte 0xFFF80000
+
+	THUMB_FUNC_START RollForLethality
+RollForLethality: @ 0x0802B38C
+	push {lr}
+	ldr r0, [r1, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x4f
+	beq _0802B39E
+	cmp r0, #0x66
+	bne _0802B3AE
+_0802B39A:
+	movs r0, #0
+	b _0802B3C2
+_0802B39E:
+	ldr r0, _0802B3C8  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xe]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0x15
+	beq _0802B39A
+	cmp r0, #0x22
+	beq _0802B39A
+_0802B3AE:
+	ldr r0, _0802B3CC  @ gUnknown_0203A4D4
+	ldrh r0, [r0, #0xe]
+	movs r1, #0
+	bl RollRNIfBattleStarted
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #1
+	bne _0802B39A
+	movs r0, #1
+_0802B3C2:
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0802B3C8: .4byte gUnknown_0202BCF0
+_0802B3CC: .4byte gUnknown_0203A4D4
+
+	THUMB_FUNC_START NullifyBattleDamageIfUsingStone
+NullifyBattleDamageIfUsingStone: @ 0x0802B3D0
+	push {lr}
+	adds r0, #0x48
+	ldrh r0, [r0]
+	bl GetItemIndex
+	cmp r0, #0xb5
+	bne _0802B3E4
+	ldr r1, _0802B3E8  @ gUnknown_0203A4D4
+	movs r0, #0
+	strh r0, [r1, #4]
+_0802B3E4:
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802B3E8: .4byte gUnknown_0203A4D4
+
+	THUMB_FUNC_START GenerateCurrentRoundData
+GenerateCurrentRoundData: @ 0x0802B3EC
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	adds r6, r0, #0
+	mov r8, r1
+	ldr r4, _0802B440  @ gUnknown_0203A4D4
+	movs r0, #0
+	strh r0, [r4, #4]
+	adds r0, r6, #0
+	bl RollForSureShot
+	ldr r5, _0802B444  @ gUnknown_0203A608
+	ldr r0, [r5]
+	ldr r0, [r0]
+	lsls r0, r0, #0xd
+	lsrs r0, r0, #0xd
+	movs r1, #0x80
+	lsls r1, r1, #7
+	ands r0, r1
+	cmp r0, #0
+	bne _0802B44C
+	ldrh r0, [r4, #0xa]
+	movs r1, #1
+	bl Roll2RNIfBattleStarted
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802B44C
+	ldr r3, [r5]
+	ldr r2, [r3]
+	lsls r1, r2, #0xd
+	lsrs r1, r1, #0xd
+	movs r0, #2
+	orrs r1, r0
+	ldr r0, _0802B448  @ 0xFFF80000
+	ands r0, r2
+	orrs r0, r1
+	str r0, [r3]
+	b _0802B55E
+	.align 2, 0
+_0802B440: .4byte gUnknown_0203A4D4
+_0802B444: .4byte gUnknown_0203A608
+_0802B448: .4byte 0xFFF80000
+_0802B44C:
+	ldr r5, _0802B4FC  @ gUnknown_0203A4D4
+	ldrh r0, [r5, #6]
+	mov r9, r0
+	ldrh r4, [r5, #8]
+	adds r0, r6, #0
+	mov r1, r8
+	bl RollForGreatShield
+	ldr r7, _0802B500  @ gUnknown_0203A608
+	ldr r0, [r7]
+	ldr r0, [r0]
+	lsls r0, r0, #0xd
+	lsrs r0, r0, #0xd
+	movs r1, #0x80
+	lsls r1, r1, #8
+	mov sl, r1
+	ands r0, r1
+	cmp r0, #0
+	bne _0802B47A
+	adds r0, r6, #0
+	mov r1, r8
+	bl RollForPierce
+_0802B47A:
+	ldr r2, [r7]
+	ldr r0, [r2]
+	lsls r0, r0, #0xd
+	lsrs r0, r0, #0xd
+	movs r1, #0x80
+	lsls r1, r1, #9
+	ands r0, r1
+	cmp r0, #0
+	beq _0802B48E
+	movs r4, #0
+_0802B48E:
+	mov r0, r9
+	lsls r1, r0, #0x10
+	asrs r1, r1, #0x10
+	lsls r0, r4, #0x10
+	asrs r0, r0, #0x10
+	subs r1, r1, r0
+	strh r1, [r5, #4]
+	ldr r0, [r2]
+	lsls r0, r0, #0xd
+	lsrs r0, r0, #0xd
+	mov r1, sl
+	ands r0, r1
+	cmp r0, #0
+	beq _0802B4AE
+	movs r0, #0
+	strh r0, [r5, #4]
+_0802B4AE:
+	ldrh r0, [r5, #0xc]
+	movs r1, #0
+	bl RollRNIfBattleStarted
+	lsls r0, r0, #0x18
+	asrs r4, r0, #0x18
+	cmp r4, #1
+	bne _0802B52C
+	adds r0, r6, #0
+	mov r1, r8
+	bl RollForLethality
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802B50C
+	ldr r4, [r7]
+	ldr r3, [r4]
+	lsls r1, r3, #0xd
+	lsrs r1, r1, #0xd
+	movs r0, #0x80
+	lsls r0, r0, #4
+	orrs r1, r0
+	ldr r2, _0802B504  @ 0xFFF80000
+	adds r0, r2, #0
+	ands r0, r3
+	orrs r0, r1
+	str r0, [r4]
+	movs r0, #0x7f
+	strh r0, [r5, #4]
+	ldr r3, [r4]
+	lsls r0, r3, #0xd
+	lsrs r0, r0, #0xd
+	ldr r1, _0802B508  @ 0xFFFF7FFF
+	ands r0, r1
+	ands r2, r3
+	orrs r2, r0
+	str r2, [r4]
+	b _0802B52C
+	.align 2, 0
+_0802B4FC: .4byte gUnknown_0203A4D4
+_0802B500: .4byte gUnknown_0203A608
+_0802B504: .4byte 0xFFF80000
+_0802B508: .4byte 0xFFFF7FFF
+_0802B50C:
+	ldr r3, [r7]
+	ldr r2, [r3]
+	lsls r1, r2, #0xd
+	lsrs r1, r1, #0xd
+	orrs r1, r4
+	ldr r0, _0802B56C  @ 0x0007FFFF
+	ands r1, r0
+	ldr r0, _0802B570  @ 0xFFF80000
+	ands r0, r2
+	orrs r0, r1
+	str r0, [r3]
+	movs r0, #4
+	ldrsh r1, [r5, r0]
+	lsls r0, r1, #1
+	adds r0, r0, r1
+	strh r0, [r5, #4]
+_0802B52C:
+	ldr r4, _0802B574  @ gUnknown_0203A4D4
+	movs r1, #4
+	ldrsh r0, [r4, r1]
+	cmp r0, #0x7f
+	ble _0802B53A
+	movs r0, #0x7f
+	strh r0, [r4, #4]
+_0802B53A:
+	movs r1, #4
+	ldrsh r0, [r4, r1]
+	cmp r0, #0
+	bge _0802B546
+	movs r0, #0
+	strh r0, [r4, #4]
+_0802B546:
+	adds r0, r6, #0
+	mov r1, r8
+	bl NullifyBattleDamageIfUsingStone
+	movs r1, #4
+	ldrsh r0, [r4, r1]
+	cmp r0, #0
+	beq _0802B55E
+	adds r1, r6, #0
+	adds r1, #0x7c
+	movs r0, #1
+	strb r0, [r1]
+_0802B55E:
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802B56C: .4byte 0x0007FFFF
+_0802B570: .4byte 0xFFF80000
+_0802B574: .4byte gUnknown_0203A4D4
+
+	THUMB_FUNC_START UpdateBattleTriangleAttackData
+UpdateBattleTriangleAttackData: @ 0x0802B578
+	push {r4, r5, lr}
+	adds r2, r0, #0
+	adds r3, r1, #0
+	ldr r0, [r2]
+	ldr r1, [r2, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	movs r1, #0xc0
+	lsls r1, r1, #0xf
+	ands r0, r1
+	cmp r0, #0
+	beq _0802B5EC
+	ldr r4, _0802B5F4  @ gUnknown_0203A4D4
+	ldrb r1, [r4, #2]
+	cmp r1, #1
+	bne _0802B5EC
+	ldr r5, _0802B5F8  @ gUnknown_0203A608
+	ldr r0, [r5]
+	ldr r0, [r0]
+	lsls r0, r0, #8
+	lsrs r0, r0, #0x1b
+	ands r0, r1
+	cmp r0, #0
+	beq _0802B5EC
+	adds r0, r2, #0
+	adds r0, #0x30
+	ldrb r1, [r0]
+	movs r0, #0xf
+	ands r0, r1
+	cmp r0, #4
+	beq _0802B5EC
+	ldrh r1, [r4]
+	movs r0, #0x20
+	ands r0, r1
+	cmp r0, #0
+	bne _0802B5EC
+	adds r0, r2, #0
+	adds r1, r3, #0
+	bl CheckForTriangleAttack
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802B5EC
+	ldr r3, [r5]
+	ldr r2, [r3]
+	lsls r1, r2, #0xd
+	lsrs r1, r1, #0xd
+	movs r0, #0x80
+	lsls r0, r0, #3
+	orrs r1, r0
+	ldr r0, _0802B5FC  @ 0xFFF80000
+	ands r0, r2
+	orrs r0, r1
+	str r0, [r3]
+	movs r0, #0x64
+	strh r0, [r4, #0xc]
+	strh r0, [r4, #0xa]
+_0802B5EC:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802B5F4: .4byte gUnknown_0203A4D4
+_0802B5F8: .4byte gUnknown_0203A608
+_0802B5FC: .4byte 0xFFF80000
+
+	THUMB_FUNC_START CurrentRound_ComputeWeaponEffects
+CurrentRound_ComputeWeaponEffects: @ 0x0802B600
+	push {r4, r5, r6, r7, lr}
+	adds r5, r0, #0
+	adds r4, r1, #0
+	adds r1, r5, #0
+	adds r1, #0x7b
+	ldrb r0, [r1]
+	adds r0, #1
+	strb r0, [r1]
+	ldr r6, _0802B640  @ gUnknown_0203A608
+	ldr r0, [r6]
+	ldr r0, [r0]
+	lsls r0, r0, #0xd
+	lsrs r0, r0, #0xd
+	movs r1, #2
+	ands r0, r1
+	cmp r0, #0
+	beq _0802B624
+	b _0802B7EA
+_0802B624:
+	ldr r0, [r4, #4]
+	ldrb r0, [r0, #4]
+	adds r7, r5, #0
+	adds r7, #0x48
+	cmp r0, #0x66
+	beq _0802B696
+	ldrh r0, [r7]
+	bl GetItemWeaponEffect
+	cmp r0, #1
+	beq _0802B644
+	cmp r0, #3
+	beq _0802B680
+	b _0802B696
+	.align 2, 0
+_0802B640: .4byte gUnknown_0203A608
+_0802B644:
+	adds r1, r4, #0
+	adds r1, #0x6f
+	strb r0, [r1]
+	ldr r3, [r6]
+	ldr r2, [r3]
+	lsls r1, r2, #0xd
+	lsrs r1, r1, #0xd
+	movs r0, #0x40
+	orrs r1, r0
+	ldr r0, _0802B67C  @ 0xFFF80000
+	ands r0, r2
+	orrs r0, r1
+	str r0, [r3]
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #0xb
+	beq _0802B670
+	cmp r1, #0xd
+	bne _0802B696
+_0802B670:
+	ldr r0, [r4, #0xc]
+	movs r1, #3
+	negs r1, r1
+	ands r0, r1
+	str r0, [r4, #0xc]
+	b _0802B696
+	.align 2, 0
+_0802B67C: .4byte 0xFFF80000
+_0802B680:
+	ldr r3, [r6]
+	ldr r2, [r3]
+	lsls r1, r2, #0xd
+	lsrs r1, r1, #0xd
+	movs r0, #0x80
+	lsls r0, r0, #2
+	orrs r1, r0
+	ldr r0, _0802B6E4  @ 0xFFF80000
+	ands r0, r2
+	orrs r0, r1
+	str r0, [r3]
+_0802B696:
+	ldrh r0, [r7]
+	bl GetItemWeaponEffect
+	cmp r0, #4
+	bne _0802B6F0
+	movs r1, #0x19
+	ldrsb r1, [r5, r1]
+	movs r0, #0x1f
+	subs r0, r0, r1
+	lsls r0, r0, #0x10
+	lsrs r0, r0, #0x10
+	movs r1, #0
+	bl RollRNIfBattleStarted
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802B6F0
+	ldr r0, _0802B6E8  @ gUnknown_0203A608
+	ldr r3, [r0]
+	ldr r2, [r3]
+	lsls r1, r2, #0xd
+	lsrs r1, r1, #0xd
+	movs r0, #0x80
+	orrs r1, r0
+	ldr r0, _0802B6E4  @ 0xFFF80000
+	ands r0, r2
+	orrs r0, r1
+	str r0, [r3]
+	ldr r0, _0802B6EC  @ gUnknown_0203A4D4
+	ldrb r1, [r0, #4]
+	ldrb r0, [r5, #0x13]
+	subs r0, r0, r1
+	strb r0, [r5, #0x13]
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bge _0802B712
+	movs r0, #0
+	strb r0, [r5, #0x13]
+	b _0802B712
+	.align 2, 0
+_0802B6E4: .4byte 0xFFF80000
+_0802B6E8: .4byte gUnknown_0203A608
+_0802B6EC: .4byte gUnknown_0203A4D4
+_0802B6F0:
+	ldr r1, _0802B734  @ gUnknown_0203A4D4
+	movs r2, #0x13
+	ldrsb r2, [r4, r2]
+	movs r3, #4
+	ldrsh r0, [r1, r3]
+	cmp r0, r2
+	ble _0802B700
+	strh r2, [r1, #4]
+_0802B700:
+	ldrb r1, [r1, #4]
+	ldrb r0, [r4, #0x13]
+	subs r0, r0, r1
+	strb r0, [r4, #0x13]
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bge _0802B712
+	movs r0, #0
+	strb r0, [r4, #0x13]
+_0802B712:
+	ldrh r0, [r7]
+	bl GetItemWeaponEffect
+	cmp r0, #2
+	bne _0802B758
+	movs r0, #0x12
+	ldrsb r0, [r5, r0]
+	movs r1, #0x13
+	ldrsb r1, [r5, r1]
+	ldr r3, _0802B734  @ gUnknown_0203A4D4
+	movs r6, #4
+	ldrsh r2, [r3, r6]
+	adds r1, r1, r2
+	cmp r0, r1
+	bge _0802B738
+	ldrb r0, [r5, #0x12]
+	b _0802B73E
+	.align 2, 0
+_0802B734: .4byte gUnknown_0203A4D4
+_0802B738:
+	ldrb r0, [r3, #4]
+	ldrb r1, [r5, #0x13]
+	adds r0, r0, r1
+_0802B73E:
+	strb r0, [r5, #0x13]
+	ldr r0, _0802B77C  @ gUnknown_0203A608
+	ldr r3, [r0]
+	ldr r2, [r3]
+	lsls r1, r2, #0xd
+	lsrs r1, r1, #0xd
+	movs r0, #0x80
+	lsls r0, r0, #1
+	orrs r1, r0
+	ldr r0, _0802B780  @ 0xFFF80000
+	ands r0, r2
+	orrs r0, r1
+	str r0, [r3]
+_0802B758:
+	ldr r0, [r4, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x66
+	beq _0802B7EA
+	ldrh r0, [r7]
+	bl GetItemWeaponEffect
+	cmp r0, #5
+	bne _0802B7EA
+	ldr r0, _0802B784  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xf]
+	cmp r0, #0x40
+	beq _0802B7B6
+	cmp r0, #0x40
+	bgt _0802B788
+	cmp r0, #0
+	beq _0802B78E
+	b _0802B7D2
+	.align 2, 0
+_0802B77C: .4byte gUnknown_0203A608
+_0802B780: .4byte 0xFFF80000
+_0802B784: .4byte gUnknown_0202BCF0
+_0802B788:
+	cmp r0, #0x80
+	beq _0802B7A2
+	b _0802B7D2
+_0802B78E:
+	movs r0, #0xb
+	ldrsb r0, [r4, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, #0
+	bne _0802B7CA
+	adds r1, r4, #0
+	adds r1, #0x6f
+	movs r0, #0xd
+	b _0802B7D0
+_0802B7A2:
+	movs r0, #0xb
+	ldrsb r0, [r4, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, #0x80
+	bne _0802B7CA
+	adds r1, r4, #0
+	adds r1, #0x6f
+	movs r0, #0xd
+	b _0802B7D0
+_0802B7B6:
+	movs r0, #0xb
+	ldrsb r0, [r4, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, #0x40
+	bne _0802B7CA
+	adds r1, r4, #0
+	adds r1, #0x6f
+	movs r0, #0xd
+	b _0802B7D0
+_0802B7CA:
+	adds r1, r4, #0
+	adds r1, #0x6f
+	movs r0, #0xb
+_0802B7D0:
+	strb r0, [r1]
+_0802B7D2:
+	ldr r0, _0802B830  @ gUnknown_0203A608
+	ldr r3, [r0]
+	ldr r2, [r3]
+	lsls r1, r2, #0xd
+	lsrs r1, r1, #0xd
+	movs r0, #0x80
+	lsls r0, r0, #6
+	orrs r1, r0
+	ldr r0, _0802B834  @ 0xFFF80000
+	ands r0, r2
+	orrs r0, r1
+	str r0, [r3]
+_0802B7EA:
+	ldr r2, _0802B830  @ gUnknown_0203A608
+	ldr r1, [r2]
+	ldr r0, _0802B838  @ gUnknown_0203A4D4
+	ldrh r0, [r0, #4]
+	strb r0, [r1, #3]
+	ldr r0, [r2]
+	ldr r0, [r0]
+	lsls r0, r0, #0xd
+	lsrs r0, r0, #0xd
+	movs r1, #2
+	ands r0, r1
+	cmp r0, #0
+	beq _0802B80E
+	ldr r0, [r5, #0x4c]
+	movs r1, #0x82
+	ands r0, r1
+	cmp r0, #0
+	beq _0802B828
+_0802B80E:
+	adds r4, r5, #0
+	adds r4, #0x48
+	ldrh r0, [r4]
+	bl ValidateItem
+	strh r0, [r4]
+	lsls r0, r0, #0x10
+	cmp r0, #0
+	bne _0802B828
+	adds r1, r5, #0
+	adds r1, #0x7d
+	movs r0, #1
+	strb r0, [r1]
+_0802B828:
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802B830: .4byte gUnknown_0203A608
+_0802B834: .4byte 0xFFF80000
+_0802B838: .4byte gUnknown_0203A4D4
+
+	THUMB_FUNC_START MakeNextBattleHitRound
+MakeNextBattleHitRound: @ 0x0802B83C
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	ldr r6, _0802B8D4  @ gUnknown_0203A56C
+	cmp r4, r6
+	bne _0802B862
+	ldr r0, _0802B8D8  @ gUnknown_0203A608
+	ldr r3, [r0]
+	ldr r1, [r3]
+	lsls r1, r1, #8
+	lsrs r1, r1, #0x1b
+	movs r0, #8
+	orrs r1, r0
+	lsls r1, r1, #3
+	ldrb r2, [r3, #2]
+	movs r0, #7
+	ands r0, r2
+	orrs r0, r1
+	strb r0, [r3, #2]
+_0802B862:
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl UpdateBattleStats
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl UpdateBattleTriangleAttackData
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl GenerateCurrentRoundData
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl CurrentRound_ComputeWeaponEffects
+	movs r0, #0x13
+	ldrsb r0, [r4, r0]
+	cmp r0, #0
+	beq _0802B892
+	movs r0, #0x13
+	ldrsb r0, [r5, r0]
+	cmp r0, #0
+	bne _0802B8DC
+_0802B892:
+	adds r1, r4, #0
+	adds r1, #0x7b
+	ldrb r0, [r1]
+	adds r0, #1
+	strb r0, [r1]
+	ldr r4, _0802B8D8  @ gUnknown_0203A608
+	ldr r2, [r4]
+	ldr r1, [r2]
+	lsls r1, r1, #8
+	lsrs r1, r1, #0x1b
+	movs r0, #2
+	orrs r1, r0
+	lsls r1, r1, #3
+	ldrb r3, [r2, #2]
+	movs r5, #7
+	adds r0, r5, #0
+	ands r0, r3
+	orrs r0, r1
+	strb r0, [r2, #2]
+	movs r0, #0x13
+	ldrsb r0, [r6, r0]
+	cmp r0, #0
+	bne _0802B908
+	ldr r3, [r4]
+	ldr r1, [r3]
+	lsls r1, r1, #8
+	lsrs r1, r1, #0x1b
+	movs r0, #4
+	orrs r1, r0
+	lsls r1, r1, #3
+	ldrb r2, [r3, #2]
+	adds r0, r5, #0
+	b _0802B902
+	.align 2, 0
+_0802B8D4: .4byte gUnknown_0203A56C
+_0802B8D8: .4byte gUnknown_0203A608
+_0802B8DC:
+	adds r0, r5, #0
+	adds r0, #0x6f
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0xb
+	beq _0802B8EE
+	cmp r0, #0xd
+	bne _0802B918
+_0802B8EE:
+	ldr r4, _0802B914  @ gUnknown_0203A608
+	ldr r3, [r4]
+	ldr r1, [r3]
+	lsls r1, r1, #8
+	lsrs r1, r1, #0x1b
+	movs r0, #2
+	orrs r1, r0
+	lsls r1, r1, #3
+	ldrb r2, [r3, #2]
+	movs r0, #7
+_0802B902:
+	ands r0, r2
+	orrs r0, r1
+	strb r0, [r3, #2]
+_0802B908:
+	ldr r0, [r4]
+	adds r0, #4
+	str r0, [r4]
+	movs r0, #1
+	b _0802B922
+	.align 2, 0
+_0802B914: .4byte gUnknown_0203A608
+_0802B918:
+	ldr r1, _0802B928  @ gUnknown_0203A608
+	ldr r0, [r1]
+	adds r0, #4
+	str r0, [r1]
+	movs r0, #0
+_0802B922:
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0802B928: .4byte gUnknown_0203A608
+
+	THUMB_FUNC_START sub_802B92C
+sub_802B92C: @ 0x0802B92C
+	push {r4, r5, r6, lr}
+	ldr r5, _0802B994  @ gUnknown_0203A4EC
+	movs r0, #0xb
+	ldrsb r0, [r5, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, #0
+	bne _0802B94A
+	ldr r0, _0802B998  @ gUnknown_0203A56C
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	ands r0, r1
+	cmp r0, #0
+	beq _0802B98E
+_0802B94A:
+	ldr r0, _0802B99C  @ gUnknown_0202BCF0
+	ldrb r1, [r0, #0x14]
+	movs r0, #0x80
+	ands r0, r1
+	cmp r0, #0
+	bne _0802B98E
+	ldr r4, _0802B998  @ gUnknown_0203A56C
+	adds r0, r5, #0
+	adds r1, r4, #0
+	bl sub_802C534
+	adds r6, r5, #0
+	adds r6, #0x6e
+	strb r0, [r6]
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl sub_802C534
+	adds r1, r4, #0
+	adds r1, #0x6e
+	strb r0, [r1]
+	ldrb r1, [r6]
+	ldrb r2, [r5, #9]
+	adds r1, r1, r2
+	strb r1, [r5, #9]
+	ldrb r1, [r4, #9]
+	adds r1, r1, r0
+	strb r1, [r4, #9]
+	adds r0, r5, #0
+	bl CheckForLevelUp
+	adds r0, r4, #0
+	bl CheckForLevelUp
+_0802B98E:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802B994: .4byte gUnknown_0203A4EC
+_0802B998: .4byte gUnknown_0203A56C
+_0802B99C: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START GetStatIncrease
+GetStatIncrease: @ 0x0802B9A0
+	push {r4, lr}
+	movs r4, #0
+	cmp r0, #0x64
+	ble _0802B9B0
+_0802B9A8:
+	adds r4, #1
+	subs r0, #0x64
+	cmp r0, #0x64
+	bgt _0802B9A8
+_0802B9B0:
+	bl Roll1RN
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802B9BC
+	adds r4, #1
+_0802B9BC:
+	adds r0, r4, #0
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START GetAutoleveledStat
+GetAutoleveledStat: @ 0x0802B9C4
+	push {r4, lr}
+	adds r4, r0, #0
+	muls r4, r1, r4
+	adds r0, r4, #0
+	cmp r4, #0
+	bge _0802B9D2
+	adds r0, r4, #3
+_0802B9D2:
+	asrs r0, r0, #2
+	bl NextRN_N
+	adds r1, r0, #0
+	adds r0, r4, #0
+	cmp r4, #0
+	bge _0802B9E2
+	adds r0, r4, #7
+_0802B9E2:
+	asrs r0, r0, #3
+	subs r0, r1, r0
+	adds r0, r4, r0
+	bl GetStatIncrease
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START CanUnitNotLevelUp
+CanUnitNotLevelUp: @ 0x0802B9F4
+	push {lr}
+	adds r2, r0, #0
+	ldr r0, _0802BA1C  @ gUnknown_0202BCB0
+	ldrb r1, [r0, #4]
+	movs r0, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _0802BA16
+	ldrb r0, [r2, #9]
+	cmp r0, #0xff
+	beq _0802BA20
+	movs r0, #0xb
+	ldrsb r0, [r2, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, #0
+	bne _0802BA20
+_0802BA16:
+	movs r0, #1
+	b _0802BA22
+	.align 2, 0
+_0802BA1C: .4byte gUnknown_0202BCB0
+_0802BA20:
+	movs r0, #0
+_0802BA22:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START CheckForLevelUp
+CheckForLevelUp: @ 0x0802BA28
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #0x10
+	adds r7, r0, #0
+	bl CanUnitNotLevelUp
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802BA42
+	b _0802BBEE
+_0802BA42:
+	ldrb r0, [r7, #9]
+	cmp r0, #0x63
+	bhi _0802BA4A
+	b _0802BBEE
+_0802BA4A:
+	adds r3, r0, #0
+	subs r3, #0x64
+	strb r3, [r7, #9]
+	ldrb r0, [r7, #8]
+	adds r2, r0, #1
+	strb r2, [r7, #8]
+	ldr r0, [r7]
+	ldr r1, [r7, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #0xc
+	ands r0, r1
+	cmp r0, #0
+	beq _0802BA74
+	lsls r0, r2, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0xa
+	bne _0802BA8A
+	b _0802BA7C
+_0802BA74:
+	lsls r0, r2, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0x14
+	bne _0802BA8A
+_0802BA7C:
+	adds r1, r7, #0
+	adds r1, #0x6e
+	ldrb r0, [r1]
+	subs r0, r0, r3
+	strb r0, [r1]
+	movs r0, #0xff
+	strb r0, [r7, #9]
+_0802BA8A:
+	ldr r0, [r7, #0xc]
+	movs r1, #0x80
+	lsls r1, r1, #6
+	ands r0, r1
+	movs r1, #0
+	mov sl, r1
+	cmp r0, #0
+	beq _0802BA9E
+	movs r0, #5
+	mov sl, r0
+_0802BA9E:
+	ldr r0, [r7]
+	ldrb r0, [r0, #0x1c]
+	add r0, sl
+	bl GetStatIncrease
+	adds r1, r7, #0
+	adds r1, #0x73
+	str r1, [sp]
+	strb r0, [r1]
+	movs r6, #0
+	ldrsb r6, [r1, r6]
+	ldr r0, [r7]
+	ldrb r0, [r0, #0x1d]
+	add r0, sl
+	bl GetStatIncrease
+	adds r1, r7, #0
+	adds r1, #0x74
+	str r1, [sp, #4]
+	strb r0, [r1]
+	movs r0, #0
+	ldrsb r0, [r1, r0]
+	adds r6, r6, r0
+	ldr r0, [r7]
+	ldrb r0, [r0, #0x1e]
+	add r0, sl
+	bl GetStatIncrease
+	movs r1, #0x75
+	adds r1, r1, r7
+	mov r8, r1
+	strb r0, [r1]
+	movs r0, #0
+	ldrsb r0, [r1, r0]
+	adds r6, r6, r0
+	ldr r0, [r7]
+	ldrb r0, [r0, #0x1f]
+	add r0, sl
+	bl GetStatIncrease
+	movs r1, #0x76
+	adds r1, r1, r7
+	mov r9, r1
+	strb r0, [r1]
+	movs r0, #0
+	ldrsb r0, [r1, r0]
+	adds r6, r6, r0
+	ldr r0, [r7]
+	adds r0, #0x20
+	ldrb r0, [r0]
+	add r0, sl
+	bl GetStatIncrease
+	adds r5, r7, #0
+	adds r5, #0x77
+	strb r0, [r5]
+	movs r0, #0
+	ldrsb r0, [r5, r0]
+	adds r6, r6, r0
+	ldr r0, [r7]
+	adds r0, #0x21
+	ldrb r0, [r0]
+	add r0, sl
+	bl GetStatIncrease
+	adds r4, r7, #0
+	adds r4, #0x78
+	strb r0, [r4]
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	adds r6, r6, r0
+	ldr r0, [r7]
+	adds r0, #0x22
+	ldrb r0, [r0]
+	add r0, sl
+	bl GetStatIncrease
+	adds r1, r7, #0
+	adds r1, #0x79
+	strb r0, [r1]
+	movs r0, #0
+	ldrsb r0, [r1, r0]
+	adds r6, r6, r0
+	ldr r0, [sp]
+	str r0, [sp, #8]
+	ldr r0, [sp, #4]
+	str r0, [sp, #0xc]
+	mov sl, r8
+	mov r8, r5
+	adds r5, r4, #0
+	adds r4, r1, #0
+	cmp r6, #0
+	bne _0802BBE0
+	b _0802BBCA
+_0802BB5A:
+	ldr r0, [r7]
+	ldrb r0, [r0, #0x1d]
+	bl GetStatIncrease
+	ldr r1, [sp, #0xc]
+	strb r0, [r1]
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802BBE0
+	ldr r0, [r7]
+	ldrb r0, [r0, #0x1e]
+	bl GetStatIncrease
+	mov r1, sl
+	strb r0, [r1]
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802BBE0
+	ldr r0, [r7]
+	ldrb r0, [r0, #0x1f]
+	bl GetStatIncrease
+	mov r1, r9
+	strb r0, [r1]
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802BBE0
+	ldr r0, [r7]
+	adds r0, #0x20
+	ldrb r0, [r0]
+	bl GetStatIncrease
+	mov r1, r8
+	strb r0, [r1]
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802BBE0
+	ldr r0, [r7]
+	adds r0, #0x21
+	ldrb r0, [r0]
+	bl GetStatIncrease
+	strb r0, [r5]
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802BBE0
+	ldr r0, [r7]
+	adds r0, #0x22
+	ldrb r0, [r0]
+	bl GetStatIncrease
+	strb r0, [r4]
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802BBE0
+	adds r6, #1
+_0802BBCA:
+	cmp r6, #1
+	bgt _0802BBE0
+	ldr r0, [r7]
+	ldrb r0, [r0, #0x1c]
+	bl GetStatIncrease
+	ldr r1, [sp, #8]
+	strb r0, [r1]
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802BB5A
+_0802BBE0:
+	movs r0, #0xb
+	ldrsb r0, [r7, r0]
+	bl GetUnitStruct
+	adds r1, r7, #0
+	bl CheckForLevelUpCaps
+_0802BBEE:
+	add sp, #0x10
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_802BC00
+sub_802BC00: @ 0x0802BC00
+	push {r4, r5, r6, r7, lr}
+	mov r7, r9
+	mov r6, r8
+	push {r6, r7}
+	adds r5, r0, #0
+	ldr r0, [r5, #4]
+	ldrb r0, [r0, #5]
+	bl GetROMClassStruct
+	adds r4, r0, #0
+	ldr r0, [r5, #4]
+	ldrb r0, [r0, #4]
+	mov r8, r0
+	ldrb r0, [r4, #4]
+	mov r9, r0
+	adds r6, r4, #0
+	adds r6, #0x22
+	ldrb r0, [r6]
+	ldrb r1, [r5, #0x12]
+	adds r0, r0, r1
+	strb r0, [r5, #0x12]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	ldrb r2, [r4, #0x13]
+	movs r1, #0x13
+	ldrsb r1, [r4, r1]
+	cmp r0, r1
+	ble _0802BC3A
+	strb r2, [r5, #0x12]
+_0802BC3A:
+	adds r0, r4, #0
+	adds r0, #0x23
+	ldrb r0, [r0]
+	ldrb r1, [r5, #0x14]
+	adds r0, r0, r1
+	strb r0, [r5, #0x14]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	ldrb r2, [r4, #0x14]
+	movs r1, #0x14
+	ldrsb r1, [r4, r1]
+	cmp r0, r1
+	ble _0802BC56
+	strb r2, [r5, #0x14]
+_0802BC56:
+	adds r0, r4, #0
+	adds r0, #0x24
+	ldrb r0, [r0]
+	ldrb r1, [r5, #0x15]
+	adds r0, r0, r1
+	strb r0, [r5, #0x15]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	ldrb r2, [r4, #0x15]
+	movs r1, #0x15
+	ldrsb r1, [r4, r1]
+	cmp r0, r1
+	ble _0802BC72
+	strb r2, [r5, #0x15]
+_0802BC72:
+	adds r0, r4, #0
+	adds r0, #0x25
+	ldrb r0, [r0]
+	ldrb r1, [r5, #0x16]
+	adds r0, r0, r1
+	strb r0, [r5, #0x16]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	ldrb r2, [r4, #0x16]
+	movs r1, #0x16
+	ldrsb r1, [r4, r1]
+	cmp r0, r1
+	ble _0802BC8E
+	strb r2, [r5, #0x16]
+_0802BC8E:
+	adds r0, r4, #0
+	adds r0, #0x26
+	ldrb r0, [r0]
+	ldrb r1, [r5, #0x17]
+	adds r0, r0, r1
+	strb r0, [r5, #0x17]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	ldrb r2, [r4, #0x17]
+	movs r1, #0x17
+	ldrsb r1, [r4, r1]
+	cmp r0, r1
+	ble _0802BCAA
+	strb r2, [r5, #0x17]
+_0802BCAA:
+	adds r0, r4, #0
+	adds r0, #0x27
+	ldrb r0, [r0]
+	ldrb r1, [r5, #0x18]
+	adds r0, r0, r1
+	strb r0, [r5, #0x18]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	ldrb r2, [r4, #0x18]
+	movs r1, #0x18
+	ldrsb r1, [r4, r1]
+	cmp r0, r1
+	ble _0802BCC6
+	strb r2, [r5, #0x18]
+_0802BCC6:
+	movs r3, #0
+	mov ip, r6
+	adds r7, r5, #0
+	adds r7, #0x28
+	adds r6, r7, #0
+_0802BCD0:
+	adds r2, r6, r3
+	ldr r0, [r5, #4]
+	adds r0, #0x2c
+	adds r0, r0, r3
+	ldrb r1, [r2]
+	ldrb r0, [r0]
+	subs r1, r1, r0
+	strb r1, [r2]
+	adds r3, #1
+	cmp r3, #7
+	ble _0802BCD0
+	str r4, [r5, #4]
+	movs r3, #0
+	adds r4, r7, #0
+_0802BCEC:
+	adds r2, r4, r3
+	ldrb r1, [r2]
+	ldr r0, [r5, #4]
+	adds r0, #0x2c
+	adds r0, r0, r3
+	ldrb r0, [r0]
+	adds r1, r1, r0
+	cmp r1, #0xfb
+	ble _0802BD00
+	movs r1, #0xfb
+_0802BD00:
+	strb r1, [r2]
+	adds r3, #1
+	cmp r3, #7
+	ble _0802BCEC
+	mov r0, r8
+	cmp r0, #0x3e
+	bne _0802BD1C
+	mov r1, r9
+	cmp r1, #0x2d
+	bne _0802BD1C
+	adds r1, r5, #0
+	adds r1, #0x2d
+	movs r0, #0
+	strb r0, [r1]
+_0802BD1C:
+	movs r1, #0
+	movs r0, #1
+	strb r0, [r5, #8]
+	strb r1, [r5, #9]
+	mov r1, ip
+	ldrb r0, [r1]
+	ldrb r1, [r5, #0x13]
+	adds r0, r0, r1
+	strb r0, [r5, #0x13]
+	movs r4, #0x13
+	ldrsb r4, [r5, r4]
+	adds r0, r5, #0
+	bl GetUnitMaxHP
+	cmp r4, r0
+	ble _0802BD44
+	adds r0, r5, #0
+	bl GetUnitMaxHP
+	strb r0, [r5, #0x13]
+_0802BD44:
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_802BD50
+sub_802BD50: @ 0x0802BD50
+	push {r4, r5, r6, r7, lr}
+	mov r7, r9
+	mov r6, r8
+	push {r6, r7}
+	adds r5, r0, #0
+	lsls r0, r1, #0x18
+	lsrs r0, r0, #0x18
+	bl GetROMClassStruct
+	adds r4, r0, #0
+	ldr r0, [r5, #4]
+	ldrb r0, [r0, #4]
+	mov r8, r0
+	ldrb r0, [r4, #4]
+	mov r9, r0
+	adds r6, r4, #0
+	adds r6, #0x22
+	ldrb r0, [r6]
+	ldrb r1, [r5, #0x12]
+	adds r0, r0, r1
+	strb r0, [r5, #0x12]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	ldrb r2, [r4, #0x13]
+	movs r1, #0x13
+	ldrsb r1, [r4, r1]
+	cmp r0, r1
+	ble _0802BD8A
+	strb r2, [r5, #0x12]
+_0802BD8A:
+	adds r0, r4, #0
+	adds r0, #0x23
+	ldrb r0, [r0]
+	ldrb r1, [r5, #0x14]
+	adds r0, r0, r1
+	strb r0, [r5, #0x14]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	ldrb r2, [r4, #0x14]
+	movs r1, #0x14
+	ldrsb r1, [r4, r1]
+	cmp r0, r1
+	ble _0802BDA6
+	strb r2, [r5, #0x14]
+_0802BDA6:
+	adds r0, r4, #0
+	adds r0, #0x24
+	ldrb r0, [r0]
+	ldrb r1, [r5, #0x15]
+	adds r0, r0, r1
+	strb r0, [r5, #0x15]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	ldrb r2, [r4, #0x15]
+	movs r1, #0x15
+	ldrsb r1, [r4, r1]
+	cmp r0, r1
+	ble _0802BDC2
+	strb r2, [r5, #0x15]
+_0802BDC2:
+	adds r0, r4, #0
+	adds r0, #0x25
+	ldrb r0, [r0]
+	ldrb r1, [r5, #0x16]
+	adds r0, r0, r1
+	strb r0, [r5, #0x16]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	ldrb r2, [r4, #0x16]
+	movs r1, #0x16
+	ldrsb r1, [r4, r1]
+	cmp r0, r1
+	ble _0802BDDE
+	strb r2, [r5, #0x16]
+_0802BDDE:
+	adds r0, r4, #0
+	adds r0, #0x26
+	ldrb r0, [r0]
+	ldrb r1, [r5, #0x17]
+	adds r0, r0, r1
+	strb r0, [r5, #0x17]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	ldrb r2, [r4, #0x17]
+	movs r1, #0x17
+	ldrsb r1, [r4, r1]
+	cmp r0, r1
+	ble _0802BDFA
+	strb r2, [r5, #0x17]
+_0802BDFA:
+	adds r0, r4, #0
+	adds r0, #0x27
+	ldrb r0, [r0]
+	ldrb r1, [r5, #0x18]
+	adds r0, r0, r1
+	strb r0, [r5, #0x18]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	ldrb r2, [r4, #0x18]
+	movs r1, #0x18
+	ldrsb r1, [r4, r1]
+	cmp r0, r1
+	ble _0802BE16
+	strb r2, [r5, #0x18]
+_0802BE16:
+	movs r3, #0
+	mov ip, r6
+	adds r7, r5, #0
+	adds r7, #0x28
+	adds r6, r7, #0
+_0802BE20:
+	adds r2, r6, r3
+	ldr r0, [r5, #4]
+	adds r0, #0x2c
+	adds r0, r0, r3
+	ldrb r1, [r2]
+	ldrb r0, [r0]
+	subs r1, r1, r0
+	strb r1, [r2]
+	adds r3, #1
+	cmp r3, #7
+	ble _0802BE20
+	str r4, [r5, #4]
+	movs r3, #0
+	adds r4, r7, #0
+_0802BE3C:
+	adds r2, r4, r3
+	ldrb r1, [r2]
+	ldr r0, [r5, #4]
+	adds r0, #0x2c
+	adds r0, r0, r3
+	ldrb r0, [r0]
+	adds r1, r1, r0
+	cmp r1, #0xfb
+	ble _0802BE50
+	movs r1, #0xfb
+_0802BE50:
+	strb r1, [r2]
+	adds r3, #1
+	cmp r3, #7
+	ble _0802BE3C
+	mov r0, r8
+	cmp r0, #0x3e
+	bne _0802BE6C
+	mov r1, r9
+	cmp r1, #0x2d
+	bne _0802BE6C
+	adds r1, r5, #0
+	adds r1, #0x2d
+	movs r0, #0
+	strb r0, [r1]
+_0802BE6C:
+	movs r1, #0
+	movs r0, #1
+	strb r0, [r5, #8]
+	strb r1, [r5, #9]
+	mov r1, ip
+	ldrb r0, [r1]
+	ldrb r1, [r5, #0x13]
+	adds r0, r0, r1
+	strb r0, [r5, #0x13]
+	movs r4, #0x13
+	ldrsb r4, [r5, r4]
+	adds r0, r5, #0
+	bl GetUnitMaxHP
+	cmp r4, r0
+	ble _0802BE94
+	adds r0, r5, #0
+	bl GetUnitMaxHP
+	strb r0, [r5, #0x13]
+_0802BE94:
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_802BEA0
+sub_802BEA0: @ 0x0802BEA0
+	push {r4, r5, lr}
+	adds r3, r0, #0
+	ldrb r0, [r3, #0x12]
+	ldrb r2, [r1, #0x12]
+	subs r0, r0, r2
+	adds r2, r3, #0
+	adds r2, #0x73
+	strb r0, [r2]
+	ldrb r0, [r3, #0x14]
+	ldrb r2, [r1, #0x14]
+	subs r0, r0, r2
+	adds r2, r3, #0
+	adds r2, #0x74
+	strb r0, [r2]
+	ldrb r0, [r3, #0x15]
+	ldrb r2, [r1, #0x15]
+	subs r0, r0, r2
+	adds r2, r3, #0
+	adds r2, #0x75
+	strb r0, [r2]
+	ldrb r0, [r3, #0x16]
+	ldrb r2, [r1, #0x16]
+	subs r0, r0, r2
+	adds r2, r3, #0
+	adds r2, #0x76
+	strb r0, [r2]
+	ldrb r0, [r3, #0x17]
+	ldrb r2, [r1, #0x17]
+	subs r0, r0, r2
+	adds r2, r3, #0
+	adds r2, #0x77
+	strb r0, [r2]
+	ldrb r0, [r3, #0x18]
+	ldrb r2, [r1, #0x18]
+	subs r0, r0, r2
+	adds r2, r3, #0
+	adds r2, #0x78
+	strb r0, [r2]
+	ldrb r0, [r3, #0x19]
+	ldrb r2, [r1, #0x19]
+	subs r0, r0, r2
+	adds r2, r3, #0
+	adds r2, #0x79
+	strb r0, [r2]
+	ldrb r5, [r3, #0x1a]
+	movs r2, #0x1a
+	ldrsb r2, [r3, r2]
+	ldrb r4, [r1, #0x1a]
+	movs r0, #0x1a
+	ldrsb r0, [r1, r0]
+	cmp r2, r0
+	beq _0802BF12
+	subs r1, r5, r4
+	adds r0, r3, #0
+	adds r0, #0x7a
+	strb r1, [r0]
+	b _0802BF1C
+_0802BF12:
+	adds r1, r3, #0
+	adds r1, #0x7a
+	movs r0, #0
+	strb r0, [r1]
+	strb r4, [r3, #0x1a]
+_0802BF1C:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START CheckForLevelUpCaps
+CheckForLevelUpCaps: @ 0x0802BF24
+	push {r4, r5, lr}
+	adds r2, r0, #0
+	mov ip, r1
+	movs r1, #0x12
+	ldrsb r1, [r2, r1]
+	mov r0, ip
+	adds r0, #0x73
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	adds r3, r1, r0
+	movs r0, #0xb
+	ldrsb r0, [r2, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, #0x80
+	bne _0802BF4C
+	cmp r3, #0x78
+	bgt _0802BF50
+	b _0802BF6E
+_0802BF4C:
+	cmp r3, #0x3c
+	ble _0802BF6E
+_0802BF50:
+	movs r3, #0x12
+	ldrsb r3, [r2, r3]
+	movs r0, #0xb
+	ldrsb r0, [r2, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, #0x80
+	bne _0802BF64
+	movs r0, #0x78
+	b _0802BF66
+_0802BF64:
+	movs r0, #0x3c
+_0802BF66:
+	subs r0, r0, r3
+	mov r1, ip
+	adds r1, #0x73
+	strb r0, [r1]
+_0802BF6E:
+	movs r0, #0x14
+	ldrsb r0, [r2, r0]
+	mov r4, ip
+	adds r4, #0x74
+	movs r1, #0
+	ldrsb r1, [r4, r1]
+	adds r0, r0, r1
+	ldr r5, [r2, #4]
+	movs r1, #0x14
+	ldrsb r1, [r5, r1]
+	adds r3, r5, #0
+	cmp r0, r1
+	ble _0802BF90
+	ldrb r0, [r3, #0x14]
+	ldrb r1, [r2, #0x14]
+	subs r0, r0, r1
+	strb r0, [r4]
+_0802BF90:
+	movs r0, #0x15
+	ldrsb r0, [r2, r0]
+	mov r4, ip
+	adds r4, #0x75
+	movs r1, #0
+	ldrsb r1, [r4, r1]
+	adds r0, r0, r1
+	movs r1, #0x15
+	ldrsb r1, [r3, r1]
+	cmp r0, r1
+	ble _0802BFAE
+	ldrb r0, [r3, #0x15]
+	ldrb r1, [r2, #0x15]
+	subs r0, r0, r1
+	strb r0, [r4]
+_0802BFAE:
+	movs r0, #0x16
+	ldrsb r0, [r2, r0]
+	mov r4, ip
+	adds r4, #0x76
+	movs r1, #0
+	ldrsb r1, [r4, r1]
+	adds r0, r0, r1
+	movs r1, #0x16
+	ldrsb r1, [r3, r1]
+	cmp r0, r1
+	ble _0802BFCC
+	ldrb r0, [r3, #0x16]
+	ldrb r1, [r2, #0x16]
+	subs r0, r0, r1
+	strb r0, [r4]
+_0802BFCC:
+	movs r0, #0x17
+	ldrsb r0, [r2, r0]
+	mov r4, ip
+	adds r4, #0x77
+	movs r1, #0
+	ldrsb r1, [r4, r1]
+	adds r0, r0, r1
+	movs r1, #0x17
+	ldrsb r1, [r3, r1]
+	cmp r0, r1
+	ble _0802BFEA
+	ldrb r0, [r3, #0x17]
+	ldrb r1, [r2, #0x17]
+	subs r0, r0, r1
+	strb r0, [r4]
+_0802BFEA:
+	movs r0, #0x18
+	ldrsb r0, [r2, r0]
+	mov r3, ip
+	adds r3, #0x78
+	movs r1, #0
+	ldrsb r1, [r3, r1]
+	adds r0, r0, r1
+	movs r1, #0x18
+	ldrsb r1, [r5, r1]
+	cmp r0, r1
+	ble _0802C008
+	ldrb r0, [r5, #0x18]
+	ldrb r1, [r2, #0x18]
+	subs r0, r0, r1
+	strb r0, [r3]
+_0802C008:
+	movs r0, #0x19
+	ldrsb r0, [r2, r0]
+	mov r3, ip
+	adds r3, #0x79
+	movs r1, #0
+	ldrsb r1, [r3, r1]
+	adds r0, r0, r1
+	cmp r0, #0x1e
+	ble _0802C022
+	ldrb r1, [r2, #0x19]
+	movs r0, #0x1e
+	subs r0, r0, r1
+	strb r0, [r3]
+_0802C022:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START SaveUnitsFromBattle
+SaveUnitsFromBattle: @ 0x0802C028
+	push {r4, r5, r6, r7, lr}
+	ldr r5, _0802C09C  @ gUnknown_0203A4EC
+	movs r0, #0xb
+	ldrsb r0, [r5, r0]
+	bl GetUnitStruct
+	adds r7, r0, #0
+	ldr r4, _0802C0A0  @ gUnknown_0203A56C
+	movs r0, #0xb
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	adds r6, r0, #0
+	adds r0, r5, #0
+	adds r0, #0x52
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0
+	beq _0802C064
+	adds r0, r5, #0
+	adds r0, #0x51
+	ldrb r0, [r0]
+	lsls r0, r0, #1
+	adds r1, r5, #0
+	adds r1, #0x1e
+	adds r0, r0, r1
+	adds r1, #0x2a
+	ldrh r1, [r1]
+	strh r1, [r0]
+_0802C064:
+	adds r0, r4, #0
+	adds r0, #0x52
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0
+	beq _0802C086
+	adds r0, r4, #0
+	adds r0, #0x51
+	ldrb r0, [r0]
+	lsls r0, r0, #1
+	adds r1, r4, #0
+	adds r1, #0x1e
+	adds r0, r0, r1
+	adds r1, #0x2a
+	ldrh r1, [r1]
+	strh r1, [r0]
+_0802C086:
+	adds r0, r7, #0
+	adds r1, r5, #0
+	bl SaveUnitFromBattle
+	cmp r6, #0
+	beq _0802C0A4
+	adds r0, r6, #0
+	adds r1, r4, #0
+	bl SaveUnitFromBattle
+	b _0802C0AA
+	.align 2, 0
+_0802C09C: .4byte gUnknown_0203A4EC
+_0802C0A0: .4byte gUnknown_0203A56C
+_0802C0A4:
+	adds r0, r4, #0
+	bl SaveSnagWallFromBattle
+_0802C0AA:
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_802C0B0
+sub_802C0B0: @ 0x0802C0B0
+	movs r0, #1
+	bx lr
+
+	THUMB_FUNC_START GetBattleNewWExp
+GetBattleNewWExp: @ 0x0802C0B4
+	push {r4, r5, r6, r7, lr}
+	adds r7, r0, #0
+	movs r0, #0xb
+	ldrsb r0, [r7, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, #0
+	bne _0802C112
+	movs r0, #0x13
+	ldrsb r0, [r7, r0]
+	cmp r0, #0
+	beq _0802C112
+	ldr r0, _0802C118  @ gUnknown_0202BCF0
+	ldrb r1, [r0, #0x14]
+	movs r0, #0x80
+	ands r0, r1
+	cmp r0, #0
+	bne _0802C112
+	ldr r0, _0802C11C  @ gUnknown_0202BCB0
+	ldrb r1, [r0, #4]
+	movs r0, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _0802C112
+	ldr r0, _0802C120  @ gUnknown_0203A4D4
+	ldrh r1, [r0]
+	movs r0, #0x20
+	ands r0, r1
+	cmp r0, #0
+	bne _0802C124
+	adds r0, r7, #0
+	adds r0, #0x52
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0
+	beq _0802C112
+	ldr r1, [r7, #0x4c]
+	movs r0, #5
+	ands r0, r1
+	cmp r0, #0
+	beq _0802C112
+	movs r0, #0x88
+	lsls r0, r0, #3
+	ands r1, r0
+	cmp r1, #0
+	beq _0802C124
+_0802C112:
+	movs r0, #1
+	negs r0, r0
+	b _0802C1AA
+	.align 2, 0
+_0802C118: .4byte gUnknown_0202BCF0
+_0802C11C: .4byte gUnknown_0202BCB0
+_0802C120: .4byte gUnknown_0203A4D4
+_0802C124:
+	adds r5, r7, #0
+	adds r5, #0x50
+	ldrb r0, [r5]
+	adds r4, r7, #0
+	adds r4, #0x28
+	adds r0, r4, r0
+	ldrb r6, [r0]
+	adds r0, r7, #0
+	adds r0, #0x48
+	ldrh r0, [r0]
+	bl GetItemWExp
+	adds r1, r7, #0
+	adds r1, #0x7b
+	ldrb r1, [r1]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	muls r0, r1, r0
+	adds r6, r6, r0
+	movs r1, #0
+	ldrb r3, [r5]
+_0802C14E:
+	ldr r2, [r7, #4]
+	cmp r1, r3
+	beq _0802C170
+	adds r0, r2, #0
+	adds r0, #0x2c
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	cmp r0, #0xfb
+	beq _0802C170
+	adds r0, r4, r1
+	ldrb r0, [r0]
+	cmp r0, #0xfa
+	bls _0802C170
+	cmp r6, #0xfa
+	ble _0802C176
+	movs r6, #0xfa
+	b _0802C176
+_0802C170:
+	adds r1, #1
+	cmp r1, #7
+	ble _0802C14E
+_0802C176:
+	ldr r0, [r7]
+	ldr r4, [r0, #0x28]
+	ldr r0, [r2, #0x28]
+	orrs r4, r0
+	movs r0, #0x80
+	lsls r0, r0, #1
+	ands r0, r4
+	cmp r0, #0
+	beq _0802C190
+	cmp r6, #0xfb
+	ble _0802C1A8
+	movs r6, #0xfb
+	b _0802C1A8
+_0802C190:
+	movs r0, #0x80
+	lsls r0, r0, #0xc
+	ands r4, r0
+	cmp r4, #0
+	beq _0802C1A2
+	cmp r6, #0x47
+	ble _0802C1A8
+	movs r6, #0x47
+	b _0802C1A8
+_0802C1A2:
+	cmp r6, #0xb5
+	ble _0802C1A8
+	movs r6, #0xb5
+_0802C1A8:
+	adds r0, r6, #0
+_0802C1AA:
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START BattleUnit_DidWRankGoUp
+BattleUnit_DidWRankGoUp: @ 0x0802C1B0
+	push {r4, r5, lr}
+	adds r2, r0, #0
+	adds r2, #0x50
+	adds r1, r0, #0
+	adds r1, #0x28
+	ldrb r2, [r2]
+	adds r1, r1, r2
+	ldrb r4, [r1]
+	bl GetBattleNewWExp
+	adds r5, r0, #0
+	cmp r5, #0
+	blt _0802C1E4
+	adds r0, r4, #0
+	bl GetWeaponRankLevel
+	adds r4, r0, #0
+	adds r0, r5, #0
+	bl GetWeaponRankLevel
+	adds r1, r0, #0
+	eors r1, r4
+	negs r0, r1
+	orrs r0, r1
+	lsrs r0, r0, #0x1f
+	b _0802C1E6
+_0802C1E4:
+	movs r0, #0
+_0802C1E6:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START SaveUnitFromBattle
+SaveUnitFromBattle: @ 0x0802C1EC
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	ldrb r0, [r5, #8]
+	strb r0, [r4, #8]
+	ldrb r0, [r5, #9]
+	strb r0, [r4, #9]
+	ldrb r0, [r5, #0x13]
+	strb r0, [r4, #0x13]
+	ldr r0, [r5, #0xc]
+	str r0, [r4, #0xc]
+	ldr r2, _0802C2D0  @ gUnknown_03003060
+	lsrs r0, r0, #0x11
+	movs r1, #7
+	ands r0, r1
+	strb r0, [r2]
+	adds r1, r5, #0
+	adds r1, #0x6f
+	movs r0, #0
+	ldrsb r0, [r1, r0]
+	cmp r0, #0
+	blt _0802C220
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl SetUnitNewStatus
+_0802C220:
+	adds r0, r5, #0
+	adds r0, #0x73
+	ldrb r0, [r0]
+	ldrb r1, [r4, #0x12]
+	adds r0, r0, r1
+	strb r0, [r4, #0x12]
+	adds r0, r5, #0
+	adds r0, #0x74
+	ldrb r0, [r0]
+	ldrb r1, [r4, #0x14]
+	adds r0, r0, r1
+	strb r0, [r4, #0x14]
+	adds r0, r5, #0
+	adds r0, #0x75
+	ldrb r0, [r0]
+	ldrb r1, [r4, #0x15]
+	adds r0, r0, r1
+	strb r0, [r4, #0x15]
+	adds r0, r5, #0
+	adds r0, #0x76
+	ldrb r0, [r0]
+	ldrb r1, [r4, #0x16]
+	adds r0, r0, r1
+	strb r0, [r4, #0x16]
+	adds r0, r5, #0
+	adds r0, #0x77
+	ldrb r0, [r0]
+	ldrb r1, [r4, #0x17]
+	adds r0, r0, r1
+	strb r0, [r4, #0x17]
+	adds r0, r5, #0
+	adds r0, #0x78
+	ldrb r0, [r0]
+	ldrb r1, [r4, #0x18]
+	adds r0, r0, r1
+	strb r0, [r4, #0x18]
+	adds r0, r5, #0
+	adds r0, #0x79
+	ldrb r0, [r0]
+	ldrb r1, [r4, #0x19]
+	adds r0, r0, r1
+	strb r0, [r4, #0x19]
+	adds r0, r4, #0
+	bl CheckForStatCaps
+	adds r0, r5, #0
+	bl GetBattleNewWExp
+	adds r2, r0, #0
+	cmp r2, #0
+	ble _0802C294
+	adds r1, r5, #0
+	adds r1, #0x50
+	adds r0, r4, #0
+	adds r0, #0x28
+	ldrb r1, [r1]
+	adds r0, r0, r1
+	strb r2, [r0]
+_0802C294:
+	adds r6, r5, #0
+	adds r6, #0x6e
+	adds r1, r5, #0
+	adds r1, #0x1e
+	adds r3, r4, #0
+	adds r3, #0x1e
+	movs r2, #4
+_0802C2A2:
+	ldrh r0, [r1]
+	strh r0, [r3]
+	adds r1, #2
+	adds r3, #2
+	subs r2, #1
+	cmp r2, #0
+	bge _0802C2A2
+	adds r0, r4, #0
+	bl RemoveUnitBlankItems
+	movs r0, #0
+	ldrsb r0, [r6, r0]
+	cmp r0, #0
+	beq _0802C2CA
+	ldr r0, [r4]
+	ldrb r0, [r0, #4]
+	movs r1, #0
+	ldrsb r1, [r6, r1]
+	bl BWL_AddExpGained
+_0802C2CA:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802C2D0: .4byte gUnknown_03003060
+
+	THUMB_FUNC_START sub_802C2D4
+sub_802C2D4: @ 0x0802C2D4
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	adds r4, r1, #0
+	ldrb r0, [r4, #0x13]
+	strb r0, [r5, #0x13]
+	adds r0, r4, #0
+	bl GetBattleNewWExp
+	adds r2, r0, #0
+	cmp r2, #0
+	ble _0802C2F8
+	adds r1, r4, #0
+	adds r1, #0x50
+	adds r0, r5, #0
+	adds r0, #0x28
+	ldrb r1, [r1]
+	adds r0, r0, r1
+	strb r2, [r0]
+_0802C2F8:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START UpdateBallistaUsesFromBattle
+UpdateBallistaUsesFromBattle: @ 0x0802C300
+	push {r4, r5, lr}
+	ldr r0, _0802C32C  @ gUnknown_0203A4D4
+	ldrh r1, [r0]
+	movs r0, #8
+	ands r0, r1
+	cmp r0, #0
+	beq _0802C324
+	ldr r4, _0802C330  @ gUnknown_0203A4EC
+	adds r0, r4, #0
+	adds r0, #0x48
+	ldrh r0, [r0]
+	bl GetItemUses
+	adds r5, r0, #0
+	ldrb r0, [r4, #0x1c]
+	bl GetTrap
+	strb r5, [r0, #6]
+_0802C324:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802C32C: .4byte gUnknown_0203A4D4
+_0802C330: .4byte gUnknown_0203A4EC
+
+	THUMB_FUNC_START NullSomeStuff
+NullSomeStuff: @ 0x0802C334
+	ldr r1, _0802C340  @ gUnknown_0203A60C
+	movs r0, #0
+	strb r0, [r1]
+	strb r0, [r1, #1]
+	strb r0, [r1, #2]
+	bx lr
+	.align 2, 0
+_0802C340: .4byte gUnknown_0203A60C
+
+	THUMB_FUNC_START sub_802C344
+sub_802C344: @ 0x0802C344
+	push {lr}
+	movs r3, #8
+	ldrsb r3, [r0, r3]
+	ldr r1, [r0]
+	ldr r2, [r0, #4]
+	ldr r0, [r1, #0x28]
+	ldr r1, [r2, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _0802C360
+	adds r3, #0x14
+_0802C360:
+	adds r0, r3, #0
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_802C368
+sub_802C368: @ 0x0802C368
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	adds r4, r1, #0
+	bl sub_802C344
+	adds r5, r0, #0
+	adds r0, r4, #0
+	bl sub_802C344
+	subs r5, r5, r0
+	movs r0, #0x1f
+	subs r5, r0, r5
+	cmp r5, #0
+	bge _0802C386
+	movs r5, #0
+_0802C386:
+	ldr r0, [r6, #4]
+	movs r1, #0x1a
+	ldrsb r1, [r0, r1]
+	adds r0, r5, #0
+	bl __divsi3
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_802C398
+sub_802C398: @ 0x0802C398
+	push {r4, lr}
+	movs r2, #8
+	ldrsb r2, [r0, r2]
+	ldr r3, [r0, #4]
+	movs r1, #0x1a
+	ldrsb r1, [r3, r1]
+	adds r4, r2, #0
+	muls r4, r1, r4
+	ldr r0, [r0]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r3, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _0802C3D0
+	ldrb r0, [r3, #5]
+	cmp r0, #0
+	beq _0802C3D0
+	bl GetROMClassStruct
+	movs r1, #0x1a
+	ldrsb r1, [r0, r1]
+	lsls r0, r1, #2
+	adds r0, r0, r1
+	lsls r0, r0, #2
+	adds r4, r4, r0
+_0802C3D0:
+	adds r0, r4, #0
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_802C3D8
+sub_802C3D8: @ 0x0802C3D8
+	push {lr}
+	movs r2, #0
+	ldr r0, [r1]
+	ldr r3, [r1, #4]
+	ldr r1, [r0, #0x28]
+	ldr r0, [r3, #0x28]
+	orrs r1, r0
+	movs r0, #8
+	ands r0, r1
+	cmp r0, #0
+	beq _0802C3F0
+	movs r2, #0x14
+_0802C3F0:
+	movs r0, #0x80
+	lsls r0, r0, #8
+	ands r1, r0
+	cmp r1, #0
+	beq _0802C3FC
+	adds r2, #0x28
+_0802C3FC:
+	ldrb r0, [r3, #4]
+	cmp r0, #0x53
+	bne _0802C404
+	adds r2, #0x28
+_0802C404:
+	adds r0, r2, #0
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_802C40C
+sub_802C40C: @ 0x0802C40C
+	push {lr}
+	ldr r1, [r0]
+	ldr r2, [r0, #4]
+	ldr r0, [r1, #0x28]
+	ldr r1, [r2, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #0x12
+	ands r0, r1
+	cmp r0, #0
+	bne _0802C428
+	b _0802C444
+_0802C424:
+	movs r0, #2
+	b _0802C446
+_0802C428:
+	movs r2, #0
+	movs r3, #0x80
+	lsls r3, r3, #4
+	ldr r1, _0802C44C  @ gUnknown_0203A5EC
+_0802C430:
+	ldr r0, [r1]
+	lsls r0, r0, #0xd
+	lsrs r0, r0, #0xd
+	ands r0, r3
+	cmp r0, #0
+	bne _0802C424
+	adds r1, #4
+	adds r2, #1
+	cmp r2, #6
+	ble _0802C430
+_0802C444:
+	movs r0, #1
+_0802C446:
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0802C44C: .4byte gUnknown_0203A5EC
+
+	THUMB_FUNC_START sub_802C450
+sub_802C450: @ 0x0802C450
+	push {r4, r5, r6, r7, lr}
+	adds r7, r0, #0
+	adds r5, r1, #0
+	movs r0, #0x13
+	ldrsb r0, [r5, r0]
+	cmp r0, #0
+	beq _0802C462
+	movs r0, #0
+	b _0802C4EA
+_0802C462:
+	movs r6, #0x14
+	ldr r0, _0802C48C  @ gUnknown_0202BCB0
+	ldrb r1, [r0, #4]
+	movs r0, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _0802C478
+	ldr r0, _0802C490  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0x1b]
+	cmp r0, #1
+	beq _0802C494
+_0802C478:
+	adds r0, r5, #0
+	bl sub_802C398
+	adds r6, r0, #0
+	adds r6, #0x14
+	adds r0, r7, #0
+	bl sub_802C398
+	subs r6, r6, r0
+	b _0802C4CE
+	.align 2, 0
+_0802C48C: .4byte gUnknown_0202BCB0
+_0802C490: .4byte gUnknown_0202BCF0
+_0802C494:
+	adds r0, r5, #0
+	bl sub_802C398
+	adds r4, r0, #0
+	adds r0, r7, #0
+	bl sub_802C398
+	cmp r4, r0
+	bgt _0802C4BC
+	adds r0, r5, #0
+	bl sub_802C398
+	adds r4, r0, #0
+	adds r0, r7, #0
+	bl sub_802C398
+	lsrs r1, r0, #0x1f
+	adds r0, r0, r1
+	asrs r0, r0, #1
+	b _0802C4CA
+_0802C4BC:
+	adds r0, r5, #0
+	bl sub_802C398
+	adds r4, r0, #0
+	adds r0, r7, #0
+	bl sub_802C398
+_0802C4CA:
+	subs r4, r4, r0
+	adds r6, r6, r4
+_0802C4CE:
+	adds r0, r7, #0
+	adds r1, r5, #0
+	bl sub_802C3D8
+	adds r6, r6, r0
+	adds r0, r7, #0
+	adds r1, r5, #0
+	bl sub_802C40C
+	muls r6, r0, r6
+	cmp r6, #0
+	bge _0802C4E8
+	movs r6, #0
+_0802C4E8:
+	adds r0, r6, #0
+_0802C4EA:
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_802C4F0
+sub_802C4F0: @ 0x0802C4F0
+	push {lr}
+	adds r3, r0, #0
+	ldr r0, [r1, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x62
+	beq _0802C500
+	cmp r0, #0x34
+	bne _0802C510
+_0802C500:
+	movs r0, #0x13
+	ldrsb r0, [r1, r0]
+	cmp r0, #0
+	bne _0802C50C
+	movs r0, #0x32
+	b _0802C50E
+_0802C50C:
+	movs r0, #0
+_0802C50E:
+	str r0, [r2]
+_0802C510:
+	ldr r0, [r1, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x66
+	bne _0802C524
+	ldrb r1, [r1, #0x13]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	cmp r1, #0
+	bne _0802C524
+	str r1, [r2]
+_0802C524:
+	ldr r0, [r3, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x51
+	bne _0802C530
+	movs r0, #0
+	str r0, [r2]
+_0802C530:
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_802C534
+sub_802C534: @ 0x0802C534
+	push {r4, r5, lr}
+	sub sp, #4
+	adds r4, r0, #0
+	adds r5, r1, #0
+	bl CanUnitNotLevelUp
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802C562
+	movs r0, #0x13
+	ldrsb r0, [r4, r0]
+	cmp r0, #0
+	beq _0802C562
+	ldr r0, [r5]
+	ldr r1, [r5, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #0x11
+	ands r0, r1
+	cmp r0, #0
+	beq _0802C566
+_0802C562:
+	movs r0, #0
+	b _0802C5AE
+_0802C566:
+	adds r0, r4, #0
+	adds r0, #0x7c
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0
+	bne _0802C578
+	movs r0, #1
+	b _0802C5AE
+_0802C578:
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl sub_802C368
+	str r0, [sp]
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl sub_802C450
+	ldr r1, [sp]
+	adds r1, r1, r0
+	str r1, [sp]
+	cmp r1, #0x64
+	ble _0802C598
+	movs r0, #0x64
+	str r0, [sp]
+_0802C598:
+	ldr r0, [sp]
+	cmp r0, #0
+	bgt _0802C5A2
+	movs r0, #1
+	str r0, [sp]
+_0802C5A2:
+	adds r0, r4, #0
+	adds r1, r5, #0
+	mov r2, sp
+	bl sub_802C4F0
+	ldr r0, [sp]
+_0802C5AE:
+	add sp, #4
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START HandleSomeExp
+HandleSomeExp: @ 0x0802C5B8
+	push {r4, lr}
+	ldr r0, _0802C604  @ gUnknown_0202BCF0
+	ldrb r1, [r0, #0x14]
+	movs r0, #0x80
+	ands r0, r1
+	cmp r0, #0
+	bne _0802C632
+	ldr r4, _0802C608  @ gUnknown_0203A4EC
+	ldr r0, [r4, #0x4c]
+	movs r1, #4
+	ands r0, r1
+	cmp r0, #0
+	beq _0802C60C
+	movs r0, #0xb
+	ldrsb r0, [r4, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, #0
+	bne _0802C5E8
+	adds r1, r4, #0
+	adds r1, #0x7b
+	ldrb r0, [r1]
+	adds r0, #1
+	strb r0, [r1]
+_0802C5E8:
+	adds r0, r4, #0
+	bl GetBattleUnitStaffExp
+	adds r1, r4, #0
+	adds r1, #0x6e
+	strb r0, [r1]
+	ldrb r1, [r4, #9]
+	adds r1, r1, r0
+	strb r1, [r4, #9]
+	adds r0, r4, #0
+	bl CheckForLevelUp
+	b _0802C632
+	.align 2, 0
+_0802C604: .4byte gUnknown_0202BCF0
+_0802C608: .4byte gUnknown_0203A4EC
+_0802C60C:
+	adds r0, r4, #0
+	adds r0, #0x50
+	ldrb r0, [r0]
+	cmp r0, #0xc
+	bne _0802C632
+	ldrb r1, [r4, #9]
+	adds r0, r1, #0
+	cmp r0, #0xff
+	beq _0802C632
+	adds r2, r4, #0
+	adds r2, #0x6e
+	movs r0, #0x14
+	strb r0, [r2]
+	adds r0, r1, #0
+	adds r0, #0x14
+	strb r0, [r4, #9]
+	adds r0, r4, #0
+	bl CheckForLevelUp
+_0802C632:
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START GetBattleUnitStaffExp
+GetBattleUnitStaffExp: @ 0x0802C638
+	push {r4, lr}
+	adds r4, r0, #0
+	bl CanUnitNotLevelUp
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802C64A
+	movs r0, #0
+	b _0802C69A
+_0802C64A:
+	ldr r0, _0802C660  @ gUnknown_0203A5EC
+	ldr r0, [r0]
+	lsls r0, r0, #0xd
+	lsrs r0, r0, #0xd
+	movs r1, #2
+	ands r0, r1
+	cmp r0, #0
+	beq _0802C664
+	movs r0, #1
+	b _0802C69A
+	.align 2, 0
+_0802C660: .4byte gUnknown_0203A5EC
+_0802C664:
+	adds r0, r4, #0
+	adds r0, #0x48
+	ldrh r0, [r0]
+	bl GetItemCostPerUse
+	movs r1, #0x14
+	bl __divsi3
+	adds r2, r0, #0
+	adds r2, #0xa
+	ldr r0, [r4]
+	ldr r1, [r4, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _0802C692
+	lsrs r0, r2, #0x1f
+	adds r0, r2, r0
+	asrs r2, r0, #1
+_0802C692:
+	cmp r2, #0x64
+	ble _0802C698
+	movs r2, #0x64
+_0802C698:
+	adds r0, r2, #0
+_0802C69A:
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START InstigatorAdd10Exp
+InstigatorAdd10Exp: @ 0x0802C6A0
+	push {r4, lr}
+	ldr r4, _0802C6E4  @ gUnknown_0203A4EC
+	movs r0, #0xb
+	ldrsb r0, [r4, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, #0
+	bne _0802C6DC
+	adds r0, r4, #0
+	bl CanUnitNotLevelUp
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802C6DC
+	ldr r0, _0802C6E8  @ gUnknown_0202BCF0
+	ldrb r1, [r0, #0x14]
+	movs r0, #0x80
+	ands r0, r1
+	cmp r0, #0
+	bne _0802C6DC
+	adds r1, r4, #0
+	adds r1, #0x6e
+	movs r0, #0xa
+	strb r0, [r1]
+	ldrb r0, [r4, #9]
+	adds r0, #0xa
+	strb r0, [r4, #9]
+	adds r0, r4, #0
+	bl CheckForLevelUp
+_0802C6DC:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802C6E4: .4byte gUnknown_0203A4EC
+_0802C6E8: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START sub_802C6EC
+sub_802C6EC: @ 0x0802C6EC
+	push {r4, r5, r6, lr}
+	adds r5, r0, #0
+	adds r4, r5, #0
+	adds r4, #0x4a
+	ldrh r0, [r4]
+	cmp r0, #0
+	bne _0802C73A
+	adds r0, r5, #0
+	bl GetUnitEquippedWeapon
+	strh r0, [r4]
+	lsls r0, r0, #0x10
+	cmp r0, #0
+	bne _0802C73A
+	adds r0, r5, #0
+	bl UnitHasMagicRank
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802C73A
+	movs r6, #0
+	subs r4, #0x2c
+_0802C718:
+	ldrh r1, [r4]
+	adds r0, r5, #0
+	bl CanUnitUseAsStaff
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #1
+	bne _0802C732
+	ldrh r1, [r4]
+	adds r0, r5, #0
+	adds r0, #0x4a
+	strh r1, [r0]
+	b _0802C73A
+_0802C732:
+	adds r4, #2
+	adds r6, #1
+	cmp r6, #4
+	ble _0802C718
+_0802C73A:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_802C740
+sub_802C740: @ 0x0802C740
+	push {lr}
+	adds r2, r0, #0
+	adds r0, #0x52
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0
+	bne _0802C768
+	adds r0, r2, #0
+	adds r0, #0x5a
+	movs r1, #0xff
+	strh r1, [r0]
+	adds r0, #6
+	strh r1, [r0]
+	adds r0, #4
+	strh r1, [r0]
+	adds r0, #2
+	strh r1, [r0]
+	adds r0, #4
+	strh r1, [r0]
+_0802C768:
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START BattleReverseWTriangeEffect
+BattleReverseWTriangeEffect: @ 0x0802C76C
+	push {lr}
+	adds r2, r0, #0
+	adds r3, r1, #0
+	ldr r0, [r2, #0x4c]
+	movs r1, #0x80
+	lsls r1, r1, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _0802C786
+	ldr r0, [r3, #0x4c]
+	ands r0, r1
+	cmp r0, #0
+	bne _0802C7BA
+_0802C786:
+	adds r1, r2, #0
+	adds r1, #0x53
+	movs r0, #0
+	ldrsb r0, [r1, r0]
+	lsls r0, r0, #1
+	negs r0, r0
+	strb r0, [r1]
+	adds r1, #1
+	movs r0, #0
+	ldrsb r0, [r1, r0]
+	lsls r0, r0, #1
+	negs r0, r0
+	strb r0, [r1]
+	adds r1, r3, #0
+	adds r1, #0x53
+	movs r0, #0
+	ldrsb r0, [r1, r0]
+	lsls r0, r0, #1
+	negs r0, r0
+	strb r0, [r1]
+	adds r1, #1
+	movs r0, #0
+	ldrsb r0, [r1, r0]
+	lsls r0, r0, #1
+	negs r0, r0
+	strb r0, [r1]
+_0802C7BA:
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START BattleApplyWeaponTriangle
+BattleApplyWeaponTriangle: @ 0x0802C7C0
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	ldr r2, _0802C7CC  @ gUnknown_0859BA90
+	b _0802C812
+	.align 2, 0
+_0802C7CC: .4byte gUnknown_0859BA90
+_0802C7D0:
+	adds r0, r4, #0
+	adds r0, #0x50
+	ldrb r1, [r0]
+	movs r0, #0
+	ldrsb r0, [r2, r0]
+	cmp r1, r0
+	bne _0802C810
+	adds r0, r5, #0
+	adds r0, #0x50
+	ldrb r1, [r0]
+	movs r0, #1
+	ldrsb r0, [r2, r0]
+	cmp r1, r0
+	bne _0802C810
+	ldrb r0, [r2, #2]
+	adds r1, r4, #0
+	adds r1, #0x53
+	strb r0, [r1]
+	ldrb r1, [r2, #3]
+	adds r0, r4, #0
+	adds r0, #0x54
+	strb r1, [r0]
+	ldrb r0, [r2, #2]
+	negs r0, r0
+	adds r1, r5, #0
+	adds r1, #0x53
+	strb r0, [r1]
+	ldrb r0, [r2, #3]
+	negs r0, r0
+	adds r1, #1
+	strb r0, [r1]
+	b _0802C81A
+_0802C810:
+	adds r2, #4
+_0802C812:
+	movs r0, #0
+	ldrsb r0, [r2, r0]
+	cmp r0, #0
+	bge _0802C7D0
+_0802C81A:
+	ldr r0, [r4, #0x4c]
+	movs r6, #0x80
+	lsls r6, r6, #1
+	ands r0, r6
+	cmp r0, #0
+	beq _0802C82E
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl BattleReverseWTriangeEffect
+_0802C82E:
+	ldr r0, [r5, #0x4c]
+	ands r0, r6
+	cmp r0, #0
+	beq _0802C83E
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl BattleReverseWTriangeEffect
+_0802C83E:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START DoSomeBattleWeaponStuff
+DoSomeBattleWeaponStuff: @ 0x0802C844
+	push {r4, lr}
+	ldr r1, _0802C8BC  @ gUnknown_0203A56C
+	ldr r0, [r1, #4]
+	ldrb r0, [r0, #4]
+	mov ip, r1
+	cmp r0, #0x62
+	beq _0802C856
+	cmp r0, #0x34
+	bne _0802C864
+_0802C856:
+	mov r0, ip
+	adds r0, #0x48
+	movs r2, #0
+	movs r1, #0
+	strh r1, [r0]
+	adds r0, #0xa
+	strb r2, [r0]
+_0802C864:
+	ldr r4, _0802C8C0  @ gUnknown_0203A4EC
+	mov r3, ip
+	ldr r0, [r4, #0x4c]
+	ldr r1, [r3, #0x4c]
+	orrs r0, r1
+	movs r1, #0x80
+	ands r0, r1
+	cmp r0, #0
+	beq _0802C886
+	adds r1, r3, #0
+	adds r1, #0x48
+	movs r2, #0
+	movs r0, #0
+	strh r0, [r1]
+	adds r0, r3, #0
+	adds r0, #0x52
+	strb r2, [r0]
+_0802C886:
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r1, [r0]
+	movs r0, #0xf
+	ands r0, r1
+	cmp r0, #4
+	bne _0802C8B6
+	movs r0, #0xb
+	ldrsb r0, [r4, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, #0
+	bne _0802C8B6
+	mov r0, ip
+	movs r2, #0xb
+	ldrsb r2, [r0, r2]
+	ands r2, r1
+	cmp r2, #0
+	bne _0802C8B6
+	adds r0, #0x48
+	movs r1, #0
+	strh r2, [r0]
+	adds r0, #0xa
+	strb r1, [r0]
+_0802C8B6:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802C8BC: .4byte gUnknown_0203A56C
+_0802C8C0: .4byte gUnknown_0203A4EC
+
+	THUMB_FUNC_START MakeSnagBattleTarget
+MakeSnagBattleTarget: @ 0x0802C8C4
+	push {r4, lr}
+	ldr r4, _0802C91C  @ gUnknown_0203A56C
+	adds r0, r4, #0
+	bl ClearUnitStruct
+	movs r0, #0
+	strb r0, [r4, #0xb]
+	movs r0, #1
+	bl GetROMClassStruct
+	str r0, [r4, #4]
+	ldr r0, _0802C920  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xe]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	bl GetROMChapterStruct
+	adds r0, #0x2c
+	ldrb r0, [r0]
+	strb r0, [r4, #0x12]
+	ldr r1, _0802C924  @ gUnknown_0203A958
+	ldrb r0, [r1, #0x15]
+	strb r0, [r4, #0x13]
+	ldrb r0, [r1, #0x13]
+	strb r0, [r4, #0x10]
+	ldrb r0, [r1, #0x14]
+	strb r0, [r4, #0x11]
+	movs r0, #0x11
+	ldrsb r0, [r4, r0]
+	ldr r1, _0802C928  @ gUnknown_0202E4DC
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r1, #0x10
+	ldrsb r1, [r4, r1]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	cmp r0, #0x1b
+	beq _0802C92C
+	cmp r0, #0x33
+	beq _0802C936
+	b _0802C942
+	.align 2, 0
+_0802C91C: .4byte gUnknown_0203A56C
+_0802C920: .4byte gUnknown_0202BCF0
+_0802C924: .4byte gUnknown_0203A958
+_0802C928: .4byte gUnknown_0202E4DC
+_0802C92C:
+	movs r0, #0xfe
+	bl GetROMCharStruct
+	str r0, [r4]
+	b _0802C942
+_0802C936:
+	movs r0, #0xff
+	bl GetROMCharStruct
+	str r0, [r4]
+	movs r0, #0x14
+	strb r0, [r4, #0x12]
+_0802C942:
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START FillSnagBattleStats
+FillSnagBattleStats: @ 0x0802C948
+	push {r4, lr}
+	ldr r1, _0802C97C  @ gUnknown_0203A4EC
+	adds r2, r1, #0
+	adds r2, #0x64
+	movs r4, #0
+	movs r3, #0
+	movs r0, #0x64
+	strh r0, [r2]
+	adds r1, #0x6a
+	strh r3, [r1]
+	ldr r1, _0802C980  @ gUnknown_0203A56C
+	adds r2, r1, #0
+	adds r2, #0x5e
+	movs r0, #0xff
+	strh r0, [r2]
+	ldrb r0, [r1, #0x13]
+	adds r2, #0x14
+	strb r0, [r2]
+	adds r0, r1, #0
+	adds r0, #0x53
+	strb r4, [r0]
+	adds r0, #1
+	strb r4, [r0]
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802C97C: .4byte gUnknown_0203A4EC
+_0802C980: .4byte gUnknown_0203A56C
+
+	THUMB_FUNC_START SaveSnagWallFromBattle
+SaveSnagWallFromBattle: @ 0x0802C984
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	bl GetTrapAt
+	adds r6, r0, #0
+	ldrb r0, [r4, #0x13]
+	strb r0, [r6, #3]
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802CA00
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	bl GetMapChangesIdAt
+	adds r5, r0, #0
+	movs r0, #0x11
+	ldrsb r0, [r4, r0]
+	ldr r1, _0802CA08  @ gUnknown_0202E4DC
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r1, #0x10
+	ldrsb r1, [r4, r1]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	cmp r0, #0x33
+	bne _0802C9DA
+	ldr r0, _0802CA0C  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _0802C9DA
+	ldr r0, _0802CA10  @ 0x000002D7
+	bl m4aSongNumStart
+_0802C9DA:
+	bl sub_8019CBC
+	adds r0, r5, #0
+	bl ApplyMapChangesById
+	movs r0, #0
+	strb r0, [r6, #2]
+	adds r0, r5, #0
+	bl AddMapChange
+	bl FlushTerrainData
+	bl sub_802E690
+	bl UpdateGameTilesGraphics
+	movs r0, #0
+	bl NewBMXFADE
+_0802CA00:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802CA08: .4byte gUnknown_0202E4DC
+_0802CA0C: .4byte gUnknown_0202BCF0
+_0802CA10: .4byte 0x000002D7
+
+	THUMB_FUNC_START BeginBattleAnimations
+BeginBattleAnimations: @ 0x0802CA14
+	push {lr}
+	ldr r0, _0802CA48  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #4
+	bl BG_EnableSyncByMask
+	ldr r1, _0802CA4C  @ gPaletteBuffer
+	movs r0, #0
+	strh r0, [r1]
+	bl EnablePaletteSync
+	bl UpdateGameTilesGraphics
+	bl sub_8055BC4
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802CA50
+	movs r0, #0
+	bl sub_804FD48
+	bl BeginAnimsOnBattleAnimations
+	b _0802CA66
+	.align 2, 0
+_0802CA48: .4byte gBG2TilemapBuffer
+_0802CA4C: .4byte gPaletteBuffer
+_0802CA50:
+	bl ClearMOVEUNITs
+	bl UpdateGameTilesGraphics
+	bl BeginBattleMapAnims
+	ldr r0, _0802CA6C  @ gUnknown_0203A4D4
+	ldrh r1, [r0]
+	movs r2, #0x80
+	orrs r1, r2
+	strh r1, [r0]
+_0802CA66:
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802CA6C: .4byte gUnknown_0203A4D4
+
+	THUMB_FUNC_START sub_802CA70
+sub_802CA70: @ 0x0802CA70
+	push {lr}
+	ldr r1, [r0, #0xc]
+	movs r0, #0x80
+	lsls r0, r0, #7
+	ands r0, r1
+	cmp r0, #0
+	beq _0802CA82
+	movs r0, #0
+	b _0802CA92
+_0802CA82:
+	movs r0, #0x80
+	lsls r0, r0, #8
+	ands r1, r0
+	cmp r1, #0
+	bne _0802CA90
+	movs r0, #1
+	b _0802CA92
+_0802CA90:
+	movs r0, #3
+_0802CA92:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_802CA98
+sub_802CA98: @ 0x0802CA98
+	push {lr}
+	ldr r0, _0802CACC  @ gUnknown_0202BCF0
+	adds r0, #0x42
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1d
+	lsrs r0, r0, #0x1e
+	cmp r0, #2
+	bne _0802CAF2
+	ldr r2, _0802CAD0  @ gUnknown_0203A4EC
+	movs r0, #0xb
+	ldrsb r0, [r2, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	adds r3, r2, #0
+	cmp r0, #0
+	bne _0802CAD8
+	ldr r0, _0802CAD4  @ gUnknown_0203A56C
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	ands r0, r1
+	cmp r0, #0
+	bne _0802CAEC
+	adds r0, r3, #0
+	b _0802CAEE
+	.align 2, 0
+_0802CACC: .4byte gUnknown_0202BCF0
+_0802CAD0: .4byte gUnknown_0203A4EC
+_0802CAD4: .4byte gUnknown_0203A56C
+_0802CAD8:
+	ldr r2, _0802CAE8  @ gUnknown_0203A56C
+	movs r0, #0xb
+	ldrsb r0, [r2, r0]
+	ands r0, r1
+	cmp r0, #0
+	beq _0802CAEC
+	movs r0, #1
+	b _0802CAF2
+	.align 2, 0
+_0802CAE8: .4byte gUnknown_0203A56C
+_0802CAEC:
+	adds r0, r2, #0
+_0802CAEE:
+	bl sub_802CA70
+_0802CAF2:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START nullsub_11
+nullsub_11: @ 0x0802CAF8
+	bx lr
+
+	THUMB_FUNC_START sub_802CAFC
+sub_802CAFC: @ 0x0802CAFC
+	push {lr}
+	ldr r2, _0802CB0C  @ gUnknown_0203A5EC
+	ldr r0, [r2]
+	lsls r0, r0, #8
+	lsrs r0, r0, #0x1b
+	movs r1, #0x10
+	b _0802CB18
+	.align 2, 0
+_0802CB0C: .4byte gUnknown_0203A5EC
+_0802CB10:
+	adds r2, #4
+	ldr r0, [r2]
+	lsls r0, r0, #8
+	lsrs r0, r0, #0x1b
+_0802CB18:
+	ands r0, r1
+	cmp r0, #0
+	beq _0802CB10
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_802CB24
+sub_802CB24: @ 0x0802CB24
+	push {r4, r5, r6, r7, lr}
+	adds r2, r0, #0
+	adds r7, r1, #0
+	lsls r1, r7, #1
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r6, [r0]
+	cmp r7, #0
+	bge _0802CB38
+	movs r6, #0
+_0802CB38:
+	ldr r1, _0802CBBC  @ gUnknown_0203A4D4
+	movs r4, #0
+	movs r0, #0
+	strh r0, [r1]
+	ldr r5, _0802CBC0  @ gUnknown_0203A4EC
+	adds r0, r5, #0
+	adds r1, r2, #0
+	bl CopyUnitToBattleStruct
+	adds r0, r5, #0
+	bl BattleSetupTerrainData
+	adds r0, r5, #0
+	bl LoadRawDefense
+	adds r0, r5, #0
+	movs r1, #0
+	bl BattleApplyMiscBonuses
+	adds r0, r5, #0
+	adds r0, #0x5a
+	movs r2, #0xff
+	strh r2, [r0]
+	adds r1, r5, #0
+	adds r1, #0x64
+	movs r0, #0x64
+	strh r0, [r1]
+	adds r0, r5, #0
+	adds r0, #0x6a
+	strh r2, [r0]
+	subs r0, #0x22
+	strh r6, [r0]
+	adds r0, #2
+	strh r6, [r0]
+	adds r0, #7
+	strb r7, [r0]
+	adds r0, r6, #0
+	bl GetItemWType
+	adds r1, r5, #0
+	adds r1, #0x50
+	strb r0, [r1]
+	adds r0, r6, #0
+	bl GetItemAttributes
+	str r0, [r5, #0x4c]
+	adds r1, r5, #0
+	adds r1, #0x52
+	movs r0, #1
+	strb r0, [r1]
+	adds r0, r5, #0
+	adds r0, #0x7e
+	strb r4, [r0]
+	adds r1, #0x1d
+	movs r0, #0xff
+	strb r0, [r1]
+	ldr r0, _0802CBC4  @ gUnknown_0203A56C
+	adds r0, #0x6f
+	movs r1, #1
+	negs r1, r1
+	strb r1, [r0]
+	bl ClearRounds
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802CBBC: .4byte gUnknown_0203A4D4
+_0802CBC0: .4byte gUnknown_0203A4EC
+_0802CBC4: .4byte gUnknown_0203A56C
+
+	THUMB_FUNC_START sub_802CBC8
+sub_802CBC8: @ 0x0802CBC8
+	push {r4, lr}
+	adds r1, r0, #0
+	ldr r4, _0802CC14  @ gUnknown_0203A56C
+	adds r0, r4, #0
+	bl CopyUnitToBattleStruct
+	adds r0, r4, #0
+	bl BattleSetupTerrainData
+	adds r0, r4, #0
+	bl LoadRawDefense
+	adds r0, r4, #0
+	movs r1, #0
+	bl BattleApplyMiscBonuses
+	adds r0, r4, #0
+	adds r0, #0x5a
+	movs r2, #0
+	movs r1, #0xff
+	strh r1, [r0]
+	adds r0, #0xa
+	strh r1, [r0]
+	adds r0, #6
+	strh r1, [r0]
+	subs r0, #0x20
+	strh r2, [r0]
+	adds r0, r4, #0
+	bl sub_802C6EC
+	ldr r0, _0802CC18  @ gUnknown_0203A4EC
+	adds r0, #0x7e
+	movs r1, #1
+	strb r1, [r0]
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802CC14: .4byte gUnknown_0203A56C
+_0802CC18: .4byte gUnknown_0203A4EC
+
+	THUMB_FUNC_START SaveInstigatorFromBattle
+SaveInstigatorFromBattle: @ 0x0802CC1C
+	push {r4, lr}
+	ldr r4, _0802CC34  @ gUnknown_0203A4EC
+	movs r0, #0xb
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	adds r1, r4, #0
+	bl SaveUnitFromBattle
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802CC34: .4byte gUnknown_0203A4EC
+
+	THUMB_FUNC_START SaveInstigatorWith10ExtraExp
+SaveInstigatorWith10ExtraExp: @ 0x0802CC38
+	push {r4, lr}
+	adds r4, r0, #0
+	bl InstigatorAdd10Exp
+	ldr r0, _0802CC50  @ gUnknown_0859BAC4
+	adds r1, r4, #0
+	bl Proc_CreateBlockingChild
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802CC50: .4byte gUnknown_0859BAC4
+
+	THUMB_FUNC_START sub_802CC54
+sub_802CC54: @ 0x0802CC54
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	ldr r0, _0802CCD0  @ gUnknown_0203A608
+	ldr r2, [r0]
+	adds r2, #4
+	str r2, [r0]
+	ldrb r1, [r2, #2]
+	movs r0, #7
+	ands r0, r1
+	movs r1, #0x80
+	orrs r0, r1
+	strb r0, [r2, #2]
+	bl HandleSomeExp
+	ldr r4, _0802CCD4  @ gUnknown_0203A4EC
+	adds r0, r4, #0
+	adds r0, #0x52
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0
+	beq _0802CCC0
+	adds r5, r4, #0
+	adds r5, #0x48
+	ldrh r0, [r5]
+	bl GetItemAttributes
+	movs r1, #4
+	ands r1, r0
+	cmp r1, #0
+	beq _0802CC9A
+	adds r1, r4, #0
+	adds r1, #0x7d
+	movs r0, #1
+	strb r0, [r1]
+_0802CC9A:
+	ldrh r0, [r5]
+	bl ValidateItem
+	strh r0, [r5]
+	adds r1, r4, #0
+	adds r1, #0x51
+	ldrb r1, [r1]
+	lsls r1, r1, #1
+	adds r2, r4, #0
+	adds r2, #0x1e
+	adds r1, r1, r2
+	strh r0, [r1]
+	ldrh r0, [r5]
+	cmp r0, #0
+	beq _0802CCC0
+	adds r1, r4, #0
+	adds r1, #0x7d
+	movs r0, #0
+	strb r0, [r1]
+_0802CCC0:
+	ldr r0, _0802CCD8  @ gUnknown_0859BAC4
+	adds r1, r6, #0
+	bl Proc_CreateBlockingChild
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802CCD0: .4byte gUnknown_0203A608
+_0802CCD4: .4byte gUnknown_0203A4EC
+_0802CCD8: .4byte gUnknown_0859BAC4
+
+	THUMB_FUNC_START GetStaffAccuracy
+GetStaffAccuracy: @ 0x0802CCDC
+	push {r4, r5, r6, r7, lr}
+	adds r5, r0, #0
+	adds r6, r1, #0
+	bl GetUnitPower
+	adds r4, r0, #0
+	adds r0, r6, #0
+	bl GetUnitResistance
+	subs r4, r4, r0
+	lsls r0, r4, #2
+	adds r7, r0, r4
+	adds r0, r5, #0
+	bl GetUnitSkill
+	adds r4, r0, #0
+	movs r2, #0x10
+	ldrsb r2, [r5, r2]
+	movs r0, #0x10
+	ldrsb r0, [r6, r0]
+	subs r1, r2, r0
+	cmp r1, #0
+	bge _0802CD0C
+	subs r1, r0, r2
+_0802CD0C:
+	movs r3, #0x11
+	ldrsb r3, [r5, r3]
+	movs r2, #0x11
+	ldrsb r2, [r6, r2]
+	subs r0, r3, r2
+	cmp r0, #0
+	bge _0802CD1C
+	subs r0, r2, r3
+_0802CD1C:
+	adds r2, r1, r0
+	ldr r0, [r5, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x66
+	bne _0802CD2E
+	adds r1, r7, r4
+	lsls r0, r2, #1
+	subs r1, r1, r0
+	b _0802CD38
+_0802CD2E:
+	adds r0, r4, #0
+	adds r0, #0x1e
+	adds r0, r7, r0
+	lsls r1, r2, #1
+	subs r1, r0, r1
+_0802CD38:
+	ldr r0, [r6, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x66
+	beq _0802CD4C
+	ldr r0, [r6]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x40
+	beq _0802CD4C
+	cmp r0, #0x6c
+	bne _0802CD50
+_0802CD4C:
+	movs r0, #0
+	b _0802CD5E
+_0802CD50:
+	cmp r1, #0
+	bge _0802CD56
+	movs r1, #0
+_0802CD56:
+	cmp r1, #0x64
+	ble _0802CD5C
+	movs r1, #0x64
+_0802CD5C:
+	adds r0, r1, #0
+_0802CD5E:
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_802CD64
+sub_802CD64: @ 0x0802CD64
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #4
+	adds r6, r0, #0
+	ldr r0, _0802CE34  @ gUnknown_0203A8F0
+	mov r9, r0
+	ldr r1, [r0, #4]
+	mov r8, r1
+	ldr r0, _0802CE38  @ gUnknown_0202BCB0
+	adds r0, #0x3c
+	ldrb r0, [r0]
+	str r0, [sp]
+	ldr r7, _0802CE3C  @ gUnknown_0203A4D4
+	movs r0, #0x21
+	strh r0, [r7]
+	ldr r5, _0802CE40  @ gUnknown_0203A4EC
+	adds r0, r5, #0
+	adds r1, r6, #0
+	bl CopyUnitToBattleStruct
+	ldr r4, _0802CE44  @ gUnknown_0203A56C
+	adds r0, r4, #0
+	mov r1, r8
+	bl CopyUnitToBattleStruct
+	ldr r0, _0802CE48  @ gUnknown_0203A958
+	mov sl, r0
+	ldrb r0, [r0, #0x15]
+	cmp r0, #0
+	beq _0802CDAE
+	strb r0, [r4, #0x13]
+	adds r1, r4, #0
+	adds r1, #0x72
+	strb r0, [r1]
+_0802CDAE:
+	mov r1, r9
+	ldrb r0, [r1, #0xc]
+	strb r0, [r7, #2]
+	ldrb r1, [r5, #0x10]
+	adds r0, r0, r1
+	strb r0, [r4, #0x10]
+	ldrb r0, [r5, #0x11]
+	strb r0, [r4, #0x11]
+	adds r0, r5, #0
+	movs r1, #6
+	bl SetupBattleWeaponData
+	adds r0, r4, #0
+	movs r1, #7
+	bl SetupBattleWeaponData
+	adds r0, r5, #0
+	adds r1, r4, #0
+	bl BattleApplyWeaponTriangle
+	movs r0, #4
+	mov r1, sl
+	strb r0, [r1, #0x16]
+	movs r0, #3
+	bl SaveSuspendedGame
+	adds r0, r5, #0
+	bl BattleSetupTerrainData
+	adds r0, r4, #0
+	movs r1, #8
+	bl WriteBattleStructTerrainBonuses
+	adds r0, r6, #0
+	mov r1, r8
+	bl sub_802A398
+	movs r0, #0x13
+	ldrsb r0, [r4, r0]
+	cmp r0, #0
+	bne _0802CE04
+	bl sub_802B92C
+_0802CE04:
+	adds r0, r6, #0
+	adds r1, r5, #0
+	bl sub_802C2D4
+	ldr r0, [sp]
+	cmp r0, #0
+	beq _0802CE1A
+	movs r0, #0x13
+	ldrsb r0, [r4, r0]
+	cmp r0, #0
+	bne _0802CE62
+_0802CE1A:
+	bl sub_80A4AA4
+	ldr r0, [r6, #0xc]
+	ldr r2, _0802CE4C  @ 0xFFF1FFFF
+	ands r2, r0
+	lsrs r0, r0, #0x11
+	movs r1, #7
+	ands r0, r1
+	adds r0, #1
+	cmp r0, #7
+	bhi _0802CE50
+	lsls r0, r0, #0x11
+	b _0802CE54
+	.align 2, 0
+_0802CE34: .4byte gUnknown_0203A8F0
+_0802CE38: .4byte gUnknown_0202BCB0
+_0802CE3C: .4byte gUnknown_0203A4D4
+_0802CE40: .4byte gUnknown_0203A4EC
+_0802CE44: .4byte gUnknown_0203A56C
+_0802CE48: .4byte gUnknown_0203A958
+_0802CE4C: .4byte 0xFFF1FFFF
+_0802CE50:
+	movs r0, #0xe0
+	lsls r0, r0, #0xc
+_0802CE54:
+	adds r1, r2, r0
+	str r1, [r6, #0xc]
+	ldr r0, _0802CE7C  @ gUnknown_03003060
+	lsrs r1, r1, #0x11
+	movs r2, #7
+	ands r1, r2
+	strb r1, [r0]
+_0802CE62:
+	ldr r0, _0802CE80  @ gUnknown_0203A4EC
+	ldr r1, _0802CE84  @ gUnknown_0203A56C
+	bl nullsub_11
+	add sp, #4
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802CE7C: .4byte gUnknown_03003060
+_0802CE80: .4byte gUnknown_0203A4EC
+_0802CE84: .4byte gUnknown_0203A56C
+
+	THUMB_FUNC_START IsCurrentBattleTriangleAttack
+IsCurrentBattleTriangleAttack: @ 0x0802CE88
+	ldr r0, _0802CE98  @ gUnknown_0203A5EC
+	ldr r0, [r0]
+	lsls r0, r0, #0xd
+	lsrs r0, r0, #0x17
+	movs r1, #1
+	ands r0, r1
+	bx lr
+	.align 2, 0
+_0802CE98: .4byte gUnknown_0203A5EC
+
+	THUMB_FUNC_START DidWeaponBreak
+DidWeaponBreak: @ 0x0802CE9C
+	push {lr}
+	adds r1, r0, #0
+	movs r0, #0x13
+	ldrsb r0, [r1, r0]
+	cmp r0, #0
+	beq _0802CEB4
+	adds r0, r1, #0
+	adds r0, #0x7d
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	b _0802CEB6
+_0802CEB4:
+	movs r0, #0
+_0802CEB6:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_802CEBC
+sub_802CEBC: @ 0x0802CEBC
+	ldr r1, _0802CEC4  @ gUnknown_0203A958
+	str r0, [r1, #0x18]
+	bx lr
+	.align 2, 0
+_0802CEC4: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START CurrentRound_ComputeDamage
+CurrentRound_ComputeDamage: @ 0x0802CEC8
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r2, _0802CF0C  @ gUnknown_0203A4D4
+	movs r0, #0
+	strh r0, [r2, #4]
+	ldr r0, _0802CF10  @ gUnknown_0203A608
+	ldr r3, [r0]
+	ldr r0, [r3]
+	lsls r0, r0, #0xd
+	lsrs r0, r0, #0xd
+	movs r1, #2
+	ands r0, r1
+	cmp r0, #0
+	bne _0802CF44
+	movs r0, #3
+	ldrsb r0, [r3, r0]
+	cmp r0, #0
+	bne _0802CF14
+	ldrh r0, [r2, #6]
+	ldrh r1, [r2, #8]
+	subs r0, r0, r1
+	strh r0, [r2, #4]
+	ldr r0, [r3]
+	lsls r0, r0, #0xd
+	lsrs r0, r0, #0xd
+	movs r1, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _0802CF1A
+	movs r0, #4
+	ldrsh r1, [r2, r0]
+	lsls r0, r1, #1
+	adds r0, r0, r1
+	b _0802CF18
+	.align 2, 0
+_0802CF0C: .4byte gUnknown_0203A4D4
+_0802CF10: .4byte gUnknown_0203A608
+_0802CF14:
+	movs r0, #3
+	ldrsb r0, [r3, r0]
+_0802CF18:
+	strh r0, [r2, #4]
+_0802CF1A:
+	adds r1, r2, #0
+	movs r3, #4
+	ldrsh r0, [r1, r3]
+	cmp r0, #0x7f
+	ble _0802CF28
+	movs r0, #0x7f
+	strh r0, [r1, #4]
+_0802CF28:
+	movs r3, #4
+	ldrsh r0, [r1, r3]
+	cmp r0, #0
+	bge _0802CF34
+	movs r0, #0
+	strh r0, [r1, #4]
+_0802CF34:
+	movs r1, #4
+	ldrsh r0, [r2, r1]
+	cmp r0, #0
+	beq _0802CF44
+	adds r1, r4, #0
+	adds r1, #0x7c
+	movs r0, #1
+	strb r0, [r1]
+_0802CF44:
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_802CF4C
+sub_802CF4C: @ 0x0802CF4C
+	push {r4, r5, r6, r7, lr}
+	ldr r0, _0802CFA4  @ gUnknown_0203A958
+	ldr r3, [r0, #0x18]
+	ldr r4, _0802CFA8  @ gUnknown_0203A5EC
+	ldr r2, [r3]
+	lsls r0, r2, #8
+	lsrs r0, r0, #0x1b
+	movs r1, #0x10
+	ands r0, r1
+	adds r5, r4, #0
+	ldr r6, _0802CFAC  @ gUnknown_0203A608
+	cmp r0, #0
+	bne _0802CF76
+_0802CF66:
+	stm r4!, {r2}
+	adds r3, #4
+	ldr r2, [r3]
+	lsls r0, r2, #8
+	lsrs r0, r0, #0x1b
+	ands r0, r1
+	cmp r0, #0
+	beq _0802CF66
+_0802CF76:
+	ldr r0, [r3]
+	str r0, [r4]
+	str r5, [r6]
+	ldr r0, [r5]
+	lsls r0, r0, #8
+	lsrs r0, r0, #0x1b
+	movs r1, #0x10
+	ands r0, r1
+	cmp r0, #0
+	beq _0802CF8C
+	b _0802D0AC
+_0802CF8C:
+	movs r7, #7
+_0802CF8E:
+	ldr r0, [r6]
+	ldr r0, [r0]
+	lsls r0, r0, #8
+	lsrs r0, r0, #0x1b
+	movs r1, #8
+	ands r0, r1
+	cmp r0, #0
+	beq _0802CFB8
+	ldr r4, _0802CFB0  @ gUnknown_0203A56C
+	ldr r5, _0802CFB4  @ gUnknown_0203A4EC
+	b _0802CFBC
+	.align 2, 0
+_0802CFA4: .4byte gUnknown_0203A958
+_0802CFA8: .4byte gUnknown_0203A5EC
+_0802CFAC: .4byte gUnknown_0203A608
+_0802CFB0: .4byte gUnknown_0203A56C
+_0802CFB4: .4byte gUnknown_0203A4EC
+_0802CFB8:
+	ldr r4, _0802D034  @ gUnknown_0203A4EC
+	ldr r5, _0802D038  @ gUnknown_0203A56C
+_0802CFBC:
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl UpdateBattleStats
+	adds r0, r4, #0
+	bl CurrentRound_ComputeDamage
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl CurrentRound_ComputeWeaponEffects
+	movs r0, #0x13
+	ldrsb r0, [r4, r0]
+	cmp r0, #0
+	beq _0802CFE2
+	movs r0, #0x13
+	ldrsb r0, [r5, r0]
+	cmp r0, #0
+	bne _0802D040
+_0802CFE2:
+	adds r1, r4, #0
+	adds r1, #0x7b
+	ldrb r0, [r1]
+	adds r0, #1
+	strb r0, [r1]
+	ldr r5, _0802D03C  @ gUnknown_0203A608
+	ldr r3, [r5]
+	ldr r1, [r3]
+	lsls r1, r1, #8
+	lsrs r1, r1, #0x1b
+	movs r0, #2
+	orrs r1, r0
+	lsls r1, r1, #3
+	ldrb r2, [r3, #2]
+	movs r4, #7
+	adds r0, r4, #0
+	ands r0, r2
+	orrs r0, r1
+	strb r0, [r3, #2]
+	ldr r0, _0802D038  @ gUnknown_0203A56C
+	ldrb r0, [r0, #0x13]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0
+	bne _0802D02C
+	ldr r3, [r5]
+	ldr r1, [r3]
+	lsls r1, r1, #8
+	lsrs r1, r1, #0x1b
+	movs r0, #4
+	orrs r1, r0
+	lsls r1, r1, #3
+	ldrb r2, [r3, #2]
+	adds r0, r4, #0
+	ands r0, r2
+	orrs r0, r1
+	strb r0, [r3, #2]
+_0802D02C:
+	ldr r2, [r5]
+	ldrb r1, [r2, #6]
+	adds r0, r4, #0
+	b _0802D08C
+	.align 2, 0
+_0802D034: .4byte gUnknown_0203A4EC
+_0802D038: .4byte gUnknown_0203A56C
+_0802D03C: .4byte gUnknown_0203A608
+_0802D040:
+	adds r0, r5, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #0xb
+	beq _0802D064
+	cmp r1, #0xd
+	beq _0802D064
+	adds r0, r5, #0
+	adds r0, #0x6f
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0xb
+	beq _0802D064
+	cmp r0, #0xd
+	bne _0802D096
+_0802D064:
+	adds r1, r4, #0
+	adds r1, #0x7b
+	ldrb r0, [r1]
+	adds r0, #1
+	strb r0, [r1]
+	ldr r3, [r6]
+	ldr r1, [r3]
+	lsls r1, r1, #8
+	lsrs r1, r1, #0x1b
+	movs r0, #2
+	orrs r1, r0
+	lsls r1, r1, #3
+	ldrb r2, [r3, #2]
+	adds r0, r7, #0
+	ands r0, r2
+	orrs r0, r1
+	strb r0, [r3, #2]
+	ldr r2, [r6]
+	ldrb r1, [r2, #6]
+	adds r0, r7, #0
+_0802D08C:
+	ands r0, r1
+	movs r1, #0x80
+	orrs r0, r1
+	strb r0, [r2, #6]
+	b _0802D0AC
+_0802D096:
+	ldr r1, [r6]
+	adds r0, r1, #4
+	str r0, [r6]
+	ldr r0, [r1, #4]
+	lsls r0, r0, #8
+	lsrs r0, r0, #0x1b
+	movs r1, #0x10
+	ands r0, r1
+	cmp r0, #0
+	bne _0802D0AC
+	b _0802CF8E
+_0802D0AC:
+	ldr r1, _0802D0B8  @ gUnknown_0203A958
+	movs r0, #0
+	str r0, [r1, #0x18]
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802D0B8: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START sub_802D0BC
+sub_802D0BC: @ 0x0802D0BC
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #8
+	adds r4, r0, #0
+	ldrb r1, [r4, #8]
+	movs r0, #8
+	ldrsb r0, [r4, r0]
+	cmp r0, #0x14
+	bne _0802D0D6
+	b _0802D2A4
+_0802D0D6:
+	movs r0, #0
+	strb r0, [r4, #9]
+	adds r0, r1, #1
+	strb r0, [r4, #8]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0x14
+	bne _0802D0EA
+	movs r0, #0xff
+	strb r0, [r4, #9]
+_0802D0EA:
+	ldr r0, [r4, #0xc]
+	movs r1, #0x80
+	lsls r1, r1, #6
+	ands r0, r1
+	movs r6, #0
+	cmp r0, #0
+	beq _0802D0FA
+	movs r6, #5
+_0802D0FA:
+	ldr r0, [r4]
+	ldrb r0, [r0, #0x1c]
+	adds r0, r6, r0
+	bl GetStatIncrease
+	mov r8, r0
+	ldr r0, [r4]
+	ldrb r0, [r0, #0x1d]
+	adds r0, r6, r0
+	bl GetStatIncrease
+	str r0, [sp]
+	adds r5, r0, #0
+	add r5, r8
+	ldr r0, [r4]
+	ldrb r0, [r0, #0x1e]
+	adds r0, r6, r0
+	bl GetStatIncrease
+	str r0, [sp, #4]
+	adds r5, r5, r0
+	ldr r0, [r4]
+	ldrb r0, [r0, #0x1f]
+	adds r0, r6, r0
+	bl GetStatIncrease
+	mov sl, r0
+	add r5, sl
+	ldr r0, [r4]
+	adds r0, #0x20
+	ldrb r0, [r0]
+	adds r0, r6, r0
+	bl GetStatIncrease
+	mov r9, r0
+	add r5, r9
+	ldr r0, [r4]
+	adds r0, #0x21
+	ldrb r0, [r0]
+	adds r0, r6, r0
+	bl GetStatIncrease
+	adds r7, r0, #0
+	adds r5, r5, r7
+	ldr r0, [r4]
+	adds r0, #0x22
+	ldrb r0, [r0]
+	adds r0, r6, r0
+	bl GetStatIncrease
+	adds r6, r0, #0
+	adds r5, r5, r6
+	cmp r5, #0
+	bne _0802D1D6
+	b _0802D1A8
+_0802D168:
+	ldr r0, [r4]
+	ldrb r0, [r0, #0x1f]
+	bl GetStatIncrease
+	mov sl, r0
+	cmp r0, #0
+	bne _0802D1D6
+	ldr r0, [r4]
+	adds r0, #0x20
+	ldrb r0, [r0]
+	bl GetStatIncrease
+	mov r9, r0
+	cmp r0, #0
+	bne _0802D1D6
+	ldr r0, [r4]
+	adds r0, #0x21
+	ldrb r0, [r0]
+	bl GetStatIncrease
+	adds r7, r0, #0
+	cmp r7, #0
+	bne _0802D1D6
+	ldr r0, [r4]
+	adds r0, #0x22
+	ldrb r0, [r0]
+	bl GetStatIncrease
+	adds r6, r0, #0
+	cmp r6, #0
+	bne _0802D1D6
+	adds r5, #1
+_0802D1A8:
+	cmp r5, #1
+	bgt _0802D1D6
+	ldr r0, [r4]
+	ldrb r0, [r0, #0x1c]
+	bl GetStatIncrease
+	mov r8, r0
+	cmp r0, #0
+	bne _0802D1D6
+	ldr r0, [r4]
+	ldrb r0, [r0, #0x1d]
+	bl GetStatIncrease
+	str r0, [sp]
+	cmp r0, #0
+	bne _0802D1D6
+	ldr r0, [r4]
+	ldrb r0, [r0, #0x1e]
+	bl GetStatIncrease
+	str r0, [sp, #4]
+	cmp r0, #0
+	beq _0802D168
+_0802D1D6:
+	movs r2, #0x12
+	ldrsb r2, [r4, r2]
+	mov r0, r8
+	adds r3, r2, r0
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	movs r0, #0xc0
+	ands r0, r1
+	cmp r0, #0x80
+	bne _0802D1F0
+	cmp r3, #0x78
+	bgt _0802D1F4
+	b _0802D206
+_0802D1F0:
+	cmp r3, #0x3c
+	ble _0802D206
+_0802D1F4:
+	movs r0, #0xc0
+	ands r0, r1
+	cmp r0, #0x80
+	bne _0802D200
+	movs r0, #0x78
+	b _0802D202
+_0802D200:
+	movs r0, #0x3c
+_0802D202:
+	subs r0, r0, r2
+	mov r8, r0
+_0802D206:
+	movs r2, #0x14
+	ldrsb r2, [r4, r2]
+	ldr r1, [sp]
+	adds r0, r2, r1
+	ldr r3, [r4, #4]
+	movs r1, #0x14
+	ldrsb r1, [r3, r1]
+	cmp r0, r1
+	ble _0802D21C
+	subs r1, r1, r2
+	str r1, [sp]
+_0802D21C:
+	movs r2, #0x15
+	ldrsb r2, [r4, r2]
+	ldr r1, [sp, #4]
+	adds r0, r2, r1
+	movs r1, #0x15
+	ldrsb r1, [r3, r1]
+	cmp r0, r1
+	ble _0802D230
+	subs r1, r1, r2
+	str r1, [sp, #4]
+_0802D230:
+	movs r2, #0x16
+	ldrsb r2, [r4, r2]
+	mov r1, sl
+	adds r0, r2, r1
+	movs r1, #0x16
+	ldrsb r1, [r3, r1]
+	cmp r0, r1
+	ble _0802D244
+	subs r1, r1, r2
+	mov sl, r1
+_0802D244:
+	movs r2, #0x17
+	ldrsb r2, [r4, r2]
+	mov r1, r9
+	adds r0, r2, r1
+	movs r1, #0x17
+	ldrsb r1, [r3, r1]
+	cmp r0, r1
+	ble _0802D258
+	subs r1, r1, r2
+	mov r9, r1
+_0802D258:
+	movs r2, #0x18
+	ldrsb r2, [r4, r2]
+	adds r0, r2, r7
+	movs r1, #0x18
+	ldrsb r1, [r3, r1]
+	cmp r0, r1
+	ble _0802D268
+	subs r7, r1, r2
+_0802D268:
+	movs r1, #0x19
+	ldrsb r1, [r4, r1]
+	adds r0, r1, r6
+	cmp r0, #0x1e
+	ble _0802D276
+	movs r0, #0x1e
+	subs r6, r0, r1
+_0802D276:
+	ldrb r0, [r4, #0x12]
+	add r0, r8
+	strb r0, [r4, #0x12]
+	ldrb r0, [r4, #0x14]
+	ldr r1, [sp]
+	adds r0, r0, r1
+	strb r0, [r4, #0x14]
+	ldrb r0, [r4, #0x15]
+	ldr r1, [sp, #4]
+	adds r0, r0, r1
+	strb r0, [r4, #0x15]
+	ldrb r0, [r4, #0x16]
+	add r0, sl
+	strb r0, [r4, #0x16]
+	ldrb r0, [r4, #0x17]
+	add r0, r9
+	strb r0, [r4, #0x17]
+	ldrb r0, [r4, #0x18]
+	adds r0, r0, r7
+	strb r0, [r4, #0x18]
+	ldrb r0, [r4, #0x19]
+	adds r0, r0, r6
+	strb r0, [r4, #0x19]
+_0802D2A4:
+	add sp, #8
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_802D2B4
+sub_802D2B4: @ 0x0802D2B4
+	ldr r1, _0802D2C0  @ gUnknown_0203A608
+	ldr r0, [r1]
+	adds r0, #4
+	str r0, [r1]
+	bx lr
+	.align 2, 0
+_0802D2C0: .4byte gUnknown_0203A608
+
+	THUMB_FUNC_START sub_802D2C4
+sub_802D2C4: @ 0x0802D2C4
+	ldr r0, _0802D2DC  @ gUnknown_0203A608
+	ldr r2, [r0]
+	adds r2, #4
+	str r2, [r0]
+	ldrb r1, [r2, #2]
+	movs r0, #7
+	ands r0, r1
+	movs r1, #0x80
+	orrs r0, r1
+	strb r0, [r2, #2]
+	bx lr
+	.align 2, 0
+_0802D2DC: .4byte gUnknown_0203A608
+
+.align 2, 0

--- a/asm/bmgold.s
+++ b/asm/bmgold.s
@@ -1,0 +1,59 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ get/set party gold amount
+
+	THUMB_FUNC_START GetPartyGoldAmount
+GetPartyGoldAmount: @ 0x08024DE8
+	push {lr}
+	ldr r1, _08024DF8  @ gUnknown_0202BCF0
+	movs r0, #0xe
+	ldrsb r0, [r1, r0]
+	cmp r0, #5
+	beq _08024DFC
+	ldr r0, [r1, #8]
+	b _08024DFE
+	.align 2, 0
+_08024DF8: .4byte gUnknown_0202BCF0
+_08024DFC:
+	movs r0, #0
+_08024DFE:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START SetPartyGoldAmount
+SetPartyGoldAmount: @ 0x08024E04
+	push {lr}
+	ldr r2, _08024E18  @ gUnknown_0202BCF0
+	str r0, [r2, #8]
+	ldr r1, _08024E1C  @ 0x000F423F
+	cmp r0, r1
+	ble _08024E12
+	str r1, [r2, #8]
+_08024E12:
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08024E18: .4byte gUnknown_0202BCF0
+_08024E1C: .4byte 0x000F423F
+
+	THUMB_FUNC_START sub_8024E20
+sub_8024E20: @ 0x08024E20
+	push {lr}
+	ldr r2, _08024E38  @ gUnknown_0202BCF0
+	ldr r1, [r2, #8]
+	adds r1, r1, r0
+	str r1, [r2, #8]
+	ldr r0, _08024E3C  @ 0x000F423F
+	cmp r1, r0
+	ble _08024E32
+	str r0, [r2, #8]
+_08024E32:
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08024E38: .4byte gUnknown_0202BCF0
+_08024E3C: .4byte 0x000F423F
+
+.align 2, 0

--- a/asm/bmitemuse.s
+++ b/asm/bmitemuse.s
@@ -1,0 +1,2672 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ Item (gameplay) effects and stuff
+
+	THUMB_FUNC_START CanUnitUseItem
+CanUnitUseItem: @ 0x08028870
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	adds r0, r5, #0
+	bl GetItemAttributes
+	movs r1, #4
+	ands r1, r0
+	cmp r1, #0
+	beq _08028894
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl CanUnitUseAsStaff
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _08028894
+	b _08028C04
+_08028894:
+	adds r0, r5, #0
+	bl GetItemIndex
+	subs r0, #0x4b
+	cmp r0, #0x76
+	bls _080288A2
+	b _08028C04
+_080288A2:
+	lsls r0, r0, #2
+	ldr r1, _080288AC  @ _080288B0
+	adds r0, r0, r1
+	ldr r0, [r0]
+	mov pc, r0
+	.align 2, 0
+_080288AC: .4byte _080288B0
+_080288B0: @ jump table
+	.4byte _08028A8C @ case 0
+	.4byte _08028A8C @ case 1
+	.4byte _08028A8C @ case 2
+	.4byte _08028A9C @ case 3
+	.4byte _08028AAC @ case 4
+	.4byte _08028ABC @ case 5
+	.4byte _08028AEC @ case 6
+	.4byte _08028AFC @ case 7
+	.4byte _08028B0C @ case 8
+	.4byte _08028B1C @ case 9
+	.4byte _08028ACC @ case 10
+	.4byte _08028BC8 @ case 11
+	.4byte _08028B2C @ case 12
+	.4byte _08028B3C @ case 13
+	.4byte _08028ADC @ case 14
+	.4byte _08028C04 @ case 15
+	.4byte _08028B4C @ case 16
+	.4byte _08028B4C @ case 17
+	.4byte _08028B4C @ case 18
+	.4byte _08028B4C @ case 19
+	.4byte _08028B4C @ case 20
+	.4byte _08028B4C @ case 21
+	.4byte _08028B4C @ case 22
+	.4byte _08028B4C @ case 23
+	.4byte _08028B4C @ case 24
+	.4byte _08028B56 @ case 25
+	.4byte _08028B56 @ case 26
+	.4byte _08028B56 @ case 27
+	.4byte _08028B56 @ case 28
+	.4byte _08028B56 @ case 29
+	.4byte _08028B80 @ case 30
+	.4byte _08028B88 @ case 31
+	.4byte _08028B90 @ case 32
+	.4byte _08028B60 @ case 33
+	.4byte _08028B60 @ case 34
+	.4byte _08028B68 @ case 35
+	.4byte _08028B78 @ case 36
+	.4byte _08028B70 @ case 37
+	.4byte _08028C04 @ case 38
+	.4byte _08028C04 @ case 39
+	.4byte _08028C04 @ case 40
+	.4byte _08028C04 @ case 41
+	.4byte _08028C04 @ case 42
+	.4byte _08028C04 @ case 43
+	.4byte _08028C04 @ case 44
+	.4byte _08028C04 @ case 45
+	.4byte _08028B80 @ case 46
+	.4byte _08028BA8 @ case 47
+	.4byte _08028BB8 @ case 48
+	.4byte _08028C04 @ case 49
+	.4byte _08028BD8 @ case 50
+	.4byte _08028BD8 @ case 51
+	.4byte _08028BD8 @ case 52
+	.4byte _08028BD8 @ case 53
+	.4byte _08028C04 @ case 54
+	.4byte _08028C04 @ case 55
+	.4byte _08028C04 @ case 56
+	.4byte _08028C04 @ case 57
+	.4byte _08028C04 @ case 58
+	.4byte _08028C04 @ case 59
+	.4byte _08028C04 @ case 60
+	.4byte _08028B56 @ case 61
+	.4byte _08028BE8 @ case 62
+	.4byte _08028B56 @ case 63
+	.4byte _08028C04 @ case 64
+	.4byte _08028B98 @ case 65
+	.4byte _08028C04 @ case 66
+	.4byte _08028C04 @ case 67
+	.4byte _08028C04 @ case 68
+	.4byte _08028C04 @ case 69
+	.4byte _08028C04 @ case 70
+	.4byte _08028C04 @ case 71
+	.4byte _08028C04 @ case 72
+	.4byte _08028C04 @ case 73
+	.4byte _08028C04 @ case 74
+	.4byte _08028C04 @ case 75
+	.4byte _08028B56 @ case 76
+	.4byte _08028B56 @ case 77
+	.4byte _08028B56 @ case 78
+	.4byte _08028C04 @ case 79
+	.4byte _08028C04 @ case 80
+	.4byte _08028C04 @ case 81
+	.4byte _08028C04 @ case 82
+	.4byte _08028C04 @ case 83
+	.4byte _08028C04 @ case 84
+	.4byte _08028C04 @ case 85
+	.4byte _08028C04 @ case 86
+	.4byte _08028B60 @ case 87
+	.4byte _08028C04 @ case 88
+	.4byte _08028C04 @ case 89
+	.4byte _08028C04 @ case 90
+	.4byte _08028C04 @ case 91
+	.4byte _08028C04 @ case 92
+	.4byte _08028C04 @ case 93
+	.4byte _08028C04 @ case 94
+	.4byte _08028C04 @ case 95
+	.4byte _08028C04 @ case 96
+	.4byte _08028C04 @ case 97
+	.4byte _08028C04 @ case 98
+	.4byte _08028C04 @ case 99
+	.4byte _08028C04 @ case 100
+	.4byte _08028C04 @ case 101
+	.4byte _08028C04 @ case 102
+	.4byte _08028C04 @ case 103
+	.4byte _08028C04 @ case 104
+	.4byte _08028C04 @ case 105
+	.4byte _08028C04 @ case 106
+	.4byte _08028C04 @ case 107
+	.4byte _08028BF8 @ case 108
+	.4byte _08028C04 @ case 109
+	.4byte _08028C04 @ case 110
+	.4byte _08028C04 @ case 111
+	.4byte _08028C04 @ case 112
+	.4byte _08028C04 @ case 113
+	.4byte _08028C04 @ case 114
+	.4byte _08028C04 @ case 115
+	.4byte _08028C04 @ case 116
+	.4byte _08028C04 @ case 117
+	.4byte _08028B56 @ case 118
+_08028A8C:
+	ldr r1, _08028A98  @ MakeTargetListForAdjacentHeal
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028A98: .4byte MakeTargetListForAdjacentHeal
+_08028A9C:
+	ldr r1, _08028AA8  @ MakeTargetListForRangedHeal
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028AA8: .4byte MakeTargetListForRangedHeal
+_08028AAC:
+	ldr r1, _08028AB8  @ MakeTargetListForRangedHeal
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028AB8: .4byte MakeTargetListForRangedHeal
+_08028ABC:
+	ldr r1, _08028AC8  @ MakeTargetListForRestore
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028AC8: .4byte MakeTargetListForRestore
+_08028ACC:
+	ldr r1, _08028AD8  @ MakeTargetListForRescueStaff
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028AD8: .4byte MakeTargetListForRescueStaff
+_08028ADC:
+	ldr r1, _08028AE8  @ MakeTargetListForBarrier
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028AE8: .4byte MakeTargetListForBarrier
+_08028AEC:
+	ldr r1, _08028AF8  @ MakeTargetListForSilence
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028AF8: .4byte MakeTargetListForSilence
+_08028AFC:
+	ldr r1, _08028B08  @ MakeTargetListForSleep
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028B08: .4byte MakeTargetListForSleep
+_08028B0C:
+	ldr r1, _08028B18  @ MakeTargetListForBerserk
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028B18: .4byte MakeTargetListForBerserk
+_08028B1C:
+	ldr r1, _08028B28  @ MakeTargetListForWarp
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028B28: .4byte MakeTargetListForWarp
+_08028B2C:
+	ldr r1, _08028B38  @ MakeTargetListForHammerne
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028B38: .4byte MakeTargetListForHammerne
+_08028B3C:
+	ldr r1, _08028B48  @ MakeTargetListForUnlock
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028B48: .4byte MakeTargetListForUnlock
+_08028B4C:
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl CanUseStatBooster
+	b _08028BFE
+_08028B56:
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl CanUsePromotionItem
+	b _08028BFE
+_08028B60:
+	adds r0, r4, #0
+	bl CanUseHealingItem
+	b _08028BFE
+_08028B68:
+	adds r0, r4, #0
+	bl CanUsePureWater
+	b _08028BFE
+_08028B70:
+	adds r0, r4, #0
+	bl CanUseTorch
+	b _08028BFE
+_08028B78:
+	adds r0, r4, #0
+	bl CanUseAntidote
+	b _08028BFE
+_08028B80:
+	adds r0, r4, #0
+	bl CanUseChestKey
+	b _08028BFE
+_08028B88:
+	adds r0, r4, #0
+	bl CanUseDoorKey
+	b _08028BFE
+_08028B90:
+	adds r0, r4, #0
+	bl CanUseLockpick
+	b _08028BFE
+_08028B98:
+	ldr r1, _08028BA4  @ MakeTargetListForLatona
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028BA4: .4byte MakeTargetListForLatona
+_08028BA8:
+	ldr r1, _08028BB4  @ MakeTargetListForMine
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028BB4: .4byte MakeTargetListForMine
+_08028BB8:
+	ldr r1, _08028BC4  @ MakeTargetListForLightRune
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028BC4: .4byte MakeTargetListForLightRune
+_08028BC8:
+	ldr r0, _08028BD4  @ gUnknown_0202BCF0
+	ldrb r1, [r0, #0xd]
+	negs r0, r1
+	orrs r0, r1
+	lsrs r0, r0, #0x1f
+	b _08028C06
+	.align 2, 0
+_08028BD4: .4byte gUnknown_0202BCF0
+_08028BD8:
+	ldr r1, _08028BE4  @ MakeTargetListForDanceRing
+	adds r0, r4, #0
+	bl IsGeneratedTargetListEmpty
+	b _08028BFE
+	.align 2, 0
+_08028BE4: .4byte MakeTargetListForDanceRing
+_08028BE8:
+	ldr r0, [r4, #0xc]
+	movs r1, #0x80
+	lsls r1, r1, #6
+	ands r0, r1
+	cmp r0, #0
+	bne _08028C04
+	movs r0, #1
+	b _08028C06
+_08028BF8:
+	adds r0, r4, #0
+	bl CanUseJunaFruit
+_08028BFE:
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	b _08028C06
+_08028C04:
+	movs r0, #0
+_08028C06:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8028C0C
+sub_8028C0C: @ 0x08028C0C
+	push {r4, r5, r6, lr}
+	adds r6, r1, #0
+	adds r0, r6, #0
+	bl GetItemIndex
+	subs r0, #0x56
+	cmp r0, #0x6b
+	bls _08028C1E
+	b _08028E54
+_08028C1E:
+	lsls r0, r0, #2
+	ldr r1, _08028C28  @ _08028C2C
+	adds r0, r0, r1
+	ldr r0, [r0]
+	mov pc, r0
+	.align 2, 0
+_08028C28: .4byte _08028C2C
+_08028C2C: @ jump table
+	.4byte _08028DDC @ case 0
+	.4byte _08028E54 @ case 1
+	.4byte _08028E54 @ case 2
+	.4byte _08028E54 @ case 3
+	.4byte _08028E54 @ case 4
+	.4byte _08028DDC @ case 5
+	.4byte _08028DDC @ case 6
+	.4byte _08028DDC @ case 7
+	.4byte _08028DDC @ case 8
+	.4byte _08028DDC @ case 9
+	.4byte _08028DDC @ case 10
+	.4byte _08028DDC @ case 11
+	.4byte _08028DDC @ case 12
+	.4byte _08028DDC @ case 13
+	.4byte _08028E20 @ case 14
+	.4byte _08028E20 @ case 15
+	.4byte _08028E20 @ case 16
+	.4byte _08028E20 @ case 17
+	.4byte _08028E20 @ case 18
+	.4byte _08028DE4 @ case 19
+	.4byte _08028DEC @ case 20
+	.4byte _08028DF4 @ case 21
+	.4byte _08028DDC @ case 22
+	.4byte _08028DDC @ case 23
+	.4byte _08028DDC @ case 24
+	.4byte _08028DDC @ case 25
+	.4byte _08028DDC @ case 26
+	.4byte _08028E54 @ case 27
+	.4byte _08028E54 @ case 28
+	.4byte _08028E54 @ case 29
+	.4byte _08028E54 @ case 30
+	.4byte _08028E54 @ case 31
+	.4byte _08028E54 @ case 32
+	.4byte _08028E54 @ case 33
+	.4byte _08028E54 @ case 34
+	.4byte _08028DE4 @ case 35
+	.4byte _08028E54 @ case 36
+	.4byte _08028E54 @ case 37
+	.4byte _08028E54 @ case 38
+	.4byte _08028E54 @ case 39
+	.4byte _08028E54 @ case 40
+	.4byte _08028E54 @ case 41
+	.4byte _08028E54 @ case 42
+	.4byte _08028E54 @ case 43
+	.4byte _08028E54 @ case 44
+	.4byte _08028E54 @ case 45
+	.4byte _08028E54 @ case 46
+	.4byte _08028E54 @ case 47
+	.4byte _08028E54 @ case 48
+	.4byte _08028E54 @ case 49
+	.4byte _08028E20 @ case 50
+	.4byte _08028E54 @ case 51
+	.4byte _08028E20 @ case 52
+	.4byte _08028E54 @ case 53
+	.4byte _08028E54 @ case 54
+	.4byte _08028E54 @ case 55
+	.4byte _08028E54 @ case 56
+	.4byte _08028E54 @ case 57
+	.4byte _08028E54 @ case 58
+	.4byte _08028E54 @ case 59
+	.4byte _08028E54 @ case 60
+	.4byte _08028E54 @ case 61
+	.4byte _08028E54 @ case 62
+	.4byte _08028E54 @ case 63
+	.4byte _08028E54 @ case 64
+	.4byte _08028E20 @ case 65
+	.4byte _08028E20 @ case 66
+	.4byte _08028E20 @ case 67
+	.4byte _08028E54 @ case 68
+	.4byte _08028E54 @ case 69
+	.4byte _08028E54 @ case 70
+	.4byte _08028E54 @ case 71
+	.4byte _08028E54 @ case 72
+	.4byte _08028E54 @ case 73
+	.4byte _08028E54 @ case 74
+	.4byte _08028E54 @ case 75
+	.4byte _08028DDC @ case 76
+	.4byte _08028E54 @ case 77
+	.4byte _08028E54 @ case 78
+	.4byte _08028E54 @ case 79
+	.4byte _08028E54 @ case 80
+	.4byte _08028E54 @ case 81
+	.4byte _08028E54 @ case 82
+	.4byte _08028E54 @ case 83
+	.4byte _08028E54 @ case 84
+	.4byte _08028E54 @ case 85
+	.4byte _08028E54 @ case 86
+	.4byte _08028E54 @ case 87
+	.4byte _08028E54 @ case 88
+	.4byte _08028E54 @ case 89
+	.4byte _08028E54 @ case 90
+	.4byte _08028E54 @ case 91
+	.4byte _08028E54 @ case 92
+	.4byte _08028E54 @ case 93
+	.4byte _08028E54 @ case 94
+	.4byte _08028E54 @ case 95
+	.4byte _08028E54 @ case 96
+	.4byte _08028E4C @ case 97
+	.4byte _08028E54 @ case 98
+	.4byte _08028E54 @ case 99
+	.4byte _08028E54 @ case 100
+	.4byte _08028E54 @ case 101
+	.4byte _08028E54 @ case 102
+	.4byte _08028E54 @ case 103
+	.4byte _08028E54 @ case 104
+	.4byte _08028E54 @ case 105
+	.4byte _08028E54 @ case 106
+	.4byte _08028E20 @ case 107
+_08028DDC:
+	ldr r0, _08028DE0  @ 0x00000859
+	b _08028E56
+	.align 2, 0
+_08028DE0: .4byte 0x00000859
+_08028DE4:
+	ldr r0, _08028DE8  @ 0x0000085E
+	b _08028E56
+	.align 2, 0
+_08028DE8: .4byte 0x0000085E
+_08028DEC:
+	ldr r0, _08028DF0  @ 0x0000085D
+	b _08028E56
+	.align 2, 0
+_08028DF0: .4byte 0x0000085D
+_08028DF4:
+	ldr r0, _08028E10  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldr r1, [r0]
+	ldr r2, [r0, #4]
+	ldr r0, [r1, #0x28]
+	ldr r1, [r2, #0x28]
+	orrs r0, r1
+	movs r1, #8
+	ands r0, r1
+	cmp r0, #0
+	beq _08028E18
+	ldr r0, _08028E14  @ 0x00000861
+	b _08028E56
+	.align 2, 0
+_08028E10: .4byte gUnknown_03004E50
+_08028E14: .4byte 0x00000861
+_08028E18:
+	ldr r0, _08028E1C  @ 0x0000085F
+	b _08028E56
+	.align 2, 0
+_08028E1C: .4byte 0x0000085F
+_08028E20:
+	ldr r4, _08028E44  @ gUnknown_03004E50
+	ldr r1, [r4]
+	movs r5, #8
+	ldrsb r5, [r1, r5]
+	movs r0, #0xa
+	strb r0, [r1, #8]
+	ldr r0, [r4]
+	adds r1, r6, #0
+	bl CanUsePromotionItem
+	ldr r1, [r4]
+	strb r5, [r1, #8]
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08028E54
+	ldr r0, _08028E48  @ 0x0000085B
+	b _08028E56
+	.align 2, 0
+_08028E44: .4byte gUnknown_03004E50
+_08028E48: .4byte 0x0000085B
+_08028E4C:
+	ldr r0, _08028E50  @ 0x0000085C
+	b _08028E56
+	.align 2, 0
+_08028E50: .4byte 0x0000085C
+_08028E54:
+	ldr r0, _08028E5C  @ 0x0000085A
+_08028E56:
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08028E5C: .4byte 0x0000085A
+
+	THUMB_FUNC_START ItemEffect_Call
+ItemEffect_Call: @ 0x08028E60
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	adds r4, r1, #0
+	bl ClearBG0BG1
+	movs r0, #0
+	bl DeleteFaceByIndex
+	adds r0, r4, #0
+	bl GetItemIndex
+	subs r0, #0x4b
+	cmp r0, #0x41
+	bls _08028E7E
+	b _0802905C
+_08028E7E:
+	lsls r0, r0, #2
+	ldr r1, _08028E88  @ _08028E8C
+	adds r0, r0, r1
+	ldr r0, [r0]
+	mov pc, r0
+	.align 2, 0
+_08028E88: .4byte _08028E8C
+_08028E8C: @ jump table
+	.4byte _08028F94 @ case 0
+	.4byte _08028F94 @ case 1
+	.4byte _08028F94 @ case 2
+	.4byte _08028F9C @ case 3
+	.4byte _08029014 @ case 4
+	.4byte _08028FBC @ case 5
+	.4byte _08028FCC @ case 6
+	.4byte _08028FD4 @ case 7
+	.4byte _08028FDC @ case 8
+	.4byte _08029004 @ case 9
+	.4byte _08028FAC @ case 10
+	.4byte _08029040 @ case 11
+	.4byte _0802900C @ case 12
+	.4byte _08028FF4 @ case 13
+	.4byte _08028FEC @ case 14
+	.4byte _0802905C @ case 15
+	.4byte _0802905C @ case 16
+	.4byte _0802905C @ case 17
+	.4byte _0802905C @ case 18
+	.4byte _0802905C @ case 19
+	.4byte _0802905C @ case 20
+	.4byte _0802905C @ case 21
+	.4byte _0802905C @ case 22
+	.4byte _0802905C @ case 23
+	.4byte _0802905C @ case 24
+	.4byte _0802905C @ case 25
+	.4byte _0802905C @ case 26
+	.4byte _0802905C @ case 27
+	.4byte _0802905C @ case 28
+	.4byte _0802905C @ case 29
+	.4byte _0802905C @ case 30
+	.4byte _0802905C @ case 31
+	.4byte _0802905C @ case 32
+	.4byte _0802905C @ case 33
+	.4byte _0802905C @ case 34
+	.4byte _0802905C @ case 35
+	.4byte _0802905C @ case 36
+	.4byte _0802905C @ case 37
+	.4byte _0802905C @ case 38
+	.4byte _0802905C @ case 39
+	.4byte _0802905C @ case 40
+	.4byte _0802905C @ case 41
+	.4byte _0802905C @ case 42
+	.4byte _0802905C @ case 43
+	.4byte _0802905C @ case 44
+	.4byte _0802905C @ case 45
+	.4byte _0802905C @ case 46
+	.4byte _0802901C @ case 47
+	.4byte _0802902C @ case 48
+	.4byte _0802905C @ case 49
+	.4byte _08029048 @ case 50
+	.4byte _08029048 @ case 51
+	.4byte _08029048 @ case 52
+	.4byte _08029048 @ case 53
+	.4byte _0802905C @ case 54
+	.4byte _0802905C @ case 55
+	.4byte _0802905C @ case 56
+	.4byte _0802905C @ case 57
+	.4byte _0802905C @ case 58
+	.4byte _0802905C @ case 59
+	.4byte _0802905C @ case 60
+	.4byte _0802905C @ case 61
+	.4byte _0802905C @ case 62
+	.4byte _0802905C @ case 63
+	.4byte _0802905C @ case 64
+	.4byte _08029014 @ case 65
+_08028F94:
+	ldr r1, _08028F98  @ MakeTargetListForAdjacentHeal
+	b _08028F9E
+	.align 2, 0
+_08028F98: .4byte MakeTargetListForAdjacentHeal
+_08028F9C:
+	ldr r1, _08028FA8  @ MakeTargetListForRangedHeal
+_08028F9E:
+	adds r0, r5, #0
+	bl PrepareTargetSelectionForHeal
+	b _08029062
+	.align 2, 0
+_08028FA8: .4byte MakeTargetListForRangedHeal
+_08028FAC:
+	ldr r1, _08028FB8  @ MakeTargetListForRescueStaff
+	adds r0, r5, #0
+	bl PrepareTargetSelectionForRescueStaff
+	b _08029062
+	.align 2, 0
+_08028FB8: .4byte MakeTargetListForRescueStaff
+_08028FBC:
+	ldr r1, _08028FC8  @ MakeTargetListForRestore
+	adds r0, r5, #0
+	bl PrepareTargetSelectionForRestoreStaff
+	b _08029062
+	.align 2, 0
+_08028FC8: .4byte MakeTargetListForRestore
+_08028FCC:
+	ldr r1, _08028FD0  @ MakeTargetListForSilence
+	b _08028FDE
+	.align 2, 0
+_08028FD0: .4byte MakeTargetListForSilence
+_08028FD4:
+	ldr r1, _08028FD8  @ MakeTargetListForSleep
+	b _08028FDE
+	.align 2, 0
+_08028FD8: .4byte MakeTargetListForSleep
+_08028FDC:
+	ldr r1, _08028FE8  @ MakeTargetListForBerserk
+_08028FDE:
+	adds r0, r5, #0
+	bl PrepareTargetSelectionForOffensiveStaff
+	b _08029062
+	.align 2, 0
+_08028FE8: .4byte MakeTargetListForBerserk
+_08028FEC:
+	adds r0, r5, #0
+	bl sub_8029C34
+	b _08029062
+_08028FF4:
+	ldr r1, _08028FFC  @ MakeTargetListForUnlock
+	ldr r2, _08029000  @ 0x0000087A
+	b _08029030
+	.align 2, 0
+_08028FFC: .4byte MakeTargetListForUnlock
+_08029000: .4byte 0x0000087A
+_08029004:
+	adds r0, r5, #0
+	bl SetupWarpTargetSelection
+	b _08029062
+_0802900C:
+	adds r0, r5, #0
+	bl SetupHammerneUseSelection
+	b _08029062
+_08029014:
+	adds r0, r5, #0
+	bl EndItemEffectSelectionThing
+	b _08029062
+_0802901C:
+	ldr r1, _08029024  @ MakeTargetListForMine
+	ldr r2, _08029028  @ 0x0000087D
+	b _08029030
+	.align 2, 0
+_08029024: .4byte MakeTargetListForMine
+_08029028: .4byte 0x0000087D
+_0802902C:
+	ldr r1, _08029038  @ MakeTargetListForLightRune
+	ldr r2, _0802903C  @ 0x0000087E
+_08029030:
+	adds r0, r5, #0
+	bl PrepareTargetSelectionForMineAndLightRune
+	b _08029062
+	.align 2, 0
+_08029038: .4byte MakeTargetListForLightRune
+_0802903C: .4byte 0x0000087E
+_08029040:
+	adds r0, r5, #0
+	bl NewTorchStaffSelection
+	b _08029062
+_08029048:
+	ldr r1, _08029054  @ MakeTargetListForDanceRing
+	ldr r2, _08029058  @ 0x0000087F
+	adds r0, r5, #0
+	bl SetupTargetSelectionForGenericStaff
+	b _08029062
+	.align 2, 0
+_08029054: .4byte MakeTargetListForDanceRing
+_08029058: .4byte 0x0000087F
+_0802905C:
+	adds r0, r5, #0
+	bl sub_8029544
+_08029062:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START IsGeneratedTargetListEmpty
+IsGeneratedTargetListEmpty: @ 0x08029068
+	push {lr}
+	bl _call_via_r1
+	bl sub_804FD28
+	cmp r0, #0
+	beq _08029078
+	movs r0, #1
+_08029078:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START CanUseHealingItem
+CanUseHealingItem: @ 0x0802907C
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	bl GetUnitCurrentHP
+	adds r5, r0, #0
+	adds r0, r4, #0
+	bl GetUnitMaxHP
+	cmp r5, r0
+	beq _08029094
+	movs r0, #1
+	b _08029096
+_08029094:
+	movs r0, #0
+_08029096:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_802909C
+sub_802909C: @ 0x0802909C
+	movs r0, #0
+	bx lr
+
+	THUMB_FUNC_START CanUsePureWater
+CanUsePureWater: @ 0x080290A0
+	push {lr}
+	adds r0, #0x31
+	ldrb r1, [r0]
+	movs r0, #0xf0
+	ands r0, r1
+	cmp r0, #0x70
+	beq _080290B2
+	movs r0, #1
+	b _080290B4
+_080290B2:
+	movs r0, #0
+_080290B4:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START CanUseTorch
+CanUseTorch: @ 0x080290B8
+	push {lr}
+	adds r1, r0, #0
+	ldr r0, _080290D8  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xd]
+	cmp r0, #0
+	beq _080290DC
+	adds r0, r1, #0
+	adds r0, #0x31
+	ldrb r1, [r0]
+	movs r0, #0xf
+	ands r0, r1
+	cmp r0, #4
+	beq _080290DC
+	movs r0, #1
+	b _080290DE
+	.align 2, 0
+_080290D8: .4byte gUnknown_0202BCF0
+_080290DC:
+	movs r0, #0
+_080290DE:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START CanUseAntidote
+CanUseAntidote: @ 0x080290E4
+	push {lr}
+	adds r0, #0x30
+	ldrb r1, [r0]
+	movs r0, #0xf
+	ands r0, r1
+	cmp r0, #1
+	bne _080290F6
+	movs r0, #1
+	b _080290F8
+_080290F6:
+	movs r0, #0
+_080290F8:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START CanUseChestKey
+CanUseChestKey: @ 0x080290FC
+	push {lr}
+	movs r3, #0x11
+	ldrsb r3, [r0, r3]
+	ldr r1, _0802912C  @ gUnknown_0202E4DC
+	ldr r2, [r1]
+	lsls r1, r3, #2
+	adds r1, r1, r2
+	movs r2, #0x10
+	ldrsb r2, [r0, r2]
+	ldr r0, [r1]
+	adds r0, r0, r2
+	ldrb r0, [r0]
+	cmp r0, #0x21
+	bne _08029130
+	adds r0, r2, #0
+	adds r1, r3, #0
+	bl IsThereClosedChestAt
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08029130
+	movs r0, #1
+	b _08029132
+	.align 2, 0
+_0802912C: .4byte gUnknown_0202E4DC
+_08029130:
+	movs r0, #0
+_08029132:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START CanUseDoorKey
+CanUseDoorKey: @ 0x08029138
+	push {lr}
+	movs r1, #0x1e
+	bl MakeTargetListForDoorAndBridges
+	bl sub_804FD28
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START CanOpenBridge
+CanOpenBridge: @ 0x0802914C
+	push {lr}
+	movs r1, #0x14
+	bl MakeTargetListForDoorAndBridges
+	bl sub_804FD28
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START CanUseLockpick
+CanUseLockpick: @ 0x08029160
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, [r4]
+	ldr r1, [r4, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	movs r1, #8
+	ands r0, r1
+	cmp r0, #0
+	beq _0802919A
+	adds r0, r4, #0
+	bl CanUseChestKey
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802919E
+	adds r0, r4, #0
+	bl CanUseDoorKey
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802919E
+	adds r0, r4, #0
+	bl CanOpenBridge
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802919E
+_0802919A:
+	movs r0, #0
+	b _080291A0
+_0802919E:
+	movs r0, #1
+_080291A0:
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START CanUsePromotionItem
+CanUsePromotionItem: @ 0x080291A8
+	push {r4, r5, r6, lr}
+	adds r5, r0, #0
+	adds r6, r1, #0
+	movs r4, #0
+	ldr r0, [r5]
+	ldrb r0, [r0, #4]
+	cmp r0, #1
+	beq _080291BC
+	cmp r0, #0xf
+	bne _080291F2
+_080291BC:
+	adds r0, r6, #0
+	bl GetItemIndex
+	cmp r0, #0x98
+	beq _080291CC
+	cmp r0, #0x99
+	beq _080291D4
+	b _080291D6
+_080291CC:
+	ldr r4, _080291D0  @ gUnknown_088ADFA4
+	b _080291D6
+	.align 2, 0
+_080291D0: .4byte gUnknown_088ADFA4
+_080291D4:
+	ldr r4, _08029214  @ gUnknown_088ADFA6
+_080291D6:
+	cmp r4, #0
+	beq _080291F2
+	ldrb r1, [r4]
+	cmp r1, #0
+	beq _080291F2
+	ldr r0, [r5, #4]
+	ldrb r0, [r0, #4]
+_080291E4:
+	cmp r0, r1
+	bne _080291EA
+	b _080293E4
+_080291EA:
+	adds r4, #1
+	ldrb r1, [r4]
+	cmp r1, #0
+	bne _080291E4
+_080291F2:
+	movs r0, #8
+	ldrsb r0, [r5, r0]
+	cmp r0, #9
+	bgt _080291FC
+	b _08029400
+_080291FC:
+	adds r0, r6, #0
+	bl GetItemIndex
+	subs r0, #0x64
+	cmp r0, #0x5d
+	bls _0802920A
+	b _080293EA
+_0802920A:
+	lsls r0, r0, #2
+	ldr r1, _08029218  @ _0802921C
+	adds r0, r0, r1
+	ldr r0, [r0]
+	mov pc, r0
+	.align 2, 0
+_08029214: .4byte gUnknown_088ADFA6
+_08029218: .4byte _0802921C
+_0802921C: @ jump table
+	.4byte _08029394 @ case 0
+	.4byte _0802939C @ case 1
+	.4byte _080293A4 @ case 2
+	.4byte _080293AC @ case 3
+	.4byte _080293B4 @ case 4
+	.4byte _080293EA @ case 5
+	.4byte _080293EA @ case 6
+	.4byte _080293EA @ case 7
+	.4byte _080293EA @ case 8
+	.4byte _080293EA @ case 9
+	.4byte _080293EA @ case 10
+	.4byte _080293EA @ case 11
+	.4byte _080293EA @ case 12
+	.4byte _080293EA @ case 13
+	.4byte _080293EA @ case 14
+	.4byte _080293EA @ case 15
+	.4byte _080293EA @ case 16
+	.4byte _080293EA @ case 17
+	.4byte _080293EA @ case 18
+	.4byte _080293EA @ case 19
+	.4byte _080293EA @ case 20
+	.4byte _080293EA @ case 21
+	.4byte _080293EA @ case 22
+	.4byte _080293EA @ case 23
+	.4byte _080293EA @ case 24
+	.4byte _080293EA @ case 25
+	.4byte _080293EA @ case 26
+	.4byte _080293EA @ case 27
+	.4byte _080293EA @ case 28
+	.4byte _080293EA @ case 29
+	.4byte _080293EA @ case 30
+	.4byte _080293EA @ case 31
+	.4byte _080293EA @ case 32
+	.4byte _080293EA @ case 33
+	.4byte _080293EA @ case 34
+	.4byte _080293EA @ case 35
+	.4byte _080293BC @ case 36
+	.4byte _080293EA @ case 37
+	.4byte _080293D4 @ case 38
+	.4byte _080293EA @ case 39
+	.4byte _080293EA @ case 40
+	.4byte _080293EA @ case 41
+	.4byte _080293EA @ case 42
+	.4byte _080293EA @ case 43
+	.4byte _080293EA @ case 44
+	.4byte _080293EA @ case 45
+	.4byte _080293EA @ case 46
+	.4byte _080293EA @ case 47
+	.4byte _080293EA @ case 48
+	.4byte _080293EA @ case 49
+	.4byte _080293EA @ case 50
+	.4byte _080293E8 @ case 51
+	.4byte _080293C4 @ case 52
+	.4byte _080293CC @ case 53
+	.4byte _080293EA @ case 54
+	.4byte _080293EA @ case 55
+	.4byte _080293EA @ case 56
+	.4byte _080293EA @ case 57
+	.4byte _080293EA @ case 58
+	.4byte _080293EA @ case 59
+	.4byte _080293EA @ case 60
+	.4byte _080293EA @ case 61
+	.4byte _080293EA @ case 62
+	.4byte _080293EA @ case 63
+	.4byte _080293EA @ case 64
+	.4byte _080293EA @ case 65
+	.4byte _080293EA @ case 66
+	.4byte _080293EA @ case 67
+	.4byte _080293EA @ case 68
+	.4byte _080293EA @ case 69
+	.4byte _080293EA @ case 70
+	.4byte _080293EA @ case 71
+	.4byte _080293EA @ case 72
+	.4byte _080293EA @ case 73
+	.4byte _080293EA @ case 74
+	.4byte _080293EA @ case 75
+	.4byte _080293EA @ case 76
+	.4byte _080293EA @ case 77
+	.4byte _080293EA @ case 78
+	.4byte _080293EA @ case 79
+	.4byte _080293EA @ case 80
+	.4byte _080293EA @ case 81
+	.4byte _080293EA @ case 82
+	.4byte _080293EA @ case 83
+	.4byte _080293EA @ case 84
+	.4byte _080293EA @ case 85
+	.4byte _080293EA @ case 86
+	.4byte _080293EA @ case 87
+	.4byte _080293EA @ case 88
+	.4byte _080293EA @ case 89
+	.4byte _080293EA @ case 90
+	.4byte _080293EA @ case 91
+	.4byte _080293EA @ case 92
+	.4byte _080293DC @ case 93
+_08029394:
+	ldr r4, _08029398  @ gUnknown_088ADF57
+	b _080293EA
+	.align 2, 0
+_08029398: .4byte gUnknown_088ADF57
+_0802939C:
+	ldr r4, _080293A0  @ gUnknown_088ADF5E
+	b _080293EA
+	.align 2, 0
+_080293A0: .4byte gUnknown_088ADF5E
+_080293A4:
+	ldr r4, _080293A8  @ gUnknown_088ADF64
+	b _080293EA
+	.align 2, 0
+_080293A8: .4byte gUnknown_088ADF64
+_080293AC:
+	ldr r4, _080293B0  @ gUnknown_088ADF67
+	b _080293EA
+	.align 2, 0
+_080293B0: .4byte gUnknown_088ADF67
+_080293B4:
+	ldr r4, _080293B8  @ gUnknown_088ADF6B
+	b _080293EA
+	.align 2, 0
+_080293B8: .4byte gUnknown_088ADF6B
+_080293BC:
+	ldr r4, _080293C0  @ gUnknown_088ADF76
+	b _080293EA
+	.align 2, 0
+_080293C0: .4byte gUnknown_088ADF76
+_080293C4:
+	ldr r4, _080293C8  @ gUnknown_088ADFA4
+	b _080293EA
+	.align 2, 0
+_080293C8: .4byte gUnknown_088ADFA4
+_080293CC:
+	ldr r4, _080293D0  @ gUnknown_088ADFA6
+	b _080293EA
+	.align 2, 0
+_080293D0: .4byte gUnknown_088ADFA6
+_080293D4:
+	ldr r4, _080293D8  @ gUnknown_088ADF96
+	b _080293EA
+	.align 2, 0
+_080293D8: .4byte gUnknown_088ADF96
+_080293DC:
+	ldr r4, _080293E0  @ gUnknown_088ADFA3
+	b _080293EA
+	.align 2, 0
+_080293E0: .4byte gUnknown_088ADFA3
+_080293E4:
+	movs r0, #1
+	b _08029402
+_080293E8:
+	ldr r4, _08029408  @ gUnknown_088ADF9E
+_080293EA:
+	ldrb r1, [r4]
+	cmp r1, #0
+	beq _08029400
+	ldr r0, [r5, #4]
+	ldrb r0, [r0, #4]
+_080293F4:
+	cmp r0, r1
+	beq _080293E4
+	adds r4, #1
+	ldrb r1, [r4]
+	cmp r1, #0
+	bne _080293F4
+_08029400:
+	movs r0, #0
+_08029402:
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08029408: .4byte gUnknown_088ADF9E
+
+	THUMB_FUNC_START CanUseStatBooster
+CanUseStatBooster: @ 0x0802940C
+	push {r4, r5, r6, lr}
+	adds r5, r0, #0
+	adds r0, r1, #0
+	bl GetItemStatBonusesPtr
+	adds r4, r0, #0
+	ldr r6, _08029500  @ gUnknown_03004C00
+	adds r0, r6, #0
+	bl ClearUnitStruct
+	ldr r0, [r5]
+	str r0, [r6]
+	ldr r0, [r5, #4]
+	str r0, [r6, #4]
+	ldrb r0, [r4]
+	ldrb r1, [r5, #0x12]
+	adds r0, r0, r1
+	strb r0, [r6, #0x12]
+	ldrb r0, [r4, #1]
+	ldrb r1, [r5, #0x14]
+	adds r0, r0, r1
+	strb r0, [r6, #0x14]
+	ldrb r0, [r4, #2]
+	ldrb r1, [r5, #0x15]
+	adds r0, r0, r1
+	strb r0, [r6, #0x15]
+	ldrb r0, [r4, #3]
+	ldrb r1, [r5, #0x16]
+	adds r0, r0, r1
+	strb r0, [r6, #0x16]
+	ldrb r0, [r4, #4]
+	ldrb r1, [r5, #0x17]
+	adds r0, r0, r1
+	strb r0, [r6, #0x17]
+	ldrb r0, [r4, #5]
+	ldrb r1, [r5, #0x18]
+	adds r0, r0, r1
+	strb r0, [r6, #0x18]
+	ldrb r0, [r4, #6]
+	ldrb r1, [r5, #0x19]
+	adds r0, r0, r1
+	strb r0, [r6, #0x19]
+	ldrb r0, [r4, #7]
+	ldrb r1, [r5, #0x1d]
+	adds r0, r0, r1
+	strb r0, [r6, #0x1d]
+	ldrb r0, [r4, #8]
+	ldrb r1, [r5, #0x1a]
+	adds r0, r0, r1
+	strb r0, [r6, #0x1a]
+	adds r0, r6, #0
+	bl CheckForStatCaps
+	movs r1, #0x12
+	ldrsb r1, [r6, r1]
+	movs r0, #0x12
+	ldrsb r0, [r5, r0]
+	eors r1, r0
+	negs r0, r1
+	orrs r0, r1
+	lsrs r2, r0, #0x1f
+	movs r1, #0x14
+	ldrsb r1, [r6, r1]
+	movs r0, #0x14
+	ldrsb r0, [r5, r0]
+	cmp r1, r0
+	beq _08029494
+	movs r2, #1
+_08029494:
+	movs r1, #0x15
+	ldrsb r1, [r6, r1]
+	movs r0, #0x15
+	ldrsb r0, [r5, r0]
+	cmp r1, r0
+	beq _080294A2
+	movs r2, #1
+_080294A2:
+	movs r1, #0x16
+	ldrsb r1, [r6, r1]
+	movs r0, #0x16
+	ldrsb r0, [r5, r0]
+	cmp r1, r0
+	beq _080294B0
+	movs r2, #1
+_080294B0:
+	movs r1, #0x17
+	ldrsb r1, [r6, r1]
+	movs r0, #0x17
+	ldrsb r0, [r5, r0]
+	cmp r1, r0
+	beq _080294BE
+	movs r2, #1
+_080294BE:
+	movs r1, #0x18
+	ldrsb r1, [r6, r1]
+	movs r0, #0x18
+	ldrsb r0, [r5, r0]
+	cmp r1, r0
+	beq _080294CC
+	movs r2, #1
+_080294CC:
+	movs r1, #0x19
+	ldrsb r1, [r6, r1]
+	movs r0, #0x19
+	ldrsb r0, [r5, r0]
+	cmp r1, r0
+	beq _080294DA
+	movs r2, #1
+_080294DA:
+	movs r1, #0x1d
+	ldrsb r1, [r6, r1]
+	movs r0, #0x1d
+	ldrsb r0, [r5, r0]
+	cmp r1, r0
+	beq _080294E8
+	movs r2, #1
+_080294E8:
+	movs r1, #0x1a
+	ldrsb r1, [r6, r1]
+	movs r0, #0x1a
+	ldrsb r0, [r5, r0]
+	cmp r1, r0
+	beq _080294F6
+	movs r2, #1
+_080294F6:
+	adds r0, r2, #0
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08029500: .4byte gUnknown_03004C00
+
+	THUMB_FUNC_START CanUseJunaFruit
+CanUseJunaFruit: @ 0x08029504
+	push {lr}
+	movs r1, #0
+	ldrb r0, [r0, #8]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #9
+	ble _08029514
+	movs r1, #1
+_08029514:
+	adds r0, r1, #0
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START EndItemEffectSelectionThing
+EndItemEffectSelectionThing: @ 0x0802951C
+	push {lr}
+	bl HideMoveRangeGraphics
+	ldr r0, _0802953C  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #4
+	bl BG_EnableSyncByMask
+	ldr r1, _08029540  @ gUnknown_0203A958
+	movs r0, #3
+	strb r0, [r1, #0x11]
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802953C: .4byte gBG2TilemapBuffer
+_08029540: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START sub_8029544
+sub_8029544: @ 0x08029544
+	ldr r1, _0802954C  @ gUnknown_0203A958
+	movs r0, #0x1a
+	strb r0, [r1, #0x11]
+	bx lr
+	.align 2, 0
+_0802954C: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START GenericStaffSelection_OnSelect
+GenericStaffSelection_OnSelect: @ 0x08029550
+	push {lr}
+	ldr r2, _08029564  @ gUnknown_0203A958
+	ldrb r0, [r1, #2]
+	strb r0, [r2, #0xd]
+	movs r0, #0
+	bl EndItemEffectSelectionThing
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08029564: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START PrepareTargetSelectionForRescueStaff
+PrepareTargetSelectionForRescueStaff: @ 0x08029568
+	push {r4, lr}
+	bl _call_via_r1
+	ldr r0, _08029598  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	movs r1, #1
+	negs r1, r1
+	bl ClearMapWith
+	ldr r0, _0802959C  @ gUnknown_0859D2F8
+	ldr r1, _080295A0  @ GenericStaffSelection_OnSelect
+	bl NewTargetSelection_Specialized
+	adds r4, r0, #0
+	ldr r0, _080295A4  @ 0x00000876
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08029598: .4byte gUnknown_0202E4E0
+_0802959C: .4byte gUnknown_0859D2F8
+_080295A0: .4byte GenericStaffSelection_OnSelect
+_080295A4: .4byte 0x00000876
+
+	THUMB_FUNC_START SetupTargetSelectionForGenericStaff
+SetupTargetSelectionForGenericStaff: @ 0x080295A8
+	push {r4, r5, lr}
+	adds r5, r2, #0
+	bl _call_via_r1
+	ldr r0, _080295DC  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	movs r1, #1
+	negs r1, r1
+	bl ClearMapWith
+	ldr r0, _080295E0  @ gUnknown_0859D2F8
+	ldr r1, _080295E4  @ GenericStaffSelection_OnSelect
+	bl NewTargetSelection_Specialized
+	adds r4, r0, #0
+	adds r0, r5, #0
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080295DC: .4byte gUnknown_0202E4E0
+_080295E0: .4byte gUnknown_0859D2F8
+_080295E4: .4byte GenericStaffSelection_OnSelect
+
+	THUMB_FUNC_START WarpTargetPosSelect_Init
+WarpTargetPosSelect_Init: @ 0x080295E8
+	push {r4, r5, r6, lr}
+	mov r6, r8
+	push {r6}
+	adds r6, r0, #0
+	ldr r0, _08029688  @ 0x00000871
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r6, #0
+	bl NewBottomHelpText
+	ldr r5, _0802968C  @ gUnknown_0203A958
+	ldrb r0, [r5, #0xd]
+	bl GetUnitStruct
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	ldrb r0, [r5, #0xd]
+	bl GetUnitStruct
+	movs r2, #0x11
+	ldrsb r2, [r0, r2]
+	adds r0, r6, #0
+	adds r1, r4, #0
+	bl EnsureCameraOntoPosition
+	bl HideMoveRangeGraphics
+	ldr r0, _08029690  @ gUnknown_03004E50
+	ldr r4, [r0]
+	ldrb r0, [r5, #0xd]
+	bl GetUnitStruct
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl FillWarpRangeMap
+	ldr r2, _08029694  @ gUnknown_0202BCB0
+	ldrb r1, [r2, #4]
+	movs r0, #0xfd
+	ands r0, r1
+	movs r1, #0
+	mov r8, r1
+	strb r0, [r2, #4]
+	movs r0, #1
+	bl DisplayMoveRangeGraphics
+	ldrb r0, [r5, #0xd]
+	bl GetUnitStruct
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	ldrb r0, [r5, #0xd]
+	bl GetUnitStruct
+	movs r1, #0x11
+	ldrsb r1, [r0, r1]
+	adds r0, r4, #0
+	bl SetCursorMapPosition
+	ldr r0, _08029698  @ gUnknown_085A0EA0
+	movs r1, #0
+	bl AP_Create
+	adds r4, r0, #0
+	mov r0, r8
+	strh r0, [r4, #0x22]
+	adds r0, r4, #0
+	movs r1, #0
+	bl AP_SwitchAnimation
+	str r4, [r6, #0x54]
+	adds r6, #0x4a
+	movs r0, #2
+	strh r0, [r6]
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08029688: .4byte 0x00000871
+_0802968C: .4byte gUnknown_0203A958
+_08029690: .4byte gUnknown_03004E50
+_08029694: .4byte gUnknown_0202BCB0
+_08029698: .4byte gUnknown_085A0EA0
+
+	THUMB_FUNC_START WarpTargetPosSelect_Loop
+WarpTargetPosSelect_Loop: @ 0x0802969C
+	push {r4, r5, r6, lr}
+	adds r5, r0, #0
+	ldr r4, _08029714  @ gUnknown_0202BCB0
+	movs r1, #0x16
+	ldrsh r0, [r4, r1]
+	ldr r1, _08029718  @ gUnknown_0202E4E0
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r2, #0x14
+	ldrsh r1, [r4, r2]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	movs r1, #0
+	ldrsb r1, [r0, r1]
+	mvns r1, r1
+	negs r0, r1
+	orrs r0, r1
+	lsrs r6, r0, #0x1f
+	bl HandlePlayerCursorMovement
+	ldr r0, _0802971C  @ gKeyStatusPtr
+	ldr r0, [r0]
+	ldrh r1, [r0, #8]
+	movs r0, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _08029742
+	cmp r6, #0
+	beq _08029730
+	adds r0, r5, #0
+	bl Proc_ClearNativeCallback
+	ldr r1, _08029720  @ gUnknown_0203A958
+	ldrh r0, [r4, #0x14]
+	strb r0, [r1, #0x13]
+	ldrh r0, [r4, #0x16]
+	strb r0, [r1, #0x14]
+	ldr r0, _08029724  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl EndItemEffectSelectionThing
+	ldr r0, _08029728  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #4
+	bl BG_EnableSyncByMask
+	ldr r0, _0802972C  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _080297BA
+	movs r0, #0x6a
+	bl m4aSongNumStart
+	b _080297BA
+	.align 2, 0
+_08029714: .4byte gUnknown_0202BCB0
+_08029718: .4byte gUnknown_0202E4E0
+_0802971C: .4byte gKeyStatusPtr
+_08029720: .4byte gUnknown_0203A958
+_08029724: .4byte gUnknown_03004E50
+_08029728: .4byte gBG2TilemapBuffer
+_0802972C: .4byte gUnknown_0202BCF0
+_08029730:
+	ldr r0, _080297C0  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _08029742
+	movs r0, #0x6c
+	bl m4aSongNumStart
+_08029742:
+	ldr r0, _080297C4  @ gKeyStatusPtr
+	ldr r0, [r0]
+	ldrh r1, [r0, #8]
+	movs r0, #2
+	ands r0, r1
+	cmp r0, #0
+	beq _08029778
+	adds r0, r5, #0
+	movs r1, #0x63
+	bl Proc_GotoLabel
+	ldr r0, _080297C8  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #4
+	bl BG_EnableSyncByMask
+	ldr r0, _080297C0  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _08029778
+	movs r0, #0x6b
+	bl m4aSongNumStart
+_08029778:
+	lsls r0, r6, #0x18
+	asrs r3, r0, #0x18
+	adds r1, r5, #0
+	adds r1, #0x4a
+	movs r4, #0
+	ldrsh r2, [r1, r4]
+	adds r4, r0, #0
+	adds r6, r1, #0
+	cmp r3, r2
+	beq _0802979A
+	ldr r0, [r5, #0x54]
+	movs r1, #0
+	cmp r3, #0
+	bne _08029796
+	movs r1, #1
+_08029796:
+	bl AP_SwitchAnimation
+_0802979A:
+	ldr r0, [r5, #0x54]
+	ldr r3, _080297CC  @ gUnknown_0202BCB0
+	movs r5, #0x20
+	ldrsh r1, [r3, r5]
+	movs r5, #0xc
+	ldrsh r2, [r3, r5]
+	subs r1, r1, r2
+	movs r5, #0x22
+	ldrsh r2, [r3, r5]
+	movs r5, #0xe
+	ldrsh r3, [r3, r5]
+	subs r2, r2, r3
+	bl AP_Update
+	asrs r0, r4, #0x18
+	strh r0, [r6]
+_080297BA:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080297C0: .4byte gUnknown_0202BCF0
+_080297C4: .4byte gKeyStatusPtr
+_080297C8: .4byte gBG2TilemapBuffer
+_080297CC: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START WarpTargetPosSelect_Confirm
+WarpTargetPosSelect_Confirm: @ 0x080297D0
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	bl sub_8003D20
+	bl HideMoveRangeGraphics
+	bl DeleteEach6CBB
+	ldr r4, _08029808  @ gUnknown_03004E50
+	ldr r1, [r4]
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	ldrb r1, [r1, #0x11]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl SetCursorMapPosition
+	ldr r0, [r4]
+	movs r1, #0x10
+	ldrsb r1, [r0, r1]
+	movs r2, #0x11
+	ldrsb r2, [r0, r2]
+	adds r0, r5, #0
+	bl EnsureCameraOntoPosition
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08029808: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START WarpTargetPosSelect_Cancel
+WarpTargetPosSelect_Cancel: @ 0x0802980C
+	push {lr}
+	bl sub_8003D20
+	bl HideMoveRangeGraphics
+	bl DeleteEach6CBB
+	ldr r0, _08029838  @ gUnknown_03004E50
+	ldr r1, [r0]
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	ldrb r1, [r1, #0x11]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl SetCursorMapPosition
+	ldr r0, _0802983C  @ gUnknown_0859B600
+	movs r1, #3
+	bl Proc_Create
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08029838: .4byte gUnknown_03004E50
+_0802983C: .4byte gUnknown_0859B600
+
+	THUMB_FUNC_START WarpTargetPosSelect_Destruct
+WarpTargetPosSelect_Destruct: @ 0x08029840
+	push {r4, lr}
+	adds r4, r0, #0
+	bl HideMoveRangeGraphics
+	ldr r0, [r4, #0x54]
+	bl AP_Delete
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START WarpTargetSelection_OnSelect
+WarpTargetSelection_OnSelect: @ 0x08029854
+	push {r4, lr}
+	adds r4, r1, #0
+	bl EndTargetSelection
+	ldr r1, _08029874  @ gUnknown_0203A958
+	ldrb r0, [r4, #2]
+	strb r0, [r1, #0xd]
+	ldr r0, _08029878  @ gUnknown_0859B9B8
+	movs r1, #3
+	bl Proc_Create
+	movs r0, #4
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08029874: .4byte gUnknown_0203A958
+_08029878: .4byte gUnknown_0859B9B8
+
+	THUMB_FUNC_START SetupWarpTargetSelection
+SetupWarpTargetSelection: @ 0x0802987C
+	push {r4, lr}
+	bl MakeTargetListForWarp
+	ldr r0, _080298C0  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	movs r1, #1
+	negs r1, r1
+	bl ClearMapWith
+	ldr r0, _080298C4  @ gUnknown_0859D2F8
+	ldr r1, _080298C8  @ WarpTargetSelection_OnSelect
+	bl NewTargetSelection_Specialized
+	adds r4, r0, #0
+	ldr r0, _080298CC  @ 0x00000875
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	ldr r0, _080298D0  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _080298B8
+	movs r0, #0x6a
+	bl m4aSongNumStart
+_080298B8:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080298C0: .4byte gUnknown_0202E4E0
+_080298C4: .4byte gUnknown_0859D2F8
+_080298C8: .4byte WarpTargetSelection_OnSelect
+_080298CC: .4byte 0x00000875
+_080298D0: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START sub_80298D4
+sub_80298D4: @ 0x080298D4
+	push {lr}
+	ldr r2, _080298EC  @ gUnknown_0203A958
+	ldrb r0, [r1]
+	strb r0, [r2, #0x13]
+	ldrb r0, [r1, #1]
+	strb r0, [r2, #0x14]
+	movs r0, #0
+	bl EndItemEffectSelectionThing
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080298EC: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START PrepareTargetSelectionForMineAndLightRune
+PrepareTargetSelectionForMineAndLightRune: @ 0x080298F0
+	push {r4, r5, lr}
+	adds r5, r2, #0
+	bl _call_via_r1
+	ldr r0, _08029934  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	movs r1, #1
+	negs r1, r1
+	bl ClearMapWith
+	ldr r0, _08029938  @ gUnknown_0859D2D8
+	ldr r1, _0802993C  @ sub_80298D4
+	bl NewTargetSelection_Specialized
+	adds r4, r0, #0
+	adds r0, r5, #0
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	ldr r0, _08029940  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _0802992E
+	movs r0, #0x6a
+	bl m4aSongNumStart
+_0802992E:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08029934: .4byte gUnknown_0202E4E0
+_08029938: .4byte gUnknown_0859D2D8
+_0802993C: .4byte sub_80298D4
+_08029940: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START HammerneTargetSelection_OnSelect
+HammerneTargetSelection_OnSelect: @ 0x08029944
+	push {r4, r5, lr}
+	sub sp, #4
+	adds r4, r1, #0
+	bl sub_8003D20
+	ldr r5, _080299B0  @ gUnknown_0203A958
+	ldrb r0, [r4, #2]
+	strb r0, [r5, #0xd]
+	ldr r0, _080299B4  @ gUnknown_0859D064
+	bl NewMenu_Default
+	adds r4, r0, #0
+	ldrb r0, [r5, #0xd]
+	bl GetUnitStruct
+	adds r1, r0, #0
+	adds r0, r4, #0
+	movs r2, #0x10
+	movs r3, #0xb
+	bl sub_801E684
+	ldrb r0, [r5, #0xd]
+	bl GetUnitStruct
+	bl GetUnitPortraitId
+	bl GetPortraitStructPointer
+	ldr r0, [r0]
+	cmp r0, #0
+	beq _080299A4
+	ldrb r0, [r5, #0xd]
+	bl GetUnitStruct
+	bl GetUnitPortraitId
+	adds r1, r0, #0
+	movs r0, #2
+	str r0, [sp]
+	movs r0, #0
+	movs r2, #0xb8
+	movs r3, #0xc
+	bl NewFace
+	movs r0, #0
+	movs r1, #5
+	bl sub_8006458
+_080299A4:
+	movs r0, #0x17
+	add sp, #4
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080299B0: .4byte gUnknown_0203A958
+_080299B4: .4byte gUnknown_0859D064
+
+	THUMB_FUNC_START SetupHammerneUseSelection
+SetupHammerneUseSelection: @ 0x080299B8
+	push {r4, lr}
+	bl MakeTargetListForHammerne
+	ldr r0, _080299F8  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	movs r1, #1
+	negs r1, r1
+	bl ClearMapWith
+	ldr r0, _080299FC  @ gUnknown_0859D3B8
+	bl NewTargetSelection
+	adds r4, r0, #0
+	ldr r0, _08029A00  @ 0x00000878
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	ldr r0, _08029A04  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _080299F2
+	movs r0, #0x6a
+	bl m4aSongNumStart
+_080299F2:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080299F8: .4byte gUnknown_0202E4E0
+_080299FC: .4byte gUnknown_0859D3B8
+_08029A00: .4byte 0x00000878
+_08029A04: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START HammerneTargetSelection_OnChange
+HammerneTargetSelection_OnChange: @ 0x08029A08
+	push {r4, lr}
+	adds r4, r1, #0
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	movs r1, #1
+	ldrsb r1, [r4, r1]
+	bl ChangeActiveUnitFacing
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	bl DrawHammerneUnitInfoWindow
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START HammerneTargetSelection_OnInit
+HammerneTargetSelection_OnInit: @ 0x08029A2C
+	push {lr}
+	bl NewUnitInfoWindow_WithAllLines
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_8029A38
+sub_8029A38: @ 0x08029A38
+	push {lr}
+	adds r1, #0x3c
+	movs r0, #0
+	ldrsb r0, [r1, r0]
+	bl sub_801E748
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START nullsub_24
+nullsub_24: @ 0x08029A48
+	bx lr
+
+	THUMB_FUNC_START sub_8029A4C
+sub_8029A4C: @ 0x08029A4C
+	push {r4, lr}
+	adds r4, r1, #0
+	ldr r0, _08029A68  @ gUnknown_0203A958
+	ldrb r0, [r0, #0xd]
+	bl GetUnitStruct
+	lsls r4, r4, #1
+	adds r0, #0x1e
+	adds r0, r0, r4
+	ldrh r0, [r0]
+	cmp r0, #0
+	bne _08029A6C
+	movs r0, #3
+	b _08029A7C
+	.align 2, 0
+_08029A68: .4byte gUnknown_0203A958
+_08029A6C:
+	bl IsItemHammernable
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08029A7A
+	movs r0, #1
+	b _08029A7C
+_08029A7A:
+	movs r0, #2
+_08029A7C:
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8029A84
+sub_8029A84: @ 0x08029A84
+	push {r4, r5, r6, lr}
+	adds r5, r1, #0
+	ldr r0, _08029AD8  @ gUnknown_0203A958
+	ldrb r0, [r0, #0xd]
+	bl GetUnitStruct
+	adds r1, r5, #0
+	adds r1, #0x3c
+	ldrb r1, [r1]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	lsls r1, r1, #1
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r4, [r0]
+	adds r0, r4, #0
+	bl IsItemHammernable
+	adds r2, r0, #0
+	adds r0, r5, #0
+	adds r0, #0x34
+	lsls r2, r2, #0x18
+	asrs r2, r2, #0x18
+	movs r1, #0x2c
+	ldrsh r3, [r5, r1]
+	lsls r3, r3, #5
+	movs r6, #0x2a
+	ldrsh r1, [r5, r6]
+	adds r3, r3, r1
+	lsls r3, r3, #1
+	ldr r1, _08029ADC  @ gBG0TilemapBuffer
+	adds r3, r3, r1
+	adds r1, r4, #0
+	bl sub_80168E0
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	movs r0, #0
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08029AD8: .4byte gUnknown_0203A958
+_08029ADC: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_8029AE0
+sub_8029AE0: @ 0x08029AE0
+	push {r4, r5, r6, r7, lr}
+	adds r7, r0, #0
+	adds r4, r1, #0
+	adds r0, r4, #0
+	adds r0, #0x3d
+	ldrb r0, [r0]
+	cmp r0, #2
+	bne _08029B68
+	movs r6, #0
+	ldr r0, _08029B20  @ gUnknown_0203A958
+	ldrb r0, [r0, #0xd]
+	bl GetUnitStruct
+	adds r1, r4, #0
+	adds r1, #0x3c
+	ldrb r1, [r1]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	lsls r1, r1, #1
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r5, [r0]
+	adds r0, r5, #0
+	bl GetItemAttributes
+	movs r1, #0xc1
+	lsls r1, r1, #3
+	ands r1, r0
+	cmp r1, #0
+	beq _08029B28
+	ldr r6, _08029B24  @ 0x00000863
+	b _08029B58
+	.align 2, 0
+_08029B20: .4byte gUnknown_0203A958
+_08029B24: .4byte 0x00000863
+_08029B28:
+	adds r0, r5, #0
+	bl GetItemAttributes
+	movs r1, #5
+	ands r1, r0
+	cmp r1, #0
+	bne _08029B40
+	ldr r6, _08029B3C  @ 0x00000857
+	b _08029B58
+	.align 2, 0
+_08029B3C: .4byte 0x00000857
+_08029B40:
+	adds r0, r5, #0
+	bl GetItemUses
+	adds r4, r0, #0
+	adds r0, r5, #0
+	bl GetItemMaxUses
+	cmp r4, r0
+	bne _08029B54
+	ldr r6, _08029B64  @ 0x00000856
+_08029B54:
+	cmp r6, #0
+	beq _08029B60
+_08029B58:
+	adds r0, r7, #0
+	adds r1, r6, #0
+	bl Menu_CallTextBox
+_08029B60:
+	movs r0, #8
+	b _08029B7C
+	.align 2, 0
+_08029B64: .4byte 0x00000856
+_08029B68:
+	ldr r1, _08029B84  @ gUnknown_0203A958
+	adds r0, r4, #0
+	adds r0, #0x3c
+	ldrb r0, [r0]
+	strb r0, [r1, #0x15]
+	ldr r0, _08029B88  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl EndItemEffectSelectionThing
+	movs r0, #0x37
+_08029B7C:
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08029B84: .4byte gUnknown_0203A958
+_08029B88: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START PrepareTargetSelectionForHeal
+PrepareTargetSelectionForHeal: @ 0x08029B8C
+	push {r4, lr}
+	bl _call_via_r1
+	ldr r0, _08029BBC  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	movs r1, #1
+	negs r1, r1
+	bl ClearMapWith
+	ldr r0, _08029BC0  @ gUnknown_0859D298
+	bl NewTargetSelection
+	adds r4, r0, #0
+	ldr r0, _08029BC4  @ 0x00000874
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08029BBC: .4byte gUnknown_0202E4E0
+_08029BC0: .4byte gUnknown_0859D298
+_08029BC4: .4byte 0x00000874
+
+	THUMB_FUNC_START PrepareTargetSelectionForRestoreStaff
+PrepareTargetSelectionForRestoreStaff: @ 0x08029BC8
+	push {r4, lr}
+	bl _call_via_r1
+	ldr r0, _08029BF8  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	movs r1, #1
+	negs r1, r1
+	bl ClearMapWith
+	ldr r0, _08029BFC  @ gUnknown_0859D278
+	bl NewTargetSelection
+	adds r4, r0, #0
+	ldr r0, _08029C00  @ 0x00000877
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08029BF8: .4byte gUnknown_0202E4E0
+_08029BFC: .4byte gUnknown_0859D278
+_08029C00: .4byte 0x00000877
+
+	THUMB_FUNC_START sub_8029C04
+sub_8029C04: @ 0x08029C04
+	push {lr}
+	bl sub_8034FFC
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8029C10
+sub_8029C10: @ 0x08029C10
+	push {r4, lr}
+	adds r4, r1, #0
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	movs r1, #1
+	ldrsb r1, [r4, r1]
+	bl ChangeActiveUnitFacing
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	bl sub_803501C
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8029C34
+sub_8029C34: @ 0x08029C34
+	push {r4, lr}
+	bl MakeTargetListForBarrier
+	ldr r0, _08029C64  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	movs r1, #1
+	negs r1, r1
+	bl ClearMapWith
+	ldr r0, _08029C68  @ gUnknown_0859D258
+	bl NewTargetSelection
+	adds r4, r0, #0
+	ldr r0, _08029C6C  @ 0x00000879
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08029C64: .4byte gUnknown_0202E4E0
+_08029C68: .4byte gUnknown_0859D258
+_08029C6C: .4byte 0x00000879
+
+	THUMB_FUNC_START sub_8029C70
+sub_8029C70: @ 0x08029C70
+	push {lr}
+	bl sub_8035090
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8029C7C
+sub_8029C7C: @ 0x08029C7C
+	push {r4, lr}
+	adds r4, r1, #0
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	movs r1, #1
+	ldrsb r1, [r4, r1]
+	bl ChangeActiveUnitFacing
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	bl sub_80350A4
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START PrepareTargetSelectionForOffensiveStaff
+PrepareTargetSelectionForOffensiveStaff: @ 0x08029CA0
+	push {r4, lr}
+	bl _call_via_r1
+	ldr r0, _08029CD0  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	movs r1, #1
+	negs r1, r1
+	bl ClearMapWith
+	ldr r0, _08029CD4  @ gUnknown_0859D238
+	bl NewTargetSelection
+	adds r4, r0, #0
+	ldr r0, _08029CD8  @ 0x0000087B
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08029CD0: .4byte gUnknown_0202E4E0
+_08029CD4: .4byte gUnknown_0859D238
+_08029CD8: .4byte 0x0000087B
+
+	THUMB_FUNC_START sub_8029CDC
+sub_8029CDC: @ 0x08029CDC
+	push {lr}
+	bl sub_80350FC
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8029CE8
+sub_8029CE8: @ 0x08029CE8
+	push {r4, r5, r6, lr}
+	adds r4, r1, #0
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	movs r1, #1
+	ldrsb r1, [r4, r1]
+	bl ChangeActiveUnitFacing
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	adds r6, r0, #0
+	ldr r0, _08029D24  @ gUnknown_03004E50
+	ldr r5, [r0]
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	adds r1, r0, #0
+	adds r0, r5, #0
+	bl GetStaffAccuracy
+	adds r1, r0, #0
+	adds r0, r6, #0
+	bl sub_803511C
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08029D24: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START GenericSelection_DeleteBBAndBG
+GenericSelection_DeleteBBAndBG: @ 0x08029D28
+	push {lr}
+	bl DeleteEach6CBB
+	bl ClearBG0BG1
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_8029D38
+sub_8029D38: @ 0x08029D38
+	push {lr}
+	adds r2, r0, #0
+	ldr r0, [r2]
+	ldr r1, [r2, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #0x12
+	ands r0, r1
+	cmp r0, #0
+	beq _08029D64
+	movs r0, #0x10
+	ldrsb r0, [r2, r0]
+	movs r1, #0x11
+	ldrsb r1, [r2, r1]
+	bl GetTrapAt
+	cmp r0, #0
+	bne _08029D64
+	movs r0, #1
+	b _08029D66
+_08029D64:
+	movs r0, #0
+_08029D66:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8029D6C
+sub_8029D6C: @ 0x08029D6C
+	push {r4, lr}
+	ldr r0, _08029D8C  @ gUnknown_0859D2F8
+	ldr r1, _08029D90  @ GenericStaffSelection_OnSelect
+	bl NewTargetSelection_Specialized
+	adds r4, r0, #0
+	ldr r0, _08029D94  @ 0x00000876
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08029D8C: .4byte gUnknown_0859D2F8
+_08029D90: .4byte GenericStaffSelection_OnSelect
+_08029D94: .4byte 0x00000876
+
+	THUMB_FUNC_START TorchTargetPosSelect_Init
+TorchTargetPosSelect_Init: @ 0x08029D98
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	ldr r2, _08029DE4  @ gUnknown_0202BCB0
+	ldrb r1, [r2, #4]
+	movs r0, #1
+	orrs r0, r1
+	strb r0, [r2, #4]
+	ldr r0, _08029DE8  @ 0x0000087C
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r5, #0
+	bl NewBottomHelpText
+	ldr r4, _08029DEC  @ gUnknown_03004E50
+	ldr r1, [r4]
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	ldrb r1, [r1, #0x11]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl ShouldMoveCameraPosSomething
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08029DDC
+	ldr r0, [r4]
+	movs r1, #0x10
+	ldrsb r1, [r0, r1]
+	movs r2, #0x11
+	ldrsb r2, [r0, r2]
+	adds r0, r5, #0
+	bl EnsureCameraOntoPosition
+_08029DDC:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08029DE4: .4byte gUnknown_0202BCB0
+_08029DE8: .4byte 0x0000087C
+_08029DEC: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START TorchTargetSelection_Loop
+TorchTargetSelection_Loop: @ 0x08029DF0
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	ldr r5, _08029E50  @ gUnknown_0202BCB0
+	movs r0, #0x14
+	ldrsh r2, [r5, r0]
+	movs r1, #0x16
+	ldrsh r0, [r5, r1]
+	ldr r1, _08029E54  @ gUnknown_0202E4E4
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	ldr r0, [r0]
+	adds r0, r0, r2
+	ldrb r4, [r0]
+	bl HandlePlayerCursorMovement
+	ldr r0, _08029E58  @ gKeyStatusPtr
+	ldr r0, [r0]
+	ldrh r1, [r0, #8]
+	movs r0, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _08029E7A
+	cmp r4, #0
+	beq _08029E68
+	ldr r0, _08029E5C  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _08029E34
+	movs r0, #0x6a
+	bl m4aSongNumStart
+_08029E34:
+	adds r0, r6, #0
+	bl Proc_ClearNativeCallback
+	ldr r1, _08029E60  @ gUnknown_0203A958
+	ldrh r0, [r5, #0x14]
+	strb r0, [r1, #0x13]
+	ldrh r0, [r5, #0x16]
+	strb r0, [r1, #0x14]
+	ldr r0, _08029E64  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl EndItemEffectSelectionThing
+	b _08029EC0
+	.align 2, 0
+_08029E50: .4byte gUnknown_0202BCB0
+_08029E54: .4byte gUnknown_0202E4E4
+_08029E58: .4byte gKeyStatusPtr
+_08029E5C: .4byte gUnknown_0202BCF0
+_08029E60: .4byte gUnknown_0203A958
+_08029E64: .4byte gUnknown_03004E50
+_08029E68:
+	ldr r0, _08029EC8  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _08029E7A
+	movs r0, #0x6c
+	bl m4aSongNumStart
+_08029E7A:
+	ldr r0, _08029ECC  @ gKeyStatusPtr
+	ldr r0, [r0]
+	ldrh r1, [r0, #8]
+	movs r0, #2
+	ands r0, r1
+	cmp r0, #0
+	beq _08029EB0
+	ldr r0, _08029ED0  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #4
+	bl BG_EnableSyncByMask
+	adds r0, r6, #0
+	movs r1, #0x63
+	bl Proc_GotoLabel
+	ldr r0, _08029EC8  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _08029EB0
+	movs r0, #0x6b
+	bl m4aSongNumStart
+_08029EB0:
+	ldr r1, _08029ED4  @ gUnknown_0202BCB0
+	movs r2, #0x20
+	ldrsh r0, [r1, r2]
+	movs r2, #0x22
+	ldrsh r1, [r1, r2]
+	movs r2, #1
+	bl DisplayCursor
+_08029EC0:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08029EC8: .4byte gUnknown_0202BCF0
+_08029ECC: .4byte gKeyStatusPtr
+_08029ED0: .4byte gBG2TilemapBuffer
+_08029ED4: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START NewTorchStaffSelection
+NewTorchStaffSelection: @ 0x08029ED8
+	push {lr}
+	ldr r0, _08029EF8  @ gUnknown_0859BA38
+	movs r1, #3
+	bl Proc_Create
+	ldr r0, _08029EFC  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _08029EF4
+	movs r0, #0x6a
+	bl m4aSongNumStart
+_08029EF4:
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08029EF8: .4byte gUnknown_0859BA38
+_08029EFC: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START CanUnitUseItemPrepScreen
+CanUnitUseItemPrepScreen: @ 0x08029F00
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	adds r4, r1, #0
+	adds r0, r4, #0
+	bl GetItemAttributes
+	movs r1, #4
+	ands r1, r0
+	cmp r1, #0
+	beq _08029F16
+	b _0802A100
+_08029F16:
+	adds r0, r4, #0
+	bl GetItemIndex
+	subs r0, #0x5b
+	cmp r0, #0x66
+	bls _08029F24
+	b _0802A100
+_08029F24:
+	lsls r0, r0, #2
+	ldr r1, _08029F30  @ _08029F34
+	adds r0, r0, r1
+	ldr r0, [r0]
+	mov pc, r0
+	.align 2, 0
+_08029F30: .4byte _08029F34
+_08029F34: @ jump table
+	.4byte _0802A0D0 @ case 0
+	.4byte _0802A0D0 @ case 1
+	.4byte _0802A0D0 @ case 2
+	.4byte _0802A0D0 @ case 3
+	.4byte _0802A0D0 @ case 4
+	.4byte _0802A0D0 @ case 5
+	.4byte _0802A0D0 @ case 6
+	.4byte _0802A0D0 @ case 7
+	.4byte _0802A0D0 @ case 8
+	.4byte _0802A0DA @ case 9
+	.4byte _0802A0DA @ case 10
+	.4byte _0802A0DA @ case 11
+	.4byte _0802A0DA @ case 12
+	.4byte _0802A0DA @ case 13
+	.4byte _0802A100 @ case 14
+	.4byte _0802A100 @ case 15
+	.4byte _0802A100 @ case 16
+	.4byte _0802A100 @ case 17
+	.4byte _0802A100 @ case 18
+	.4byte _0802A100 @ case 19
+	.4byte _0802A100 @ case 20
+	.4byte _0802A100 @ case 21
+	.4byte _0802A100 @ case 22
+	.4byte _0802A100 @ case 23
+	.4byte _0802A100 @ case 24
+	.4byte _0802A100 @ case 25
+	.4byte _0802A100 @ case 26
+	.4byte _0802A100 @ case 27
+	.4byte _0802A100 @ case 28
+	.4byte _0802A100 @ case 29
+	.4byte _0802A100 @ case 30
+	.4byte _0802A100 @ case 31
+	.4byte _0802A100 @ case 32
+	.4byte _0802A100 @ case 33
+	.4byte _0802A100 @ case 34
+	.4byte _0802A100 @ case 35
+	.4byte _0802A100 @ case 36
+	.4byte _0802A100 @ case 37
+	.4byte _0802A100 @ case 38
+	.4byte _0802A100 @ case 39
+	.4byte _0802A100 @ case 40
+	.4byte _0802A100 @ case 41
+	.4byte _0802A100 @ case 42
+	.4byte _0802A100 @ case 43
+	.4byte _0802A100 @ case 44
+	.4byte _0802A0DA @ case 45
+	.4byte _0802A0E4 @ case 46
+	.4byte _0802A0DA @ case 47
+	.4byte _0802A100 @ case 48
+	.4byte _0802A100 @ case 49
+	.4byte _0802A100 @ case 50
+	.4byte _0802A100 @ case 51
+	.4byte _0802A100 @ case 52
+	.4byte _0802A100 @ case 53
+	.4byte _0802A100 @ case 54
+	.4byte _0802A100 @ case 55
+	.4byte _0802A100 @ case 56
+	.4byte _0802A100 @ case 57
+	.4byte _0802A100 @ case 58
+	.4byte _0802A100 @ case 59
+	.4byte _0802A0DA @ case 60
+	.4byte _0802A0DA @ case 61
+	.4byte _0802A0DA @ case 62
+	.4byte _0802A100 @ case 63
+	.4byte _0802A100 @ case 64
+	.4byte _0802A100 @ case 65
+	.4byte _0802A100 @ case 66
+	.4byte _0802A100 @ case 67
+	.4byte _0802A100 @ case 68
+	.4byte _0802A100 @ case 69
+	.4byte _0802A100 @ case 70
+	.4byte _0802A100 @ case 71
+	.4byte _0802A100 @ case 72
+	.4byte _0802A100 @ case 73
+	.4byte _0802A100 @ case 74
+	.4byte _0802A100 @ case 75
+	.4byte _0802A100 @ case 76
+	.4byte _0802A100 @ case 77
+	.4byte _0802A100 @ case 78
+	.4byte _0802A100 @ case 79
+	.4byte _0802A100 @ case 80
+	.4byte _0802A100 @ case 81
+	.4byte _0802A100 @ case 82
+	.4byte _0802A100 @ case 83
+	.4byte _0802A100 @ case 84
+	.4byte _0802A100 @ case 85
+	.4byte _0802A100 @ case 86
+	.4byte _0802A100 @ case 87
+	.4byte _0802A100 @ case 88
+	.4byte _0802A100 @ case 89
+	.4byte _0802A100 @ case 90
+	.4byte _0802A100 @ case 91
+	.4byte _0802A0F4 @ case 92
+	.4byte _0802A100 @ case 93
+	.4byte _0802A100 @ case 94
+	.4byte _0802A100 @ case 95
+	.4byte _0802A100 @ case 96
+	.4byte _0802A100 @ case 97
+	.4byte _0802A100 @ case 98
+	.4byte _0802A100 @ case 99
+	.4byte _0802A100 @ case 100
+	.4byte _0802A100 @ case 101
+	.4byte _0802A0DA @ case 102
+_0802A0D0:
+	adds r0, r5, #0
+	adds r1, r4, #0
+	bl CanUseStatBooster
+	b _0802A0FA
+_0802A0DA:
+	adds r0, r5, #0
+	adds r1, r4, #0
+	bl CanUsePromotionItem
+	b _0802A0FA
+_0802A0E4:
+	ldr r0, [r5, #0xc]
+	movs r1, #0x80
+	lsls r1, r1, #6
+	ands r0, r1
+	cmp r0, #0
+	bne _0802A100
+	movs r0, #1
+	b _0802A102
+_0802A0F4:
+	adds r0, r5, #0
+	bl CanUseJunaFruit
+_0802A0FA:
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	b _0802A102
+_0802A100:
+	movs r0, #0
+_0802A102:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_802A108
+sub_802A108: @ 0x0802A108
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	bl GetUnitItemCount
+	adds r5, r0, #0
+	movs r4, #0
+	cmp r4, r5
+	bge _0802A134
+_0802A118:
+	lsls r1, r4, #1
+	adds r0, r6, #0
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r0, [r0]
+	bl GetItemIndex
+	cmp r0, #0xcc
+	bne _0802A12E
+	movs r0, #1
+	b _0802A136
+_0802A12E:
+	adds r4, #1
+	cmp r4, r5
+	blt _0802A118
+_0802A134:
+	movs r0, #0
+_0802A136:
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+
+.align 2, 0

--- a/asm/bmmenu.s
+++ b/asm/bmmenu.s
@@ -1,0 +1,5064 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ Map Menu, Unit Menu and all related various target selections and what not is here
+	@ Huge
+
+	THUMB_FUNC_START sub_80225AC
+sub_80225AC: @ 0x080225AC
+	movs r0, #0x17
+	bx lr
+
+	THUMB_FUNC_START sub_80225B0
+sub_80225B0: @ 0x080225B0
+	push {lr}
+	ldr r0, _080225C4  @ gUnknown_0202BCF0
+	ldrb r1, [r0, #0x14]
+	movs r0, #8
+	ands r0, r1
+	cmp r0, #0
+	bne _080225C8
+	movs r0, #1
+	b _080225CA
+	.align 2, 0
+_080225C4: .4byte gUnknown_0202BCF0
+_080225C8:
+	movs r0, #2
+_080225CA:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_80225D0
+sub_80225D0: @ 0x080225D0
+	push {lr}
+	adds r2, r0, #0
+	adds r1, #0x3d
+	ldrb r0, [r1]
+	cmp r0, #2
+	beq _080225E4
+	bl sub_80B5D3C
+	movs r0, #0x17
+	b _080225EE
+_080225E4:
+	ldr r1, _080225F4  @ 0x00000864
+	adds r0, r2, #0
+	bl Menu_CallTextBox
+	movs r0, #8
+_080225EE:
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080225F4: .4byte 0x00000864
+
+	THUMB_FUNC_START CommandEffectEndPlayerPhase
+CommandEffectEndPlayerPhase: @ 0x080225F8
+	push {lr}
+	ldr r0, _08022608  @ gUnknown_0859AAD8
+	bl Proc_DeleteAllWithScript
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022608: .4byte gUnknown_0859AAD8
+
+	THUMB_FUNC_START sub_802260C
+sub_802260C: @ 0x0802260C
+	push {lr}
+	ldr r0, _08022624  @ gUnknown_0859AAD8
+	bl Proc_Find
+	movs r1, #0xa
+	bl Proc_GotoLabel
+	bl sub_80920C4
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022624: .4byte gUnknown_0859AAD8
+
+	THUMB_FUNC_START sub_8022628
+sub_8022628: @ 0x08022628
+	push {lr}
+	ldr r0, _08022638  @ gUnknown_08A2ECE0
+	movs r1, #3
+	bl Proc_Create
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022638: .4byte gUnknown_08A2ECE0
+
+	THUMB_FUNC_START sub_802263C
+sub_802263C: @ 0x0802263C
+	push {lr}
+	bl GetChapterThing
+	cmp r0, #1
+	beq _0802264A
+	movs r0, #1
+	b _0802264C
+_0802264A:
+	movs r0, #3
+_0802264C:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8022650
+sub_8022650: @ 0x08022650
+	push {lr}
+	movs r0, #0
+	bl NewChapterStatusScreen
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8022660
+sub_8022660: @ 0x08022660
+	push {lr}
+	bl sub_80CDF4C
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _08022670
+	movs r0, #1
+	b _08022672
+_08022670:
+	movs r0, #3
+_08022672:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8022678
+sub_8022678: @ 0x08022678
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	adds r4, r1, #0
+	bl sub_80CF480
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _08022692
+	adds r0, r4, #0
+	adds r0, #0x34
+	movs r1, #4
+	bl Text_SetColorId
+_08022692:
+	adds r0, r4, #0
+	adds r0, #0x3d
+	ldrb r0, [r0]
+	adds r5, r4, #0
+	adds r5, #0x34
+	cmp r0, #2
+	bne _080226A8
+	adds r0, r5, #0
+	movs r1, #1
+	bl Text_SetColorId
+_080226A8:
+	ldr r0, [r4, #0x30]
+	ldrh r0, [r0, #4]
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r5, #0
+	bl Text_AppendString
+	adds r0, r6, #0
+	adds r0, #0x64
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1c
+	lsrs r0, r0, #0x1e
+	bl BG_GetMapBuffer
+	adds r1, r0, #0
+	movs r2, #0x2c
+	ldrsh r0, [r4, r2]
+	lsls r0, r0, #5
+	movs r3, #0x2a
+	ldrsh r2, [r4, r3]
+	adds r0, r0, r2
+	lsls r0, r0, #1
+	adds r1, r1, r0
+	adds r0, r5, #0
+	bl Text_Draw
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START Make6CE_Guide
+Make6CE_Guide: @ 0x080226E4
+	push {lr}
+	ldr r0, _080226F4  @ gUnknown_08B12C64
+	movs r1, #3
+	bl Proc_Create
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080226F4: .4byte gUnknown_08B12C64
+
+	THUMB_FUNC_START sub_80226F8
+sub_80226F8: @ 0x080226F8
+	push {lr}
+	ldr r0, _08022718  @ gUnknown_03004E50
+	movs r1, #0
+	str r1, [r0]
+	ldr r0, _0802271C  @ gUnknown_0202BCB0
+	adds r0, #0x3e
+	strb r1, [r0]
+	ldr r0, _08022720  @ gUnknown_0859AAD8
+	bl Proc_Find
+	movs r1, #0xc
+	bl Proc_GotoLabel
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022718: .4byte gUnknown_03004E50
+_0802271C: .4byte gUnknown_0202BCB0
+_08022720: .4byte gUnknown_0859AAD8
+
+	THUMB_FUNC_START sub_8022724
+sub_8022724: @ 0x08022724
+	push {lr}
+	movs r0, #3
+	bl Make6C_savemenu2
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8022734
+sub_8022734: @ 0x08022734
+	movs r0, #0x17
+	bx lr
+
+	THUMB_FUNC_START EffectWait
+EffectWait: @ 0x08022738
+	ldr r1, _08022744  @ gUnknown_0203A958
+	movs r0, #1
+	strb r0, [r1, #0x11]
+	movs r0, #0x17
+	bx lr
+	.align 2, 0
+_08022744: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START GenericSelection_BackToUM
+GenericSelection_BackToUM: @ 0x08022748
+	push {lr}
+	bl EndTargetSelection
+	ldr r0, _08022794  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #4
+	bl BG_EnableSyncByMask
+	bl sub_8003D20
+	bl HideMoveRangeGraphics
+	ldr r0, _08022798  @ gUnknown_0859D1F0
+	ldr r2, _0802279C  @ gUnknown_0202BCB0
+	movs r3, #0x1c
+	ldrsh r1, [r2, r3]
+	movs r3, #0xc
+	ldrsh r2, [r2, r3]
+	subs r1, r1, r2
+	movs r2, #1
+	movs r3, #0x16
+	bl NewMenu_AndDoSomethingCommands
+	ldr r1, _080227A0  @ gUnknown_03004E50
+	ldr r2, [r1]
+	movs r1, #0x10
+	ldrsb r1, [r2, r1]
+	ldrb r2, [r2, #0x11]
+	lsls r2, r2, #0x18
+	asrs r2, r2, #0x18
+	bl EnsureCameraOntoPosition
+	movs r0, #0x19
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022794: .4byte gBG2TilemapBuffer
+_08022798: .4byte gUnknown_0859D1F0
+_0802279C: .4byte gUnknown_0202BCB0
+_080227A0: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_80227A4
+sub_80227A4: @ 0x080227A4
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	ldr r5, _080227FC  @ gUnknown_03004E50
+	ldr r1, [r5]
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	ldrb r1, [r1, #0x11]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl ShouldMoveCameraPosSomething
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _080227F6
+	ldr r0, [r5]
+	movs r4, #0x11
+	ldrsb r4, [r0, r4]
+	ldr r0, _08022800  @ gUnknown_0859A548
+	bl Proc_DeleteAllWithScript
+	lsls r0, r4, #4
+	bl GetSomeAdjustedCameraY
+	lsls r0, r0, #0x10
+	lsrs r0, r0, #0x10
+	ldr r2, _08022804  @ gUnknown_0202BCB0
+	movs r3, #0x2a
+	ldrsh r1, [r2, r3]
+	cmp r0, r1
+	ble _080227E8
+	ldrh r0, [r2, #0x2a]
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x14
+	adds r4, r0, #2
+_080227E8:
+	ldr r0, [r5]
+	movs r1, #0x10
+	ldrsb r1, [r0, r1]
+	adds r0, r6, #0
+	adds r2, r4, #0
+	bl EnsureCameraOntoPosition
+_080227F6:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080227FC: .4byte gUnknown_03004E50
+_08022800: .4byte gUnknown_0859A548
+_08022804: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_8022808
+sub_8022808: @ 0x08022808
+	push {lr}
+	ldr r0, _08022824  @ gUnknown_0859D1F0
+	ldr r2, _08022828  @ gUnknown_0202BCB0
+	movs r3, #0x1c
+	ldrsh r1, [r2, r3]
+	movs r3, #0xc
+	ldrsh r2, [r2, r3]
+	subs r1, r1, r2
+	movs r2, #1
+	movs r3, #0x16
+	bl NewMenu_AndDoSomethingCommands
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08022824: .4byte gUnknown_0859D1F0
+_08022828: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START GenericSelection_BackToUM_CamWait
+GenericSelection_BackToUM_CamWait: @ 0x0802282C
+	push {lr}
+	bl EndTargetSelection
+	ldr r0, _08022858  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #4
+	bl BG_EnableSyncByMask
+	bl HideMoveRangeGraphics
+	bl sub_8003D20
+	ldr r0, _0802285C  @ gUnknown_0859B600
+	movs r1, #3
+	bl Proc_Create
+	movs r0, #0x19
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022858: .4byte gBG2TilemapBuffer
+_0802285C: .4byte gUnknown_0859B600
+
+	THUMB_FUNC_START sub_8022860
+sub_8022860: @ 0x08022860
+	push {lr}
+	ldr r0, _08022894  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #4
+	bl BG_EnableSyncByMask
+	bl sub_8003D20
+	ldr r0, _08022898  @ gUnknown_0859D1F0
+	ldr r2, _0802289C  @ gUnknown_0202BCB0
+	movs r3, #0x1c
+	ldrsh r1, [r2, r3]
+	movs r3, #0xc
+	ldrsh r2, [r2, r3]
+	subs r1, r1, r2
+	movs r2, #1
+	movs r3, #0x16
+	bl NewMenu_AndDoSomethingCommands
+	bl HideMoveRangeGraphics
+	movs r0, #0x3b
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022894: .4byte gBG2TilemapBuffer
+_08022898: .4byte gUnknown_0859D1F0
+_0802289C: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_80228A0
+sub_80228A0: @ 0x080228A0
+	movs r0, #0
+	bx lr
+
+	THUMB_FUNC_START RescueUsability
+RescueUsability: @ 0x080228A4
+	push {lr}
+	ldr r0, _080228D0  @ gUnknown_03004E50
+	ldr r2, [r0]
+	ldr r1, [r2, #0xc]
+	movs r0, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _080228D4
+	movs r0, #0x81
+	lsls r0, r0, #4
+	ands r1, r0
+	cmp r1, #0
+	bne _080228D4
+	adds r0, r2, #0
+	bl MakeRescueTargetList
+	bl sub_804FD28
+	cmp r0, #0
+	beq _080228D4
+	movs r0, #1
+	b _080228D6
+	.align 2, 0
+_080228D0: .4byte gUnknown_03004E50
+_080228D4:
+	movs r0, #3
+_080228D6:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START RescueEffect
+RescueEffect: @ 0x080228DC
+	push {lr}
+	ldr r0, _080228F4  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl MakeRescueTargetList
+	ldr r0, _080228F8  @ gUnknown_0859D478
+	bl NewTargetSelection
+	movs r0, #7
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080228F4: .4byte gUnknown_03004E50
+_080228F8: .4byte gUnknown_0859D478
+
+	THUMB_FUNC_START RescueSelection_OnSelect
+RescueSelection_OnSelect: @ 0x080228FC
+	ldr r2, _0802290C  @ gUnknown_0203A958
+	ldrb r0, [r1, #2]
+	strb r0, [r2, #0xd]
+	movs r0, #9
+	strb r0, [r2, #0x11]
+	movs r0, #0x17
+	bx lr
+	.align 2, 0
+_0802290C: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START DropUsability
+DropUsability: @ 0x08022910
+	push {lr}
+	ldr r0, _0802293C  @ gUnknown_03004E50
+	ldr r2, [r0]
+	ldr r1, [r2, #0xc]
+	movs r0, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _08022940
+	movs r0, #0x10
+	ands r1, r0
+	cmp r1, #0
+	beq _08022940
+	adds r0, r2, #0
+	bl MakeDropTargetList
+	bl sub_804FD28
+	cmp r0, #0
+	beq _08022940
+	movs r0, #1
+	b _08022942
+	.align 2, 0
+_0802293C: .4byte gUnknown_03004E50
+_08022940:
+	movs r0, #3
+_08022942:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START DropEffect
+DropEffect: @ 0x08022948
+	push {lr}
+	ldr r0, _08022960  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl MakeDropTargetList
+	ldr r0, _08022964  @ gUnknown_0859D458
+	bl NewTargetSelection
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022960: .4byte gUnknown_03004E50
+_08022964: .4byte gUnknown_0859D458
+
+	THUMB_FUNC_START DropSelection_OnSelect
+DropSelection_OnSelect: @ 0x08022968
+	ldr r2, _08022984  @ gUnknown_0203A958
+	movs r0, #0xa
+	strb r0, [r2, #0x11]
+	ldr r0, _08022988  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldrb r0, [r0, #0x1b]
+	strb r0, [r2, #0xd]
+	ldrb r0, [r1]
+	strb r0, [r2, #0x13]
+	ldrb r0, [r1, #1]
+	strb r0, [r2, #0x14]
+	movs r0, #0x17
+	bx lr
+	.align 2, 0
+_08022984: .4byte gUnknown_0203A958
+_08022988: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START TakeUsability
+TakeUsability: @ 0x0802298C
+	push {lr}
+	ldr r0, _080229C4  @ gUnknown_03004E50
+	ldr r3, [r0]
+	ldr r2, [r3, #0xc]
+	movs r0, #0x40
+	ands r0, r2
+	cmp r0, #0
+	bne _080229CC
+	ldr r0, _080229C8  @ gUnknown_0202BCB0
+	adds r0, #0x3d
+	ldrb r1, [r0]
+	movs r0, #1
+	ands r0, r1
+	cmp r0, #0
+	bne _080229CC
+	movs r0, #0x10
+	ands r2, r0
+	cmp r2, #0
+	bne _080229CC
+	adds r0, r3, #0
+	bl MakeTakeTargetList
+	bl sub_804FD28
+	cmp r0, #0
+	beq _080229CC
+	movs r0, #1
+	b _080229CE
+	.align 2, 0
+_080229C4: .4byte gUnknown_03004E50
+_080229C8: .4byte gUnknown_0202BCB0
+_080229CC:
+	movs r0, #3
+_080229CE:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START TakeEffect
+TakeEffect: @ 0x080229D4
+	push {lr}
+	ldr r0, _080229EC  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl MakeTakeTargetList
+	ldr r0, _080229F0  @ gUnknown_0859D438
+	bl NewTargetSelection
+	movs r0, #7
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080229EC: .4byte gUnknown_03004E50
+_080229F0: .4byte gUnknown_0859D438
+
+	THUMB_FUNC_START GiveUsability
+GiveUsability: @ 0x080229F4
+	push {lr}
+	ldr r0, _08022A2C  @ gUnknown_03004E50
+	ldr r3, [r0]
+	ldr r2, [r3, #0xc]
+	movs r0, #0x40
+	ands r0, r2
+	cmp r0, #0
+	bne _08022A34
+	ldr r0, _08022A30  @ gUnknown_0202BCB0
+	adds r0, #0x3d
+	ldrb r1, [r0]
+	movs r0, #1
+	ands r0, r1
+	cmp r0, #0
+	bne _08022A34
+	movs r0, #0x10
+	ands r2, r0
+	cmp r2, #0
+	beq _08022A34
+	adds r0, r3, #0
+	bl sub_8025594
+	bl sub_804FD28
+	cmp r0, #0
+	beq _08022A34
+	movs r0, #1
+	b _08022A36
+	.align 2, 0
+_08022A2C: .4byte gUnknown_03004E50
+_08022A30: .4byte gUnknown_0202BCB0
+_08022A34:
+	movs r0, #3
+_08022A36:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START GiveEffect
+GiveEffect: @ 0x08022A3C
+	push {lr}
+	ldr r0, _08022A54  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl sub_8025594
+	ldr r0, _08022A58  @ gUnknown_0859D418
+	bl NewTargetSelection
+	movs r0, #7
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022A54: .4byte gUnknown_03004E50
+_08022A58: .4byte gUnknown_0859D418
+
+	THUMB_FUNC_START MakeUnitRescueTransferGraphics
+MakeUnitRescueTransferGraphics: @ 0x08022A5C
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	ldrb r0, [r4, #0x1b]
+	bl GetUnitStruct
+	adds r6, r0, #0
+	bl DeleteEach6CBB
+	movs r0, #0x10
+	ldrsb r0, [r5, r0]
+	movs r1, #0x11
+	ldrsb r1, [r5, r1]
+	movs r2, #0x10
+	ldrsb r2, [r4, r2]
+	movs r3, #0x11
+	ldrsb r3, [r4, r3]
+	bl GetSomeFacingDirection
+	adds r1, r0, #0
+	adds r0, r6, #0
+	bl Make6CKOIDOAMM
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START TakeSelection_OnSelect
+TakeSelection_OnSelect: @ 0x08022A90
+	push {r4, r5, lr}
+	ldr r4, _08022ADC  @ gUnknown_0203A958
+	movs r0, #0xb
+	strb r0, [r4, #0x11]
+	ldrb r0, [r1, #2]
+	strb r0, [r4, #0xd]
+	ldrb r0, [r4, #0xd]
+	bl GetUnitStruct
+	bl ApplyUnitMovement
+	ldrb r0, [r4, #0xd]
+	bl GetUnitStruct
+	adds r5, r0, #0
+	ldrb r0, [r4, #0xc]
+	bl GetUnitStruct
+	adds r1, r0, #0
+	adds r0, r5, #0
+	bl MakeUnitRescueTransferGraphics
+	ldrb r0, [r4, #0xd]
+	bl GetUnitStruct
+	adds r5, r0, #0
+	ldrb r0, [r4, #0xc]
+	bl GetUnitStruct
+	adds r1, r0, #0
+	adds r0, r5, #0
+	bl UpdateRescueData
+	movs r0, #0x17
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022ADC: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START GiveSelection_OnSelect
+GiveSelection_OnSelect: @ 0x08022AE0
+	push {r4, r5, lr}
+	ldr r4, _08022B2C  @ gUnknown_0203A958
+	movs r0, #0xc
+	strb r0, [r4, #0x11]
+	ldrb r0, [r1, #2]
+	strb r0, [r4, #0xd]
+	ldrb r0, [r4, #0xc]
+	bl GetUnitStruct
+	bl ApplyUnitMovement
+	ldrb r0, [r4, #0xc]
+	bl GetUnitStruct
+	adds r5, r0, #0
+	ldrb r0, [r4, #0xd]
+	bl GetUnitStruct
+	adds r1, r0, #0
+	adds r0, r5, #0
+	bl MakeUnitRescueTransferGraphics
+	ldrb r0, [r4, #0xc]
+	bl GetUnitStruct
+	adds r5, r0, #0
+	ldrb r0, [r4, #0xd]
+	bl GetUnitStruct
+	adds r1, r0, #0
+	adds r0, r5, #0
+	bl UpdateRescueData
+	movs r0, #0x17
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022B2C: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START sub_8022B30
+sub_8022B30: @ 0x08022B30
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	adds r4, r1, #0
+	adds r0, r4, #0
+	adds r0, #0x3d
+	ldrb r0, [r0]
+	cmp r0, #2
+	bne _08022B50
+	ldr r1, _08022B4C  @ 0x00000858
+	adds r0, r5, #0
+	bl Menu_CallTextBox
+	movs r0, #8
+	b _08022B84
+	.align 2, 0
+_08022B4C: .4byte 0x00000858
+_08022B50:
+	bl ResetIconGraphics
+	movs r0, #4
+	bl LoadIconPalettes
+	ldr r0, _08022B74  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldr r0, [r0, #0xc]
+	movs r1, #0x80
+	lsls r1, r1, #4
+	ands r0, r1
+	cmp r0, #0
+	bne _08022B78
+	adds r0, r5, #0
+	adds r1, r4, #0
+	bl sub_8022BD8
+	b _08022B80
+	.align 2, 0
+_08022B74: .4byte gUnknown_03004E50
+_08022B78:
+	adds r0, r5, #0
+	adds r1, r4, #0
+	bl sub_8022B8C
+_08022B80:
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+_08022B84:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8022B8C
+sub_8022B8C: @ 0x08022B8C
+	push {r4, r5, lr}
+	sub sp, #4
+	ldr r0, _08022BD0  @ gUnknown_0859D1A8
+	bl NewMenu_Default
+	adds r5, r0, #0
+	ldr r4, _08022BD4  @ gUnknown_03004E50
+	ldr r0, [r4]
+	bl GetUnitPortraitId
+	adds r1, r0, #0
+	movs r0, #2
+	str r0, [sp]
+	movs r0, #0
+	movs r2, #0xb0
+	movs r3, #0xc
+	bl NewFace
+	movs r0, #0
+	movs r1, #5
+	bl sub_8006458
+	ldr r1, [r4]
+	adds r0, r5, #0
+	movs r2, #0xf
+	movs r3, #0xb
+	bl sub_801E684
+	movs r0, #0x17
+	add sp, #4
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022BD0: .4byte gUnknown_0859D1A8
+_08022BD4: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_8022BD8
+sub_8022BD8: @ 0x08022BD8
+	push {r4, r5, lr}
+	sub sp, #4
+	ldr r0, _08022C28  @ gUnknown_0859D1CC
+	bl NewMenu_Default
+	adds r4, r0, #0
+	ldr r5, _08022C2C  @ gUnknown_03004E50
+	ldr r1, [r5]
+	ldr r0, [r1, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x51
+	beq _08022C0E
+	adds r0, r1, #0
+	bl GetUnitPortraitId
+	adds r1, r0, #0
+	movs r0, #2
+	str r0, [sp]
+	movs r0, #0
+	movs r2, #0xb0
+	movs r3, #0xc
+	bl NewFace
+	movs r0, #0
+	movs r1, #5
+	bl sub_8006458
+_08022C0E:
+	ldr r1, [r5]
+	adds r0, r4, #0
+	movs r2, #0xf
+	movs r3, #0xb
+	bl sub_801E684
+	bl sub_80832C4
+	movs r0, #0x17
+	add sp, #4
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022C28: .4byte gUnknown_0859D1CC
+_08022C2C: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START DisplayUnitStandingAttackRange
+DisplayUnitStandingAttackRange: @ 0x08022C30
+	push {r4, r5, lr}
+	ldr r0, _08022C6C  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	movs r5, #1
+	negs r5, r5
+	adds r1, r5, #0
+	bl ClearMapWith
+	ldr r0, _08022C70  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r4, _08022C74  @ gUnknown_03004E50
+	ldr r2, [r4]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x80
+	lsls r1, r1, #4
+	ands r0, r1
+	cmp r0, #0
+	beq _08022C78
+	movs r0, #0x10
+	ldrsb r0, [r2, r0]
+	movs r1, #0x11
+	ldrsb r1, [r2, r1]
+	movs r2, #1
+	movs r3, #0xa
+	bl FillRangeMap
+	b _08022C88
+	.align 2, 0
+_08022C6C: .4byte gUnknown_0202E4E0
+_08022C70: .4byte gUnknown_0202E4E4
+_08022C74: .4byte gUnknown_03004E50
+_08022C78:
+	adds r0, r2, #0
+	adds r1, r5, #0
+	bl GetUnitRangeMask
+	adds r1, r0, #0
+	ldr r0, [r4]
+	bl FillRangeByRangeMask
+_08022C88:
+	movs r0, #3
+	bl DisplayMoveRangeGraphics
+	movs r0, #0
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START HideMoveRangeGraphicsWrapper
+HideMoveRangeGraphicsWrapper: @ 0x08022C98
+	push {lr}
+	bl HideMoveRangeGraphics
+	movs r0, #0
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8022CA4
+sub_8022CA4: @ 0x08022CA4
+	push {r4, r5, lr}
+	ldr r5, _08022CE4  @ gUnknown_03004E50
+	ldr r0, [r5]
+	lsls r1, r1, #1
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r4, [r0]
+	adds r0, r4, #0
+	bl GetItemAttributes
+	movs r1, #1
+	ands r1, r0
+	cmp r1, #0
+	beq _08022CE8
+	ldr r0, [r5]
+	adds r1, r4, #0
+	bl CanUnitUseAsWeapon
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08022CE8
+	ldr r0, [r5]
+	adds r1, r4, #0
+	bl MakeTargetListForWeapon
+	bl sub_804FD28
+	cmp r0, #0
+	beq _08022CE8
+	movs r0, #1
+	b _08022CEA
+	.align 2, 0
+_08022CE4: .4byte gUnknown_03004E50
+_08022CE8:
+	movs r0, #3
+_08022CEA:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8022CF0
+sub_8022CF0: @ 0x08022CF0
+	push {r4, lr}
+	ldr r4, _08022D28  @ gUnknown_03004E50
+	ldr r0, [r4]
+	adds r1, #0x3c
+	ldrb r1, [r1]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl EquipUnitItemByIndex
+	ldr r1, _08022D2C  @ gUnknown_0203A958
+	movs r0, #0
+	strb r0, [r1, #0x12]
+	bl ClearBG0BG1
+	ldr r0, [r4]
+	ldrh r1, [r0, #0x1e]
+	bl MakeTargetListForWeapon
+	ldr r0, _08022D30  @ gUnknown_0859D3F8
+	bl NewTargetSelection
+	bl sub_80832C8
+	movs r0, #0x27
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022D28: .4byte gUnknown_03004E50
+_08022D2C: .4byte gUnknown_0203A958
+_08022D30: .4byte gUnknown_0859D3F8
+
+	THUMB_FUNC_START sub_8022D34
+sub_8022D34: @ 0x08022D34
+	push {r4, r5, r6, lr}
+	adds r5, r1, #0
+	ldr r0, _08022D7C  @ gUnknown_03004E50
+	ldr r0, [r0]
+	adds r1, #0x3c
+	movs r2, #0
+	ldrsb r2, [r1, r2]
+	lsls r2, r2, #1
+	adds r1, r0, #0
+	adds r1, #0x1e
+	adds r1, r1, r2
+	ldrh r4, [r1]
+	adds r1, r4, #0
+	bl CanUnitUseAsWeapon
+	adds r2, r0, #0
+	adds r0, r5, #0
+	adds r0, #0x34
+	lsls r2, r2, #0x18
+	asrs r2, r2, #0x18
+	movs r1, #0x2c
+	ldrsh r3, [r5, r1]
+	lsls r3, r3, #5
+	movs r6, #0x2a
+	ldrsh r1, [r5, r6]
+	adds r3, r3, r1
+	lsls r3, r3, #1
+	ldr r1, _08022D80  @ gBG0TilemapBuffer
+	adds r3, r3, r1
+	adds r1, r4, #0
+	bl DrawItemMenuCommand
+	movs r0, #0
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022D7C: .4byte gUnknown_03004E50
+_08022D80: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_8022D84
+sub_8022D84: @ 0x08022D84
+	push {r4, r5, lr}
+	adds r5, r1, #0
+	adds r5, #0x3c
+	movs r0, #0
+	ldrsb r0, [r5, r0]
+	bl sub_801E748
+	ldr r0, _08022DCC  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	movs r1, #1
+	negs r1, r1
+	bl ClearMapWith
+	ldr r0, _08022DD0  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r4, _08022DD4  @ gUnknown_03004E50
+	ldr r0, [r4]
+	movs r1, #0
+	ldrsb r1, [r5, r1]
+	bl GetUnitRangeMask
+	adds r1, r0, #0
+	ldr r0, [r4]
+	bl FillRangeByRangeMask
+	movs r0, #2
+	bl DisplayMoveRangeGraphics
+	movs r0, #0
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022DCC: .4byte gUnknown_0202E4E0
+_08022DD0: .4byte gUnknown_0202E4E4
+_08022DD4: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_8022DD8
+sub_8022DD8: @ 0x08022DD8
+	push {lr}
+	adds r0, #0x63
+	ldrb r1, [r0]
+	movs r0, #4
+	ands r0, r1
+	cmp r0, #0
+	bne _08022DEA
+	bl HideMoveRangeGraphics
+_08022DEA:
+	movs r0, #0
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8022DF0
+sub_8022DF0: @ 0x08022DF0
+	push {r4, lr}
+	adds r4, r1, #0
+	bl EventEngineExists
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #1
+	bne _08022E04
+	movs r0, #0
+	b _08022E2A
+_08022E04:
+	ldr r1, _08022E30  @ gUnknown_0203A958
+	movs r0, #2
+	strb r0, [r1, #0x11]
+	ldrb r0, [r4, #2]
+	strb r0, [r1, #0xd]
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	cmp r0, #0
+	bne _08022E22
+	ldrb r0, [r4]
+	strb r0, [r1, #0x13]
+	ldrb r0, [r4, #1]
+	strb r0, [r1, #0x14]
+	ldrb r0, [r4, #3]
+	strb r0, [r1, #0x15]
+_08022E22:
+	ldr r0, _08022E34  @ gUnknown_0859E520
+	bl Proc_DeleteAllWithScript
+	movs r0, #0x17
+_08022E2A:
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022E30: .4byte gUnknown_0203A958
+_08022E34: .4byte gUnknown_0859E520
+
+	THUMB_FUNC_START sub_8022E38
+sub_8022E38: @ 0x08022E38
+	push {lr}
+	ldr r0, _08022E50  @ gUnknown_03004E50
+	ldr r0, [r0]
+	movs r1, #0x10
+	ldrsb r1, [r0, r1]
+	movs r2, #0x11
+	ldrsb r2, [r0, r2]
+	movs r0, #0
+	bl EnsureCameraOntoPosition
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08022E50: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_8022E54
+sub_8022E54: @ 0x08022E54
+	push {lr}
+	movs r0, #0
+	movs r1, #0
+	bl sub_8022B30
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_8022E64
+sub_8022E64: @ 0x08022E64
+	push {lr}
+	bl EventEngineExists
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #1
+	beq _08022E84
+	ldr r0, _08022E80  @ gUnknown_0859B630
+	movs r1, #3
+	bl Proc_Create
+	movs r0, #0xb
+	b _08022E86
+	.align 2, 0
+_08022E80: .4byte gUnknown_0859B630
+_08022E84:
+	movs r0, #0
+_08022E86:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8022E8C
+sub_8022E8C: @ 0x08022E8C
+	push {r4, r5, lr}
+	sub sp, #4
+	adds r4, r1, #0
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	adds r5, r0, #0
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	movs r1, #1
+	ldrsb r1, [r4, r1]
+	bl ChangeActiveUnitFacing
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	cmp r0, #0
+	bne _08022EC2
+	ldr r1, _08022EE0  @ gUnknown_0203A958
+	ldrb r0, [r4]
+	strb r0, [r1, #0x13]
+	ldrb r0, [r4, #1]
+	strb r0, [r1, #0x14]
+	ldrb r0, [r4, #3]
+	strb r0, [r1, #0x15]
+	bl MakeSnagBattleTarget
+_08022EC2:
+	ldr r1, _08022EE0  @ gUnknown_0203A958
+	ldrb r0, [r1, #0x12]
+	cmp r0, #8
+	bne _08022EE8
+	ldr r0, _08022EE4  @ gUnknown_03004E50
+	ldr r0, [r0]
+	movs r2, #0x10
+	ldrsb r2, [r0, r2]
+	movs r3, #0x11
+	ldrsb r3, [r0, r3]
+	adds r1, r5, #0
+	bl sub_802A364
+	b _08022EFC
+	.align 2, 0
+_08022EE0: .4byte gUnknown_0203A958
+_08022EE4: .4byte gUnknown_03004E50
+_08022EE8:
+	ldr r0, _08022F0C  @ gUnknown_03004E50
+	ldr r0, [r0]
+	movs r3, #1
+	negs r3, r3
+	ldrb r1, [r1, #0x12]
+	str r1, [sp]
+	adds r1, r5, #0
+	adds r2, r3, #0
+	bl sub_802A318
+_08022EFC:
+	bl sub_803738C
+	movs r0, #0
+	add sp, #4
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022F0C: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_8022F10
+sub_8022F10: @ 0x08022F10
+	push {lr}
+	ldr r0, _08022F30  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #4
+	bl BG_EnableSyncByMask
+	bl HideMoveRangeGraphics
+	bl sub_80373B4
+	movs r0, #0
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022F30: .4byte gBG2TilemapBuffer
+
+	THUMB_FUNC_START sub_8022F34
+sub_8022F34: @ 0x08022F34
+	push {lr}
+	ldr r0, _08022F78  @ gUnknown_03004E50
+	ldr r2, [r0]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _08022F80
+	ldr r0, _08022F7C  @ gUnknown_0202BCB0
+	adds r0, #0x3d
+	ldrb r1, [r0]
+	movs r0, #2
+	ands r0, r1
+	cmp r0, #0
+	bne _08022F80
+	ldr r0, [r2]
+	ldr r1, [r2, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #2
+	ands r0, r1
+	cmp r0, #0
+	bne _08022F80
+	adds r0, r2, #0
+	bl MakeTradeTargetList
+	bl sub_804FD28
+	cmp r0, #0
+	beq _08022F80
+	movs r0, #1
+	b _08022F82
+	.align 2, 0
+_08022F78: .4byte gUnknown_03004E50
+_08022F7C: .4byte gUnknown_0202BCB0
+_08022F80:
+	movs r0, #3
+_08022F82:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8022F88
+sub_8022F88: @ 0x08022F88
+	push {lr}
+	bl ClearBG0BG1
+	ldr r0, _08022FA4  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl MakeTradeTargetList
+	ldr r0, _08022FA8  @ gUnknown_0859D3D8
+	bl NewTargetSelection
+	movs r0, #7
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022FA4: .4byte gUnknown_03004E50
+_08022FA8: .4byte gUnknown_0859D3D8
+
+	THUMB_FUNC_START sub_8022FAC
+sub_8022FAC: @ 0x08022FAC
+	push {r4, lr}
+	ldr r2, _08022FD4  @ gUnknown_0203A958
+	movs r0, #0x1d
+	strb r0, [r2, #0x11]
+	ldr r0, _08022FD8  @ gUnknown_03004E50
+	ldr r4, [r0]
+	movs r0, #2
+	ldrsb r0, [r1, r0]
+	bl GetUnitStruct
+	adds r1, r0, #0
+	adds r0, r4, #0
+	movs r2, #0
+	bl sub_802DD6C
+	movs r0, #0x17
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08022FD4: .4byte gUnknown_0203A958
+_08022FD8: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_8022FDC
+sub_8022FDC: @ 0x08022FDC
+	push {r4, lr}
+	ldr r4, _08022FFC  @ gUnknown_03004E50
+	ldr r2, [r4]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _08022FF8
+	adds r0, r2, #0
+	bl CanUnitSeize
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _08023000
+_08022FF8:
+	movs r0, #3
+	b _0802301A
+	.align 2, 0
+_08022FFC: .4byte gUnknown_03004E50
+_08023000:
+	ldr r1, [r4]
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	ldrb r1, [r1, #0x11]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl GetAvailableLocaCommandAt
+	movs r1, #3
+	cmp r0, #0x11
+	bne _08023018
+	movs r1, #1
+_08023018:
+	adds r0, r1, #0
+_0802301A:
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8023020
+sub_8023020: @ 0x08023020
+	ldr r1, _08023038  @ gUnknown_0203A958
+	movs r0, #0x11
+	strb r0, [r1, #0x11]
+	ldr r0, _0802303C  @ gUnknown_03004E50
+	ldr r2, [r0]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	orrs r0, r1
+	str r0, [r2, #0xc]
+	movs r0, #0x17
+	bx lr
+	.align 2, 0
+_08023038: .4byte gUnknown_0203A958
+_0802303C: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_8023040
+sub_8023040: @ 0x08023040
+	push {r4, lr}
+	ldr r0, _08023080  @ gUnknown_03004E50
+	ldr r2, [r0]
+	ldr r1, [r2, #4]
+	ldrb r1, [r1, #4]
+	adds r4, r0, #0
+	cmp r1, #0x51
+	beq _080230B8
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _080230B8
+	movs r0, #0x11
+	ldrsb r0, [r2, r0]
+	ldr r1, _08023084  @ gUnknown_0202E4DC
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r1, #0x10
+	ldrsb r1, [r2, r1]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	cmp r0, #5
+	beq _08023090
+	cmp r0, #5
+	bgt _08023088
+	cmp r0, #3
+	beq _08023090
+	b _080230B8
+	.align 2, 0
+_08023080: .4byte gUnknown_03004E50
+_08023084: .4byte gUnknown_0202E4DC
+_08023088:
+	cmp r0, #0x38
+	bgt _080230B8
+	cmp r0, #0x37
+	blt _080230B8
+_08023090:
+	ldr r1, [r4]
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	ldrb r1, [r1, #0x11]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl GetAvailableLocaCommandAt
+	cmp r0, #0x10
+	bne _080230B8
+	ldr r0, [r4]
+	bl CanUnitNotUseMagic
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _080230B4
+	movs r0, #2
+	b _080230BA
+_080230B4:
+	movs r0, #1
+	b _080230BA
+_080230B8:
+	movs r0, #3
+_080230BA:
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_80230C0
+sub_80230C0: @ 0x080230C0
+	push {lr}
+	adds r2, r0, #0
+	adds r1, #0x3d
+	ldrb r0, [r1]
+	cmp r0, #2
+	beq _080230DC
+	ldr r1, _080230D8  @ gUnknown_0203A958
+	movs r0, #0x10
+	strb r0, [r1, #0x11]
+	movs r0, #0x17
+	b _080230E6
+	.align 2, 0
+_080230D8: .4byte gUnknown_0203A958
+_080230DC:
+	ldr r1, _080230EC  @ 0x0000084C
+	adds r0, r2, #0
+	bl Menu_CallTextBox
+	movs r0, #8
+_080230E6:
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080230EC: .4byte 0x0000084C
+
+	THUMB_FUNC_START sub_80230F0
+sub_80230F0: @ 0x080230F0
+	push {r4, r5, r6, lr}
+	ldr r6, _08023114  @ gUnknown_03004E50
+	ldr r2, [r6]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _0802314E
+	adds r0, r2, #0
+	bl sub_8025B6C
+	bl sub_804FD28
+	cmp r0, #0
+	beq _08023118
+_0802310E:
+	movs r0, #1
+	b _08023150
+	.align 2, 0
+_08023114: .4byte gUnknown_03004E50
+_08023118:
+	movs r5, #0
+	ldr r0, [r6]
+	ldrh r4, [r0, #0x1e]
+	cmp r4, #0
+	beq _0802314E
+_08023122:
+	adds r0, r4, #0
+	bl GetItemWType
+	cmp r0, #0xc
+	bne _0802313A
+	ldr r0, [r6]
+	adds r1, r4, #0
+	bl CanUnitUseItem
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802310E
+_0802313A:
+	adds r5, #1
+	cmp r5, #4
+	bgt _0802314E
+	ldr r0, [r6]
+	lsls r1, r5, #1
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r4, [r0]
+	cmp r4, #0
+	bne _08023122
+_0802314E:
+	movs r0, #3
+_08023150:
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8023158
+sub_8023158: @ 0x08023158
+	push {lr}
+	adds r3, r0, #0
+	ldr r0, _08023184  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldr r1, [r0]
+	ldr r2, [r0, #4]
+	ldr r0, [r1, #0x28]
+	ldr r1, [r2, #0x28]
+	orrs r0, r1
+	movs r1, #0x20
+	ands r0, r1
+	cmp r0, #0
+	beq _0802318C
+	ldr r1, _08023188  @ gUnknown_0202BCB0
+	movs r0, #0xcd
+	strh r0, [r1, #0x2c]
+	adds r0, r3, #0
+	bl sub_80230F0
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+	b _0802318E
+	.align 2, 0
+_08023184: .4byte gUnknown_03004E50
+_08023188: .4byte gUnknown_0202BCB0
+_0802318C:
+	movs r0, #3
+_0802318E:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8023194
+sub_8023194: @ 0x08023194
+	push {lr}
+	adds r3, r0, #0
+	ldr r0, _080231C0  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldr r1, [r0]
+	ldr r2, [r0, #4]
+	ldr r0, [r1, #0x28]
+	ldr r1, [r2, #0x28]
+	orrs r0, r1
+	movs r1, #0x10
+	ands r0, r1
+	cmp r0, #0
+	beq _080231C8
+	ldr r1, _080231C4  @ gUnknown_0202BCB0
+	movs r0, #0xa5
+	strh r0, [r1, #0x2c]
+	adds r0, r3, #0
+	bl sub_80230F0
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+	b _080231CA
+	.align 2, 0
+_080231C0: .4byte gUnknown_03004E50
+_080231C4: .4byte gUnknown_0202BCB0
+_080231C8:
+	movs r0, #3
+_080231CA:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_80231D0
+sub_80231D0: @ 0x080231D0
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #4
+	mov r9, r0
+	mov sl, r1
+	movs r7, #0
+	ldr r6, _08023248  @ gUnknown_03004E50
+	ldr r0, [r6]
+	bl sub_8025B6C
+	bl sub_804FD28
+	negs r1, r0
+	orrs r1, r0
+	lsrs r1, r1, #0x1f
+	mov r8, r1
+	movs r5, #0
+	ldr r0, [r6]
+	ldrh r4, [r0, #0x1e]
+	cmp r4, #0
+	beq _0802322E
+_08023200:
+	adds r0, r4, #0
+	bl GetItemWType
+	cmp r0, #0xc
+	bne _0802321A
+	ldr r0, [r6]
+	adds r1, r4, #0
+	bl CanUnitUseItem
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802321A
+	movs r7, #1
+_0802321A:
+	adds r5, #1
+	cmp r5, #4
+	bgt _0802322E
+	ldr r0, [r6]
+	lsls r1, r5, #1
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r4, [r0]
+	cmp r4, #0
+	bne _08023200
+_0802322E:
+	mov r0, r8
+	cmp r0, #0
+	beq _0802324C
+	cmp r7, #0
+	bne _0802324C
+	mov r0, r9
+	mov r1, sl
+	bl sub_8024AF0
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+	b _0802328C
+	.align 2, 0
+_08023248: .4byte gUnknown_03004E50
+_0802324C:
+	ldr r0, _0802329C  @ gUnknown_0859D13C
+	bl NewMenu_Default
+	adds r5, r0, #0
+	ldr r4, _080232A0  @ gUnknown_03004E50
+	ldr r0, [r4]
+	bl GetUnitPortraitId
+	adds r1, r0, #0
+	movs r0, #2
+	str r0, [sp]
+	movs r0, #0
+	movs r2, #0xb0
+	movs r3, #0xc
+	bl NewFace
+	movs r0, #0
+	movs r1, #5
+	bl sub_8006458
+	ldr r1, [r4]
+	adds r0, r5, #0
+	movs r2, #0xf
+	movs r3, #0xb
+	bl sub_801E684
+	bl ResetIconGraphics
+	movs r0, #4
+	bl LoadIconPalettes
+	movs r0, #0x17
+_0802328C:
+	add sp, #4
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0802329C: .4byte gUnknown_0859D13C
+_080232A0: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_80232A4
+sub_80232A4: @ 0x080232A4
+	ldr r2, _080232B4  @ gUnknown_0203A958
+	movs r0, #4
+	strb r0, [r2, #0x11]
+	ldrb r0, [r1, #2]
+	strb r0, [r2, #0xd]
+	movs r0, #0x17
+	bx lr
+	.align 2, 0
+_080232B4: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START sub_80232B8
+sub_80232B8: @ 0x080232B8
+	push {lr}
+	ldr r0, _080232DC  @ gUnknown_03004E50
+	ldr r2, [r0]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _080232E0
+	ldr r0, [r2, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x51
+	beq _080232E0
+	ldrh r0, [r2, #0x1e]
+	cmp r0, #0
+	beq _080232E0
+	movs r0, #1
+	b _080232E2
+	.align 2, 0
+_080232DC: .4byte gUnknown_03004E50
+_080232E0:
+	movs r0, #3
+_080232E2:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START ItemCommandEffect
+ItemCommandEffect: @ 0x080232E8
+	push {r4, r5, lr}
+	sub sp, #4
+	adds r1, #0x3d
+	ldrb r0, [r1]
+	cmp r0, #1
+	bne _08023344
+	bl ResetIconGraphics
+	movs r0, #4
+	bl LoadIconPalettes
+	bl sub_8003D20
+	ldr r0, _0802333C  @ gUnknown_0859D184
+	bl NewMenu_Default
+	adds r5, r0, #0
+	ldr r4, _08023340  @ gUnknown_03004E50
+	ldr r0, [r4]
+	bl GetUnitPortraitId
+	adds r1, r0, #0
+	movs r0, #2
+	str r0, [sp]
+	movs r0, #0
+	movs r2, #0xb0
+	movs r3, #0xc
+	bl NewFace
+	movs r0, #0
+	movs r1, #5
+	bl sub_8006458
+	ldr r1, [r4]
+	adds r0, r5, #0
+	movs r2, #0xf
+	movs r3, #0xb
+	bl sub_801E684
+	movs r0, #0x17
+	b _08023346
+	.align 2, 0
+_0802333C: .4byte gUnknown_0859D184
+_08023340: .4byte gUnknown_03004E50
+_08023344:
+	movs r0, #0
+_08023346:
+	add sp, #4
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START ItemSelectMenu_TextDraw
+ItemSelectMenu_TextDraw: @ 0x08023350
+	push {r4, r5, r6, r7, lr}
+	adds r6, r0, #0
+	adds r4, r1, #0
+	ldr r7, _08023388  @ gUnknown_03004E50
+	ldr r1, [r7]
+	adds r0, r4, #0
+	adds r0, #0x3c
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	lsls r0, r0, #1
+	adds r1, #0x1e
+	adds r1, r1, r0
+	ldrh r5, [r1]
+	adds r0, r5, #0
+	bl GetItemAttributes
+	movs r1, #1
+	ands r1, r0
+	cmp r1, #0
+	beq _0802338C
+	adds r0, r6, #0
+	adds r1, r4, #0
+	bl sub_8022D34
+	movs r0, #0
+	b _080233CC
+	.align 2, 0
+_08023388: .4byte gUnknown_03004E50
+_0802338C:
+	adds r0, r5, #0
+	bl GetItemWType
+	cmp r0, #0xc
+	bne _0802339A
+	movs r2, #0
+	b _080233A6
+_0802339A:
+	ldr r0, [r7]
+	adds r1, r5, #0
+	bl CanUnitUseItem
+	lsls r0, r0, #0x18
+	lsrs r2, r0, #0x18
+_080233A6:
+	adds r0, r4, #0
+	adds r0, #0x34
+	lsls r2, r2, #0x18
+	asrs r2, r2, #0x18
+	movs r1, #0x2c
+	ldrsh r3, [r4, r1]
+	lsls r3, r3, #5
+	movs r6, #0x2a
+	ldrsh r1, [r4, r6]
+	adds r3, r3, r1
+	lsls r3, r3, #1
+	ldr r1, _080233D4  @ gBG0TilemapBuffer
+	adds r3, r3, r1
+	adds r1, r5, #0
+	bl DrawItemMenuCommand
+	movs r0, #1
+	bl BG_EnableSyncByMask
+_080233CC:
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080233D4: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START ItemSelectMenu_Usability
+ItemSelectMenu_Usability: @ 0x080233D8
+	push {r4, r5, r6, r7, lr}
+	adds r6, r0, #0
+	adds r5, r1, #0
+	ldr r7, _080233F4  @ gUnknown_03004E50
+	ldr r0, [r7]
+	lsls r1, r5, #1
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r4, [r0]
+	cmp r4, #0
+	bne _080233F8
+	movs r0, #3
+	b _08023422
+	.align 2, 0
+_080233F4: .4byte gUnknown_03004E50
+_080233F8:
+	adds r0, r4, #0
+	bl GetItemAttributes
+	movs r1, #1
+	ands r1, r0
+	cmp r1, #0
+	beq _0802340E
+	adds r0, r6, #0
+	adds r1, r5, #0
+	bl sub_8022CA4
+_0802340E:
+	ldr r0, [r7]
+	adds r1, r4, #0
+	bl CanUnitUseItem
+	lsls r0, r0, #0x18
+	movs r1, #2
+	cmp r0, #0
+	beq _08023420
+	movs r1, #1
+_08023420:
+	adds r0, r1, #0
+_08023422:
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START ItemSelectMenu_Effect
+ItemSelectMenu_Effect: @ 0x08023428
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	ldr r2, _08023480  @ gUnknown_0203A958
+	adds r0, r1, #0
+	adds r0, #0x3c
+	ldrb r0, [r0]
+	strb r0, [r2, #0x12]
+	ldrh r0, [r1, #0x2a]
+	adds r0, #9
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+	ldr r2, _08023484  @ 0xFFFFFF00
+	ands r5, r2
+	orrs r5, r0
+	ldrh r0, [r1, #0x2c]
+	subs r0, #1
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x10
+	ldr r1, _08023488  @ 0xFFFF00FF
+	ands r5, r1
+	orrs r5, r0
+	ldr r0, _0802348C  @ 0xFF00FFFF
+	ands r5, r0
+	movs r0, #0xe0
+	lsls r0, r0, #0xb
+	orrs r5, r0
+	ldr r0, _08023490  @ 0x00FFFFFF
+	ands r5, r0
+	lsls r0, r5, #0x18
+	asrs r0, r0, #0x18
+	lsls r1, r5, #0x10
+	asrs r1, r1, #0x18
+	bl sub_80234AC
+	ldr r0, _08023494  @ gUnknown_0859D118
+	adds r1, r5, #0
+	adds r2, r4, #0
+	bl NewMenu_BG0BG1
+	movs r0, #4
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023480: .4byte gUnknown_0203A958
+_08023484: .4byte 0xFFFFFF00
+_08023488: .4byte 0xFFFF00FF
+_0802348C: .4byte 0xFF00FFFF
+_08023490: .4byte 0x00FFFFFF
+_08023494: .4byte gUnknown_0859D118
+
+	THUMB_FUNC_START sub_8023498
+sub_8023498: @ 0x08023498
+	push {lr}
+	adds r1, #0x3c
+	movs r0, #0
+	ldrsb r0, [r1, r0]
+	bl sub_801E748
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START nullsub_25
+nullsub_25: @ 0x080234A8
+	bx lr
+
+	THUMB_FUNC_START sub_80234AC
+sub_80234AC: @ 0x080234AC
+	push {lr}
+	ldr r0, _080234D8  @ gUnknown_02002774
+	ldr r1, _080234DC  @ 0x06004000
+	movs r2, #0x80
+	lsls r2, r2, #2
+	movs r3, #0
+	bl Font_InitForUI
+	ldr r0, _080234E0  @ gUnknown_02022CFE
+	ldr r1, _080234E4  @ gUnknown_02003D2C
+	movs r2, #9
+	movs r3, #0x13
+	bl TileMap_CopyRect
+	ldr r0, _080234E8  @ gUnknown_020234FE
+	ldr r1, _080234EC  @ gUnknown_0200422C
+	movs r2, #9
+	movs r3, #0x13
+	bl TileMap_CopyRect
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080234D8: .4byte gUnknown_02002774
+_080234DC: .4byte 0x06004000
+_080234E0: .4byte gUnknown_02022CFE
+_080234E4: .4byte gUnknown_02003D2C
+_080234E8: .4byte gUnknown_020234FE
+_080234EC: .4byte gUnknown_0200422C
+
+	THUMB_FUNC_START sub_80234F0
+sub_80234F0: @ 0x080234F0
+	push {lr}
+	movs r0, #0
+	bl SetFont
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_80234FC
+sub_80234FC: @ 0x080234FC
+	push {lr}
+	movs r0, #0
+	bl SetFont
+	ldr r0, _08023528  @ gUnknown_02003D2C
+	ldr r1, _0802352C  @ gUnknown_02022CFE
+	movs r2, #9
+	movs r3, #0x13
+	bl TileMap_CopyRect
+	ldr r0, _08023530  @ gUnknown_0200422C
+	ldr r1, _08023534  @ gUnknown_020234FE
+	movs r2, #9
+	movs r3, #0x13
+	bl TileMap_CopyRect
+	movs r0, #3
+	bl BG_EnableSyncByMask
+	movs r0, #0xb
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023528: .4byte gUnknown_02003D2C
+_0802352C: .4byte gUnknown_02022CFE
+_08023530: .4byte gUnknown_0200422C
+_08023534: .4byte gUnknown_020234FE
+
+	THUMB_FUNC_START sub_8023538
+sub_8023538: @ 0x08023538
+	push {lr}
+	movs r0, #0
+	bl SetFont
+	bl sub_8003D20
+	bl EndAllMenus
+	movs r0, #0x31
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8023550
+sub_8023550: @ 0x08023550
+	push {r4, r5, lr}
+	sub sp, #4
+	adds r4, r0, #0
+	bl sub_8023538
+	adds r0, r4, #0
+	bl sub_80234FC
+	ldr r0, _080235A0  @ gUnknown_0859D184
+	bl NewMenu_Default
+	adds r5, r0, #0
+	ldr r4, _080235A4  @ gUnknown_03004E50
+	ldr r0, [r4]
+	bl GetUnitPortraitId
+	adds r1, r0, #0
+	movs r0, #2
+	str r0, [sp]
+	movs r0, #0
+	movs r2, #0xb0
+	movs r3, #0xc
+	bl NewFace
+	movs r0, #0
+	movs r1, #5
+	bl sub_8006458
+	ldr r1, [r4]
+	adds r0, r5, #0
+	movs r2, #0xf
+	movs r3, #0xb
+	bl sub_801E684
+	movs r0, #1
+	add sp, #4
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080235A0: .4byte gUnknown_0859D184
+_080235A4: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_80235A8
+sub_80235A8: @ 0x080235A8
+	push {r4, r5, r6, lr}
+	sub sp, #4
+	bl sub_8023538
+	ldr r6, _08023630  @ gUnknown_03004E50
+	ldr r0, [r6]
+	bl GetUnitItemCount
+	cmp r0, #0
+	beq _08023648
+	ldr r0, _08023634  @ gUnknown_02003D2C
+	ldr r5, _08023638  @ gUnknown_02022CFE
+	adds r1, r5, #0
+	movs r2, #9
+	movs r3, #0x13
+	bl TileMap_CopyRect
+	ldr r0, _0802363C  @ gUnknown_0200422C
+	ldr r4, _08023640  @ gUnknown_020234FE
+	adds r1, r4, #0
+	movs r2, #9
+	movs r3, #0x13
+	bl TileMap_CopyRect
+	subs r5, #0x14
+	adds r0, r5, #0
+	movs r1, #0xe
+	movs r2, #0xc
+	movs r3, #0
+	bl TileMap_FillRect
+	subs r4, #0x14
+	adds r0, r4, #0
+	movs r1, #0xd
+	movs r2, #0xc
+	movs r3, #0
+	bl TileMap_FillRect
+	movs r0, #3
+	bl BG_EnableSyncByMask
+	ldr r0, _08023644  @ gUnknown_0859D184
+	bl NewMenu_Default
+	adds r4, r0, #0
+	ldr r0, [r6]
+	bl GetUnitPortraitId
+	adds r1, r0, #0
+	movs r0, #2
+	str r0, [sp]
+	movs r0, #0
+	movs r2, #0xb0
+	movs r3, #0xc
+	bl NewFace
+	movs r0, #0
+	movs r1, #5
+	bl sub_8006458
+	ldr r1, [r6]
+	adds r0, r4, #0
+	movs r2, #0xf
+	movs r3, #0xb
+	bl sub_801E684
+	movs r0, #1
+	b _0802366A
+	.align 2, 0
+_08023630: .4byte gUnknown_03004E50
+_08023634: .4byte gUnknown_02003D2C
+_08023638: .4byte gUnknown_02022CFE
+_0802363C: .4byte gUnknown_0200422C
+_08023640: .4byte gUnknown_020234FE
+_08023644: .4byte gUnknown_0859D184
+_08023648:
+	bl ClearBG0BG1
+	movs r0, #0
+	bl DeleteFaceByIndex
+	ldr r0, _08023674  @ gUnknown_0859D1F0
+	ldr r2, _08023678  @ gUnknown_0202BCB0
+	movs r3, #0x1c
+	ldrsh r1, [r2, r3]
+	movs r3, #0xc
+	ldrsh r2, [r2, r3]
+	subs r1, r1, r2
+	movs r2, #1
+	movs r3, #0x16
+	bl NewMenu_AndDoSomethingCommands
+	movs r0, #0x1b
+_0802366A:
+	add sp, #4
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023674: .4byte gUnknown_0859D1F0
+_08023678: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_802367C
+sub_802367C: @ 0x0802367C
+	push {r4, r5, lr}
+	ldr r5, _080236CC  @ gUnknown_03004E50
+	ldr r1, [r5]
+	ldr r0, _080236D0  @ gUnknown_0203A958
+	ldrb r0, [r0, #0x12]
+	lsls r0, r0, #1
+	adds r1, #0x1e
+	adds r1, r1, r0
+	ldrh r4, [r1]
+	adds r0, r4, #0
+	bl GetItemUseEffect
+	cmp r0, #0
+	beq _080236C8
+	adds r0, r4, #0
+	bl GetItemWType
+	cmp r0, #4
+	beq _080236C8
+	adds r0, r4, #0
+	bl GetItemWType
+	cmp r0, #0xc
+	beq _080236C8
+	adds r0, r4, #0
+	bl GetItemAttributes
+	movs r1, #1
+	ands r1, r0
+	cmp r1, #0
+	beq _080236D4
+	ldr r0, [r5]
+	adds r1, r4, #0
+	bl CanUnitUseAsWeapon
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _080236D4
+_080236C8:
+	movs r0, #3
+	b _080236EA
+	.align 2, 0
+_080236CC: .4byte gUnknown_03004E50
+_080236D0: .4byte gUnknown_0203A958
+_080236D4:
+	ldr r0, _080236F0  @ gUnknown_03004E50
+	ldr r0, [r0]
+	adds r1, r4, #0
+	bl CanUnitUseItem
+	lsls r0, r0, #0x18
+	movs r1, #2
+	cmp r0, #0
+	beq _080236E8
+	movs r1, #1
+_080236E8:
+	adds r0, r1, #0
+_080236EA:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080236F0: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_80236F4
+sub_80236F4: @ 0x080236F4
+	push {r4, r5, lr}
+	ldr r5, _08023718  @ gUnknown_03004E50
+	ldr r1, [r5]
+	ldr r0, _0802371C  @ gUnknown_0203A958
+	ldrb r0, [r0, #0x12]
+	lsls r0, r0, #1
+	adds r1, #0x1e
+	adds r1, r1, r0
+	ldrh r4, [r1]
+	adds r0, r4, #0
+	bl GetItemAttributes
+	movs r1, #1
+	ands r1, r0
+	cmp r1, #0
+	bne _08023720
+	movs r0, #3
+	b _08023734
+	.align 2, 0
+_08023718: .4byte gUnknown_03004E50
+_0802371C: .4byte gUnknown_0203A958
+_08023720:
+	ldr r0, [r5]
+	adds r1, r4, #0
+	bl CanUnitUseAsWeapon
+	lsls r0, r0, #0x18
+	movs r1, #2
+	cmp r0, #0
+	beq _08023732
+	movs r1, #1
+_08023732:
+	adds r0, r1, #0
+_08023734:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_802373C
+sub_802373C: @ 0x0802373C
+	push {lr}
+	ldr r0, _08023760  @ gUnknown_03004E50
+	ldr r1, [r0]
+	ldr r0, _08023764  @ gUnknown_0203A958
+	ldrb r0, [r0, #0x12]
+	lsls r0, r0, #1
+	adds r1, #0x1e
+	adds r1, r1, r0
+	ldrh r0, [r1]
+	bl GetItemAttributes
+	movs r1, #0x10
+	ands r1, r0
+	cmp r1, #0
+	bne _08023768
+	movs r0, #1
+	b _0802376A
+	.align 2, 0
+_08023760: .4byte gUnknown_03004E50
+_08023764: .4byte gUnknown_0203A958
+_08023768:
+	movs r0, #2
+_0802376A:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8023770
+sub_8023770: @ 0x08023770
+	push {r4, lr}
+	adds r4, r0, #0
+	adds r1, #0x3d
+	ldrb r0, [r1]
+	cmp r0, #2
+	bne _080237A8
+	ldr r0, _080237A0  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldr r1, _080237A4  @ gUnknown_0203A958
+	ldrb r2, [r1, #0x12]
+	lsls r2, r2, #1
+	adds r1, r0, #0
+	adds r1, #0x1e
+	adds r1, r1, r2
+	ldrh r1, [r1]
+	bl sub_8028C0C
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl Menu_CallTextBox
+	movs r0, #8
+	b _080237E4
+	.align 2, 0
+_080237A0: .4byte gUnknown_03004E50
+_080237A4: .4byte gUnknown_0203A958
+_080237A8:
+	bl ClearBG0BG1
+	ldr r0, _080237EC  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldr r1, _080237F0  @ gUnknown_0203A958
+	ldrb r2, [r1, #0x12]
+	lsls r2, r2, #1
+	adds r1, r0, #0
+	adds r1, #0x1e
+	adds r1, r1, r2
+	ldrh r1, [r1]
+	bl ItemEffect_Call
+	ldr r0, _080237F4  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _080237D4
+	movs r0, #0x6a
+	bl m4aSongNumStart
+_080237D4:
+	movs r0, #0
+	bl SetFont
+	bl sub_8003D20
+	bl EndAllMenus
+	movs r0, #0x21
+_080237E4:
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080237EC: .4byte gUnknown_03004E50
+_080237F0: .4byte gUnknown_0203A958
+_080237F4: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START sub_80237F8
+sub_80237F8: @ 0x080237F8
+	push {r4, lr}
+	adds r4, r0, #0
+	adds r1, #0x3d
+	ldrb r0, [r1]
+	cmp r0, #2
+	beq _08023824
+	ldr r0, _0802381C  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldr r1, _08023820  @ gUnknown_0203A958
+	ldrb r1, [r1, #0x12]
+	bl EquipUnitItemByIndex
+	adds r0, r4, #0
+	bl sub_8023550
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+	b _0802382E
+	.align 2, 0
+_0802381C: .4byte gUnknown_03004E50
+_08023820: .4byte gUnknown_0203A958
+_08023824:
+	ldr r1, _08023834  @ 0x0000084D
+	adds r0, r4, #0
+	bl Menu_CallTextBox
+	movs r0, #8
+_0802382E:
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023834: .4byte 0x0000084D
+
+	THUMB_FUNC_START sub_8023838
+sub_8023838: @ 0x08023838
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	ldr r0, _08023864  @ gUnknown_0202BCB0
+	ldr r1, _08023868  @ gUnknown_0203A958
+	ldrb r1, [r1, #0x12]
+	adds r0, #0x3f
+	strb r1, [r0]
+	adds r0, r4, #0
+	bl sub_8023538
+	movs r0, #0
+	bl DeleteFaceByIndex
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl sub_8022F88
+	movs r0, #1
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023864: .4byte gUnknown_0202BCB0
+_08023868: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START sub_802386C
+sub_802386C: @ 0x0802386C
+	push {r4, lr}
+	adds r4, r0, #0
+	adds r2, r1, #0
+	adds r0, r2, #0
+	adds r0, #0x3d
+	ldrb r0, [r0]
+	cmp r0, #2
+	beq _080238CC
+	ldrh r0, [r2, #0x2a]
+	adds r0, #3
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+	ldr r1, _080238B8  @ 0xFFFFFF00
+	ands r3, r1
+	orrs r3, r0
+	ldrh r0, [r2, #0x2c]
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x10
+	ldr r1, _080238BC  @ 0xFFFF00FF
+	ands r3, r1
+	orrs r3, r0
+	ldr r0, _080238C0  @ 0xFF00FFFF
+	ands r3, r0
+	movs r0, #0xa0
+	lsls r0, r0, #0xb
+	orrs r3, r0
+	ldr r0, _080238C4  @ 0x00FFFFFF
+	ands r3, r0
+	ldr r0, _080238C8  @ gUnknown_0859D0F4
+	adds r1, r3, #0
+	adds r2, r4, #0
+	bl NewMenu_BG0BG1
+	adds r0, #0x61
+	movs r1, #1
+	strb r1, [r0]
+	movs r0, #0x84
+	b _080238D6
+	.align 2, 0
+_080238B8: .4byte 0xFFFFFF00
+_080238BC: .4byte 0xFFFF00FF
+_080238C0: .4byte 0xFF00FFFF
+_080238C4: .4byte 0x00FFFFFF
+_080238C8: .4byte gUnknown_0859D0F4
+_080238CC:
+	ldr r1, _080238DC  @ 0x0000084F
+	adds r0, r4, #0
+	bl Menu_CallTextBox
+	movs r0, #8
+_080238D6:
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080238DC: .4byte 0x0000084F
+
+	THUMB_FUNC_START sub_80238E0
+sub_80238E0: @ 0x080238E0
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	ldr r0, _0802390C  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldr r4, _08023910  @ gUnknown_0203A958
+	ldrb r1, [r4, #0x12]
+	bl UnitRemoveItem
+	ldrb r0, [r4, #0x12]
+	cmp r0, #0
+	beq _080238FE
+	ldr r0, _08023914  @ gBG0TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+_080238FE:
+	adds r0, r5, #0
+	bl sub_80235A8
+	movs r0, #1
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0802390C: .4byte gUnknown_03004E50
+_08023910: .4byte gUnknown_0203A958
+_08023914: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_8023918
+sub_8023918: @ 0x08023918
+	push {lr}
+	ldr r0, _0802392C  @ gUnknown_03004E50
+	ldr r2, [r0]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	beq _08023930
+	movs r0, #3
+	b _0802394C
+	.align 2, 0
+_0802392C: .4byte gUnknown_03004E50
+_08023930:
+	movs r0, #0x10
+	ldrsb r0, [r2, r0]
+	movs r1, #0x11
+	ldrsb r1, [r2, r1]
+	bl GetBallistaItemAt
+	movs r1, #0xff
+	lsls r1, r1, #8
+	ands r1, r0
+	cmp r1, #0
+	bne _0802394A
+	movs r0, #2
+	b _0802394C
+_0802394A:
+	movs r0, #1
+_0802394C:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8023950
+sub_8023950: @ 0x08023950
+	push {r4, r5, lr}
+	adds r4, r1, #0
+	movs r5, #0
+	adds r0, r4, #0
+	adds r0, #0x3d
+	ldrb r0, [r0]
+	cmp r0, #1
+	bne _08023962
+	movs r5, #1
+_08023962:
+	ldr r0, _08023998  @ gUnknown_03004E50
+	ldr r1, [r0]
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	ldrb r1, [r1, #0x11]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl GetBallistaItemAt
+	adds r1, r0, #0
+	adds r0, r4, #0
+	adds r0, #0x34
+	adds r2, r5, #0
+	movs r5, #0x2c
+	ldrsh r3, [r4, r5]
+	lsls r3, r3, #5
+	movs r5, #0x2a
+	ldrsh r4, [r4, r5]
+	adds r3, r3, r4
+	lsls r3, r3, #1
+	ldr r4, _0802399C  @ gBG0TilemapBuffer
+	adds r3, r3, r4
+	bl DrawItemMenuCommand
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023998: .4byte gUnknown_03004E50
+_0802399C: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_80239A0
+sub_80239A0: @ 0x080239A0
+	push {lr}
+	bl ClearBG0BG1
+	ldr r1, _080239C0  @ gUnknown_0203A958
+	movs r0, #8
+	strb r0, [r1, #0x12]
+	ldr r0, _080239C4  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl FillBallistaRangeMaybe
+	ldr r0, _080239C8  @ gUnknown_0859D3F8
+	bl NewTargetSelection
+	movs r0, #0x26
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080239C0: .4byte gUnknown_0203A958
+_080239C4: .4byte gUnknown_03004E50
+_080239C8: .4byte gUnknown_0859D3F8
+
+	THUMB_FUNC_START FillBallistaRange
+FillBallistaRange: @ 0x080239CC
+	push {r4, r5, r6, lr}
+	mov r6, r8
+	push {r6}
+	ldr r0, _08023A48  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	movs r1, #1
+	negs r1, r1
+	bl ClearMapWith
+	ldr r4, _08023A4C  @ gUnknown_0202E4E4
+	ldr r0, [r4]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r0, [r4]
+	bl SetSubjectMap
+	ldr r4, _08023A50  @ gUnknown_03004E50
+	ldr r1, [r4]
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	ldrb r1, [r1, #0x11]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl GetBallistaItemAt
+	adds r5, r0, #0
+	bl sub_801E748
+	ldr r0, [r4]
+	movs r6, #0x10
+	ldrsb r6, [r0, r6]
+	ldrb r0, [r0, #0x11]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	mov r8, r0
+	adds r0, r5, #0
+	bl GetItemMinRange
+	adds r4, r0, #0
+	lsls r4, r4, #0x10
+	asrs r4, r4, #0x10
+	adds r0, r5, #0
+	bl GetItemMaxRange
+	adds r3, r0, #0
+	lsls r3, r3, #0x10
+	asrs r3, r3, #0x10
+	adds r0, r6, #0
+	mov r1, r8
+	adds r2, r4, #0
+	bl FillRangeMap
+	movs r0, #2
+	bl DisplayMoveRangeGraphics
+	movs r0, #0
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023A48: .4byte gUnknown_0202E4E0
+_08023A4C: .4byte gUnknown_0202E4E4
+_08023A50: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START StaffCommandUsability
+StaffCommandUsability: @ 0x08023A54
+	push {r4, r5, r6, lr}
+	ldr r0, _08023A68  @ gUnknown_03004E50
+	ldr r2, [r0]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	beq _08023A70
+	b _08023ABE
+	.align 2, 0
+_08023A68: .4byte gUnknown_03004E50
+_08023A6C:
+	movs r0, #2
+	b _08023AC0
+_08023A70:
+	movs r6, #0
+	ldrh r4, [r2, #0x1e]
+	cmp r4, #0
+	beq _08023ABE
+_08023A78:
+	adds r0, r4, #0
+	bl GetItemWType
+	cmp r0, #4
+	bne _08023AA8
+	ldr r5, _08023AA4  @ gUnknown_03004E50
+	ldr r0, [r5]
+	adds r1, r4, #0
+	bl CanUnitUseItem
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08023AA8
+	ldr r0, [r5]
+	bl CanUnitNotUseMagic
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _08023A6C
+	movs r0, #1
+	b _08023AC0
+	.align 2, 0
+_08023AA4: .4byte gUnknown_03004E50
+_08023AA8:
+	adds r6, #1
+	cmp r6, #4
+	bgt _08023ABE
+	ldr r0, _08023AC8  @ gUnknown_03004E50
+	ldr r0, [r0]
+	lsls r1, r6, #1
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r4, [r0]
+	cmp r4, #0
+	bne _08023A78
+_08023ABE:
+	movs r0, #3
+_08023AC0:
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023AC8: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START StaffCommandEffect
+StaffCommandEffect: @ 0x08023ACC
+	push {r4, r5, lr}
+	sub sp, #4
+	adds r2, r0, #0
+	adds r1, #0x3d
+	ldrb r0, [r1]
+	cmp r0, #2
+	beq _08023B24
+	bl ResetIconGraphics
+	movs r0, #4
+	bl LoadIconPalettes
+	ldr r0, _08023B1C  @ gUnknown_0859D160
+	bl NewMenu_Default
+	adds r5, r0, #0
+	ldr r4, _08023B20  @ gUnknown_03004E50
+	ldr r0, [r4]
+	bl GetUnitPortraitId
+	adds r1, r0, #0
+	movs r0, #2
+	str r0, [sp]
+	movs r0, #0
+	movs r2, #0xb0
+	movs r3, #0xc
+	bl NewFace
+	movs r0, #0
+	movs r1, #5
+	bl sub_8006458
+	ldr r1, [r4]
+	adds r0, r5, #0
+	movs r2, #0xf
+	movs r3, #0xb
+	bl sub_801E684
+	movs r0, #0x17
+	b _08023B2E
+	.align 2, 0
+_08023B1C: .4byte gUnknown_0859D160
+_08023B20: .4byte gUnknown_03004E50
+_08023B24:
+	ldr r1, _08023B38  @ 0x00000851
+	adds r0, r2, #0
+	bl Menu_CallTextBox
+	movs r0, #8
+_08023B2E:
+	add sp, #4
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023B38: .4byte 0x00000851
+
+	THUMB_FUNC_START sub_8023B3C
+sub_8023B3C: @ 0x08023B3C
+	push {r4, r5, r6, lr}
+	ldr r5, _08023B78  @ gUnknown_03004E50
+	ldr r0, [r5]
+	movs r4, #1
+	negs r4, r4
+	adds r1, r4, #0
+	bl GetUnitStaffRangeMask_0
+	adds r6, r0, #0
+	ldr r0, _08023B7C  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	adds r1, r4, #0
+	bl ClearMapWith
+	ldr r0, _08023B80  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r0, [r5]
+	adds r1, r6, #0
+	bl FillRangeByRangeMask
+	movs r0, #5
+	bl DisplayMoveRangeGraphics
+	movs r0, #0
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023B78: .4byte gUnknown_03004E50
+_08023B7C: .4byte gUnknown_0202E4E0
+_08023B80: .4byte gUnknown_0202E4E4
+
+	THUMB_FUNC_START sub_8023B84
+sub_8023B84: @ 0x08023B84
+	push {lr}
+	bl HideMoveRangeGraphics
+	movs r0, #0
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START StaffItemSelect_Usability
+StaffItemSelect_Usability: @ 0x08023B90
+	push {r4, r5, lr}
+	ldr r5, _08023BBC  @ gUnknown_03004E50
+	ldr r0, [r5]
+	lsls r1, r1, #1
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r4, [r0]
+	adds r0, r4, #0
+	bl GetItemWType
+	cmp r0, #4
+	bne _08023BC0
+	ldr r0, [r5]
+	adds r1, r4, #0
+	bl CanUnitUseItem
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08023BC0
+	movs r0, #1
+	b _08023BC2
+	.align 2, 0
+_08023BBC: .4byte gUnknown_03004E50
+_08023BC0:
+	movs r0, #3
+_08023BC2:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START StaffItemSelect_Effect
+StaffItemSelect_Effect: @ 0x08023BC8
+	push {r4, r5, lr}
+	ldr r5, _08023C00  @ gUnknown_03004E50
+	ldr r0, [r5]
+	adds r1, #0x3c
+	ldrb r1, [r1]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl EquipUnitItemByIndex
+	ldr r4, _08023C04  @ gUnknown_0203A958
+	movs r0, #0
+	strb r0, [r4, #0x12]
+	bl ClearBG0BG1
+	ldr r0, [r5]
+	ldrb r2, [r4, #0x12]
+	lsls r2, r2, #1
+	adds r1, r0, #0
+	adds r1, #0x1e
+	adds r1, r1, r2
+	ldrh r1, [r1]
+	bl ItemEffect_Call
+	movs r0, #7
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023C00: .4byte gUnknown_03004E50
+_08023C04: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START StaffItemSelect_TextDraw
+StaffItemSelect_TextDraw: @ 0x08023C08
+	push {lr}
+	bl ItemSelectMenu_TextDraw
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START StaffItemSelect_OnHover
+StaffItemSelect_OnHover: @ 0x08023C14
+	push {r4, r5, r6, lr}
+	adds r4, r1, #0
+	ldr r5, _08023C5C  @ gUnknown_03004E50
+	ldr r0, [r5]
+	adds r4, #0x3c
+	movs r1, #0
+	ldrsb r1, [r4, r1]
+	bl GetUnitStaffRangeMask_0
+	adds r6, r0, #0
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	bl sub_801E748
+	ldr r0, _08023C60  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	movs r1, #1
+	negs r1, r1
+	bl ClearMapWith
+	ldr r0, _08023C64  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r0, [r5]
+	adds r1, r6, #0
+	bl FillRangeByRangeMask
+	movs r0, #4
+	bl DisplayMoveRangeGraphics
+	movs r0, #0
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023C5C: .4byte gUnknown_03004E50
+_08023C60: .4byte gUnknown_0202E4E0
+_08023C64: .4byte gUnknown_0202E4E4
+
+	THUMB_FUNC_START sub_8023C68
+sub_8023C68: @ 0x08023C68
+	push {lr}
+	adds r0, #0x63
+	ldrb r1, [r0]
+	movs r0, #4
+	ands r0, r1
+	cmp r0, #0
+	bne _08023C7A
+	bl HideMoveRangeGraphics
+_08023C7A:
+	movs r0, #0
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8023C80
+sub_8023C80: @ 0x08023C80
+	push {r4, lr}
+	ldr r4, _08023CA4  @ gUnknown_03004E50
+	ldr r2, [r4]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _08023C9E
+	adds r0, r2, #0
+	bl sub_8025610
+	bl sub_804FD28
+	cmp r0, #0
+	bne _08023CA8
+_08023C9E:
+	movs r0, #3
+	b _08023CBC
+	.align 2, 0
+_08023CA4: .4byte gUnknown_03004E50
+_08023CA8:
+	ldr r0, [r4]
+	adds r0, #0x30
+	ldrb r1, [r0]
+	movs r0, #0xf
+	ands r0, r1
+	cmp r0, #3
+	beq _08023CBA
+	movs r0, #1
+	b _08023CBC
+_08023CBA:
+	movs r0, #2
+_08023CBC:
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8023CC4
+sub_8023CC4: @ 0x08023CC4
+	push {lr}
+	adds r2, r0, #0
+	adds r1, #0x3d
+	ldrb r0, [r1]
+	cmp r0, #2
+	beq _08023CEC
+	ldr r0, _08023CE4  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl sub_8025610
+	ldr r0, _08023CE8  @ gUnknown_0859D398
+	bl NewTargetSelection
+	movs r0, #7
+	b _08023CF6
+	.align 2, 0
+_08023CE4: .4byte gUnknown_03004E50
+_08023CE8: .4byte gUnknown_0859D398
+_08023CEC:
+	ldr r1, _08023CFC  @ 0x00000852
+	adds r0, r2, #0
+	bl Menu_CallTextBox
+	movs r0, #8
+_08023CF6:
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023CFC: .4byte 0x00000852
+
+	THUMB_FUNC_START sub_8023D00
+sub_8023D00: @ 0x08023D00
+	ldr r2, _08023D10  @ gUnknown_0203A958
+	movs r0, #0xe
+	strb r0, [r2, #0x11]
+	ldrb r0, [r1, #2]
+	strb r0, [r2, #0xd]
+	movs r0, #0x17
+	bx lr
+	.align 2, 0
+_08023D10: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START sub_8023D14
+sub_8023D14: @ 0x08023D14
+	push {r4, lr}
+	ldr r4, _08023D44  @ gUnknown_03004E50
+	ldr r2, [r4]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _08023D40
+	adds r0, r2, #0
+	bl MakeTargetListForSupport
+	bl sub_804FD28
+	cmp r0, #0
+	beq _08023D40
+	ldr r0, [r4]
+	bl sub_8025610
+	bl sub_804FD28
+	cmp r0, #0
+	beq _08023D48
+_08023D40:
+	movs r0, #3
+	b _08023D5C
+	.align 2, 0
+_08023D44: .4byte gUnknown_03004E50
+_08023D48:
+	ldr r0, [r4]
+	adds r0, #0x30
+	ldrb r1, [r0]
+	movs r0, #0xf
+	ands r0, r1
+	cmp r0, #3
+	beq _08023D5A
+	movs r0, #1
+	b _08023D5C
+_08023D5A:
+	movs r0, #2
+_08023D5C:
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8023D64
+sub_8023D64: @ 0x08023D64
+	push {lr}
+	adds r2, r0, #0
+	adds r1, #0x3d
+	ldrb r0, [r1]
+	cmp r0, #2
+	beq _08023D8C
+	ldr r0, _08023D84  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl MakeTargetListForSupport
+	ldr r0, _08023D88  @ gUnknown_0859D378
+	bl NewTargetSelection
+	movs r0, #7
+	b _08023D96
+	.align 2, 0
+_08023D84: .4byte gUnknown_03004E50
+_08023D88: .4byte gUnknown_0859D378
+_08023D8C:
+	ldr r1, _08023D9C  @ 0x00000852
+	adds r0, r2, #0
+	bl Menu_CallTextBox
+	movs r0, #8
+_08023D96:
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023D9C: .4byte 0x00000852
+
+	THUMB_FUNC_START sub_8023DA0
+sub_8023DA0: @ 0x08023DA0
+	ldr r2, _08023DB0  @ gUnknown_0203A958
+	movs r0, #0xf
+	strb r0, [r2, #0x11]
+	ldrb r0, [r1, #2]
+	strb r0, [r2, #0xd]
+	movs r0, #0x17
+	bx lr
+	.align 2, 0
+_08023DB0: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START sub_8023DB4
+sub_8023DB4: @ 0x08023DB4
+	push {r4, lr}
+	ldr r4, _08023DD4  @ gUnknown_03004E50
+	ldr r2, [r4]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _08023DD0
+	adds r0, r2, #0
+	movs r1, #0x1e
+	bl sub_8018A9C
+	cmp r0, #0
+	bge _08023DD8
+_08023DD0:
+	movs r0, #3
+	b _08023DEE
+	.align 2, 0
+_08023DD4: .4byte gUnknown_03004E50
+_08023DD8:
+	ldr r0, [r4]
+	movs r1, #0x1e
+	bl MakeTargetListForDoorAndBridges
+	bl sub_804FD28
+	movs r1, #3
+	cmp r0, #0
+	beq _08023DEC
+	movs r1, #1
+_08023DEC:
+	adds r0, r1, #0
+_08023DEE:
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8023DF4
+sub_8023DF4: @ 0x08023DF4
+	push {r4, lr}
+	ldr r4, _08023E14  @ gUnknown_0203A958
+	movs r0, #0x12
+	strb r0, [r4, #0x11]
+	ldr r0, _08023E18  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldrb r1, [r0, #0xb]
+	strb r1, [r4, #0xc]
+	movs r1, #0x1e
+	bl sub_8018A9C
+	strb r0, [r4, #0x12]
+	movs r0, #0x17
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023E14: .4byte gUnknown_0203A958
+_08023E18: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_8023E1C
+sub_8023E1C: @ 0x08023E1C
+	push {r4, lr}
+	ldr r4, _08023E3C  @ gUnknown_03004E50
+	ldr r2, [r4]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _08023E38
+	adds r0, r2, #0
+	movs r1, #0x21
+	bl sub_8018A9C
+	cmp r0, #0
+	bge _08023E40
+_08023E38:
+	movs r0, #3
+	b _08023E52
+	.align 2, 0
+_08023E3C: .4byte gUnknown_03004E50
+_08023E40:
+	ldr r0, [r4]
+	bl CanUseChestKey
+	lsls r0, r0, #0x18
+	movs r1, #3
+	cmp r0, #0
+	beq _08023E50
+	movs r1, #1
+_08023E50:
+	adds r0, r1, #0
+_08023E52:
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8023E58
+sub_8023E58: @ 0x08023E58
+	push {r4, lr}
+	ldr r4, _08023E74  @ gUnknown_0203A958
+	movs r0, #0x14
+	strb r0, [r4, #0x11]
+	ldr r0, _08023E78  @ gUnknown_03004E50
+	ldr r0, [r0]
+	movs r1, #0x21
+	bl sub_8018A9C
+	strb r0, [r4, #0x12]
+	movs r0, #0x17
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023E74: .4byte gUnknown_0203A958
+_08023E78: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START PickCommandUsability
+PickCommandUsability: @ 0x08023E7C
+	push {lr}
+	ldr r0, _08023E98  @ gUnknown_03004E50
+	ldr r2, [r0]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _08023E94
+	ldr r0, [r2, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x33
+	beq _08023E9C
+_08023E94:
+	movs r0, #3
+	b _08023EB0
+	.align 2, 0
+_08023E98: .4byte gUnknown_03004E50
+_08023E9C:
+	adds r0, r2, #0
+	bl sub_80258A4
+	bl sub_804FD28
+	movs r1, #3
+	cmp r0, #0
+	beq _08023EAE
+	movs r1, #1
+_08023EAE:
+	adds r0, r1, #0
+_08023EB0:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8023EB4
+sub_8023EB4: @ 0x08023EB4
+	push {lr}
+	ldr r0, _08023ED0  @ gUnknown_0203A958
+	ldrb r0, [r0, #0xc]
+	bl GetUnitStruct
+	bl sub_80258A4
+	ldr r0, _08023ED4  @ gUnknown_0859D358
+	bl NewTargetSelection
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023ED0: .4byte gUnknown_0203A958
+_08023ED4: .4byte gUnknown_0859D358
+
+	THUMB_FUNC_START sub_8023ED8
+sub_8023ED8: @ 0x08023ED8
+	ldr r2, _08023EEC  @ gUnknown_0203A958
+	ldrb r0, [r1]
+	strb r0, [r2, #0x13]
+	ldrb r0, [r1, #1]
+	strb r0, [r2, #0x14]
+	movs r0, #0x15
+	strb r0, [r2, #0x11]
+	movs r0, #0x17
+	bx lr
+	.align 2, 0
+_08023EEC: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START sub_8023EF0
+sub_8023EF0: @ 0x08023EF0
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+	mov r8, r0
+	ldr r0, _08023F44  @ gUnknown_03004E50
+	ldr r0, [r0]
+	movs r7, #0x10
+	ldrsb r7, [r0, r7]
+	movs r6, #0x11
+	ldrsb r6, [r0, r6]
+	movs r5, #0
+	ldr r4, _08023F48  @ gUnknown_080D7C04
+_08023F0C:
+	movs r2, #0
+	ldrsb r2, [r4, r2]
+	adds r2, r7, r2
+	movs r0, #1
+	ldrsb r0, [r4, r0]
+	adds r0, r6, r0
+	ldr r1, _08023F4C  @ gUnknown_0202E4D8
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	ldr r0, [r0]
+	adds r0, r0, r2
+	ldrb r1, [r0]
+	movs r0, #0x80
+	ands r0, r1
+	cmp r0, #0
+	bne _08023F50
+	adds r0, r1, #0
+	bl GetUnitStruct
+	cmp r0, #0
+	beq _08023F50
+	ldr r0, [r0]
+	ldrb r0, [r0, #4]
+	cmp r0, r8
+	bne _08023F50
+	movs r0, #1
+	b _08023F5A
+	.align 2, 0
+_08023F44: .4byte gUnknown_03004E50
+_08023F48: .4byte gUnknown_080D7C04
+_08023F4C: .4byte gUnknown_0202E4D8
+_08023F50:
+	adds r4, #2
+	adds r5, #1
+	cmp r5, #3
+	ble _08023F0C
+	movs r0, #0
+_08023F5A:
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START SupplyUsability
+SupplyUsability: @ 0x08023F64
+	push {lr}
+	bl HasConvoyAccess
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08023FAC
+	ldr r1, _08023F8C  @ gUnknown_03004E50
+	ldr r0, [r1]
+	ldr r0, [r0, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x51
+	beq _08023FAC
+	ldr r0, _08023F90  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0x1b]
+	cmp r0, #2
+	beq _08023F88
+	cmp r0, #3
+	beq _08023F94
+_08023F88:
+	movs r2, #1
+	b _08023F96
+	.align 2, 0
+_08023F8C: .4byte gUnknown_03004E50
+_08023F90: .4byte gUnknown_0202BCF0
+_08023F94:
+	movs r2, #0xf
+_08023F96:
+	ldr r0, [r1]
+	ldr r0, [r0]
+	ldrb r0, [r0, #4]
+	cmp r0, r2
+	beq _08023FB0
+	adds r0, r2, #0
+	bl sub_8023EF0
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _08023FB0
+_08023FAC:
+	movs r0, #3
+	b _08023FB2
+_08023FB0:
+	movs r0, #1
+_08023FB2:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8023FB8
+sub_8023FB8: @ 0x08023FB8
+	push {lr}
+	ldr r1, _08023FD0  @ gUnknown_0203A958
+	movs r0, #0x1d
+	strb r0, [r1, #0x11]
+	ldr r0, _08023FD4  @ gUnknown_03004E50
+	ldr r0, [r0]
+	movs r1, #0
+	bl sub_809EB38
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08023FD0: .4byte gUnknown_0203A958
+_08023FD4: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_8023FD8
+sub_8023FD8: @ 0x08023FD8
+	push {lr}
+	ldr r0, _08023FF4  @ gUnknown_03004E50
+	ldr r2, [r0]
+	ldr r0, [r2, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x51
+	beq _08023FF0
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	beq _08023FF8
+_08023FF0:
+	movs r0, #3
+	b _0802400E
+	.align 2, 0
+_08023FF4: .4byte gUnknown_03004E50
+_08023FF8:
+	movs r0, #0x10
+	ldrsb r0, [r2, r0]
+	movs r1, #0x11
+	ldrsb r1, [r2, r1]
+	bl GetAvailableLocaCommandAt
+	movs r1, #3
+	cmp r0, #0x16
+	bne _0802400C
+	movs r1, #1
+_0802400C:
+	adds r0, r1, #0
+_0802400E:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024014
+sub_8024014: @ 0x08024014
+	push {lr}
+	ldr r0, _08024030  @ gUnknown_03004E50
+	ldr r1, [r0]
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	ldrb r1, [r1, #0x11]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl sub_80840C4
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08024030: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_8024034
+sub_8024034: @ 0x08024034
+	push {lr}
+	ldr r0, _08024050  @ gUnknown_03004E50
+	ldr r2, [r0]
+	ldr r0, [r2, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x51
+	beq _0802404C
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	beq _08024054
+_0802404C:
+	movs r0, #3
+	b _0802406A
+	.align 2, 0
+_08024050: .4byte gUnknown_03004E50
+_08024054:
+	movs r0, #0x10
+	ldrsb r0, [r2, r0]
+	movs r1, #0x11
+	ldrsb r1, [r2, r1]
+	bl GetAvailableLocaCommandAt
+	movs r1, #3
+	cmp r0, #0x17
+	bne _08024068
+	movs r1, #1
+_08024068:
+	adds r0, r1, #0
+_0802406A:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024070
+sub_8024070: @ 0x08024070
+	push {lr}
+	ldr r0, _0802408C  @ gUnknown_03004E50
+	ldr r1, [r0]
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	ldrb r1, [r1, #0x11]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl sub_80840C4
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0802408C: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_8024090
+sub_8024090: @ 0x08024090
+	push {lr}
+	ldr r0, _080240AC  @ gUnknown_03004E50
+	ldr r2, [r0]
+	ldr r0, [r2, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x51
+	beq _080240A8
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	beq _080240B0
+_080240A8:
+	movs r0, #3
+	b _080240C6
+	.align 2, 0
+_080240AC: .4byte gUnknown_03004E50
+_080240B0:
+	movs r0, #0x10
+	ldrsb r0, [r2, r0]
+	movs r1, #0x11
+	ldrsb r1, [r2, r1]
+	bl GetAvailableLocaCommandAt
+	movs r1, #3
+	cmp r0, #0x18
+	bne _080240C4
+	movs r1, #1
+_080240C4:
+	adds r0, r1, #0
+_080240C6:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_80240CC
+sub_80240CC: @ 0x080240CC
+	push {lr}
+	ldr r0, _080240E8  @ gUnknown_03004E50
+	ldr r1, [r0]
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	ldrb r1, [r1, #0x11]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl sub_80840C4
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080240E8: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_80240EC
+sub_80240EC: @ 0x080240EC
+	push {lr}
+	ldr r0, _08024124  @ gUnknown_03004E50
+	ldr r2, [r0]
+	ldr r0, [r2, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x51
+	beq _0802411E
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _0802411E
+	movs r0, #0x11
+	ldrsb r0, [r2, r0]
+	ldr r1, _08024128  @ gUnknown_0202E4DC
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r1, #0x10
+	ldrsb r1, [r2, r1]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	cmp r0, #8
+	beq _0802412C
+_0802411E:
+	movs r0, #3
+	b _0802413E
+	.align 2, 0
+_08024124: .4byte gUnknown_03004E50
+_08024128: .4byte gUnknown_0202E4DC
+_0802412C:
+	adds r0, r2, #0
+	bl sub_8031F50
+	lsls r0, r0, #0x18
+	movs r1, #2
+	cmp r0, #0
+	beq _0802413C
+	movs r1, #1
+_0802413C:
+	adds r0, r1, #0
+_0802413E:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024144
+sub_8024144: @ 0x08024144
+	push {r4, lr}
+	adds r4, r0, #0
+	adds r1, #0x3d
+	ldrb r0, [r1]
+	cmp r0, #2
+	bne _08024180
+	ldr r0, _08024168  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl CanUnitNotUseMagic
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08024170
+	ldr r1, _0802416C  @ 0x00000853
+	adds r0, r4, #0
+	bl Menu_CallTextBox
+	b _08024178
+	.align 2, 0
+_08024168: .4byte gUnknown_03004E50
+_0802416C: .4byte 0x00000853
+_08024170:
+	ldr r1, _0802417C  @ 0x00000854
+	adds r0, r4, #0
+	bl Menu_CallTextBox
+_08024178:
+	movs r0, #8
+	b _08024186
+	.align 2, 0
+_0802417C: .4byte 0x00000854
+_08024180:
+	bl sub_80B576C
+	movs r0, #0x17
+_08024186:
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START StealCommandUsability
+StealCommandUsability: @ 0x0802418C
+	push {r4, lr}
+	ldr r4, _080241C0  @ gUnknown_03004E50
+	ldr r2, [r4]
+	ldr r0, [r2]
+	ldr r1, [r2, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	movs r1, #4
+	ands r0, r1
+	cmp r0, #0
+	beq _080241BC
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _080241BC
+	adds r0, r2, #0
+	bl MakeTargetListForSteal
+	bl sub_804FD28
+	cmp r0, #0
+	bne _080241C4
+_080241BC:
+	movs r0, #3
+	b _080241D4
+	.align 2, 0
+_080241C0: .4byte gUnknown_03004E50
+_080241C4:
+	ldr r0, [r4]
+	bl GetUnitItemCount
+	cmp r0, #5
+	beq _080241D2
+	movs r0, #1
+	b _080241D4
+_080241D2:
+	movs r0, #2
+_080241D4:
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START StealCommandEffect
+StealCommandEffect: @ 0x080241DC
+	push {lr}
+	adds r2, r0, #0
+	adds r1, #0x3d
+	ldrb r0, [r1]
+	cmp r0, #2
+	beq _08024208
+	bl ClearBG0BG1
+	ldr r0, _08024200  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl MakeTargetListForSteal
+	ldr r0, _08024204  @ gUnknown_0859D318
+	bl NewTargetSelection
+	movs r0, #7
+	b _08024212
+	.align 2, 0
+_08024200: .4byte gUnknown_03004E50
+_08024204: .4byte gUnknown_0859D318
+_08024208:
+	ldr r1, _08024218  @ 0x00000862
+	adds r0, r2, #0
+	bl Menu_CallTextBox
+	movs r0, #8
+_08024212:
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08024218: .4byte 0x00000862
+
+	THUMB_FUNC_START StealTargetSelection_OnInit
+StealTargetSelection_OnInit: @ 0x0802421C
+	push {r4, lr}
+	adds r4, r0, #0
+	bl NewUnitInfoWindow_WithAllLines
+	ldr r0, _08024238  @ 0x0000086D
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08024238: .4byte 0x0000086D
+
+	THUMB_FUNC_START sub_802423C
+sub_802423C: @ 0x0802423C
+	push {r4, lr}
+	adds r4, r1, #0
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	movs r1, #1
+	ldrsb r1, [r4, r1]
+	bl ChangeActiveUnitFacing
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	bl sub_8034D48
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024260
+sub_8024260: @ 0x08024260
+	push {r4, r5, r6, lr}
+	sub sp, #8
+	adds r4, r0, #0
+	ldr r6, _080242F0  @ gUnknown_0203A958
+	ldrb r0, [r1, #2]
+	strb r0, [r6, #0xd]
+	bl ResetIconGraphics
+	movs r0, #4
+	bl LoadIconPalettes
+	ldr r0, _080242F4  @ gUnknown_0859D088
+	bl NewMenu_Default
+	adds r0, r4, #0
+	bl EndTargetSelection
+	ldr r0, _080242F8  @ gUnknown_0202352C
+	ldr r1, _080242FC  @ gUnknown_085A0D4C
+	movs r2, #0x80
+	lsls r2, r2, #5
+	bl CallARM_FillTileRect
+	ldrb r0, [r6, #0xd]
+	bl GetUnitStruct
+	ldr r0, [r0]
+	ldrh r0, [r0]
+	bl GetStringFromIndex
+	bl GetStringTextWidth
+	movs r4, #0x38
+	subs r4, r4, r0
+	lsrs r0, r4, #0x1f
+	adds r4, r4, r0
+	asrs r4, r4, #1
+	ldrb r0, [r6, #0xd]
+	bl GetUnitStruct
+	ldr r0, [r0]
+	ldrh r0, [r0]
+	bl GetStringFromIndex
+	ldr r5, _08024300  @ gUnknown_02022D6E
+	movs r1, #7
+	str r1, [sp]
+	str r0, [sp, #4]
+	movs r0, #0
+	adds r1, r5, #0
+	movs r2, #0
+	adds r3, r4, #0
+	bl DrawTextInline
+	adds r5, #0x80
+	ldrb r0, [r6, #0xd]
+	bl GetUnitStruct
+	bl GetUnitPortraitId
+	adds r1, r0, #0
+	movs r2, #0x80
+	lsls r2, r2, #2
+	adds r0, r5, #0
+	movs r3, #5
+	bl sub_8005CA4
+	movs r0, #0
+	add sp, #8
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080242F0: .4byte gUnknown_0203A958
+_080242F4: .4byte gUnknown_0859D088
+_080242F8: .4byte gUnknown_0202352C
+_080242FC: .4byte gUnknown_085A0D4C
+_08024300: .4byte gUnknown_02022D6E
+
+	THUMB_FUNC_START StealItemMenuCommand_Usability
+StealItemMenuCommand_Usability: @ 0x08024304
+	push {r4, r5, lr}
+	adds r4, r1, #0
+	ldr r5, _08024320  @ gUnknown_0203A958
+	ldrb r0, [r5, #0xd]
+	bl GetUnitStruct
+	lsls r4, r4, #1
+	adds r0, #0x1e
+	adds r0, r0, r4
+	ldrh r0, [r0]
+	cmp r0, #0
+	bne _08024324
+	movs r0, #3
+	b _08024340
+	.align 2, 0
+_08024320: .4byte gUnknown_0203A958
+_08024324:
+	ldrb r0, [r5, #0xd]
+	bl GetUnitStruct
+	adds r0, #0x1e
+	adds r0, r0, r4
+	ldrh r0, [r0]
+	bl IsItemStealable
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802433E
+	movs r0, #1
+	b _08024340
+_0802433E:
+	movs r0, #2
+_08024340:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START StealItemMenuCommand_Draw
+StealItemMenuCommand_Draw: @ 0x08024348
+	push {r4, r5, r6, lr}
+	adds r5, r1, #0
+	ldr r0, _08024394  @ gUnknown_0203A958
+	ldrb r0, [r0, #0xd]
+	bl GetUnitStruct
+	adds r1, r5, #0
+	adds r1, #0x3c
+	ldrb r1, [r1]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	lsls r1, r1, #1
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r4, [r0]
+	adds r0, r4, #0
+	bl IsItemStealable
+	adds r2, r0, #0
+	adds r0, r5, #0
+	adds r0, #0x34
+	lsls r2, r2, #0x18
+	asrs r2, r2, #0x18
+	movs r1, #0x2c
+	ldrsh r3, [r5, r1]
+	lsls r3, r3, #5
+	movs r6, #0x2a
+	ldrsh r1, [r5, r6]
+	adds r3, r3, r1
+	lsls r3, r3, #1
+	ldr r1, _08024398  @ gBG0TilemapBuffer
+	adds r3, r3, r1
+	adds r1, r4, #0
+	bl DrawItemMenuCommand
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08024394: .4byte gUnknown_0203A958
+_08024398: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START StealItemMenuCommand_Effect
+StealItemMenuCommand_Effect: @ 0x0802439C
+	push {lr}
+	adds r3, r0, #0
+	adds r2, r1, #0
+	adds r0, r2, #0
+	adds r0, #0x3d
+	ldrb r0, [r0]
+	cmp r0, #2
+	beq _080243C4
+	ldr r1, _080243C0  @ gUnknown_0203A958
+	adds r0, r2, #0
+	adds r0, #0x3c
+	ldrb r0, [r0]
+	strb r0, [r1, #0x12]
+	movs r0, #6
+	strb r0, [r1, #0x11]
+	movs r0, #0x17
+	b _080243CE
+	.align 2, 0
+_080243C0: .4byte gUnknown_0203A958
+_080243C4:
+	ldr r1, _080243D4  @ 0x00000855
+	adds r0, r3, #0
+	bl Menu_CallTextBox
+	movs r0, #8
+_080243CE:
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080243D4: .4byte 0x00000855
+
+	THUMB_FUNC_START sub_80243D8
+sub_80243D8: @ 0x080243D8
+	push {r4, r5, lr}
+	ldr r5, _08024424  @ gUnknown_03004E50
+	ldr r2, [r5]
+	ldr r0, [r2]
+	ldr r1, [r2, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #0x14
+	ands r0, r1
+	cmp r0, #0
+	beq _0802445A
+	ldr r0, [r2, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _0802445A
+	adds r0, r2, #0
+	bl sub_8025CA4
+	bl sub_804FD28
+	cmp r0, #0
+	beq _0802445A
+	ldr r4, _08024428  @ 0x0000FFFF
+	movs r2, #0
+	ldr r0, [r5]
+	ldr r0, [r0]
+	ldr r1, _0802442C  @ gUnknown_0895F5A4
+	ldrb r0, [r0, #4]
+	adds r3, r1, #0
+	ldrb r1, [r3]
+	cmp r0, r1
+	bne _08024430
+	movs r4, #0
+	b _0802444E
+	.align 2, 0
+_08024424: .4byte gUnknown_03004E50
+_08024428: .4byte 0x0000FFFF
+_0802442C: .4byte gUnknown_0895F5A4
+_08024430:
+	adds r0, r2, #1
+	lsls r0, r0, #0x10
+	lsrs r2, r0, #0x10
+	cmp r2, #2
+	bhi _0802444E
+	ldr r0, _08024460  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldr r1, [r0]
+	lsls r0, r2, #1
+	adds r0, r0, r3
+	ldrb r1, [r1, #4]
+	ldrb r0, [r0]
+	cmp r1, r0
+	bne _08024430
+	adds r4, r2, #0
+_0802444E:
+	lsls r0, r4, #0x10
+	asrs r1, r0, #0x10
+	movs r0, #1
+	negs r0, r0
+	cmp r1, r0
+	bne _08024470
+_0802445A:
+	movs r0, #3
+	b _080244B0
+	.align 2, 0
+_08024460: .4byte gUnknown_03004E50
+_08024464:
+	ldr r0, _0802446C  @ 0xFFFEFFF3
+	ands r1, r0
+	str r1, [r2, #0xc]
+	b _080244AE
+	.align 2, 0
+_0802446C: .4byte 0xFFFEFFF3
+_08024470:
+	movs r4, #1
+	lsls r1, r1, #1
+	ldr r0, _080244A0  @ gUnknown_0895F5A5
+	adds r5, r1, r0
+_08024478:
+	adds r0, r4, #0
+	bl GetUnitStruct
+	adds r2, r0, #0
+	cmp r2, #0
+	beq _080244A8
+	ldr r0, [r2]
+	cmp r0, #0
+	beq _080244A8
+	ldrb r0, [r0, #4]
+	ldrb r1, [r5]
+	cmp r0, r1
+	bne _080244A8
+	ldr r1, [r2, #0xc]
+	ldr r0, _080244A4  @ 0x0001000C
+	ands r0, r1
+	cmp r0, #0
+	bne _08024464
+	b _0802445A
+	.align 2, 0
+_080244A0: .4byte gUnknown_0895F5A5
+_080244A4: .4byte 0x0001000C
+_080244A8:
+	adds r4, #1
+	cmp r4, #0x3f
+	ble _08024478
+_080244AE:
+	movs r0, #1
+_080244B0:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_80244B8
+sub_80244B8: @ 0x080244B8
+	push {lr}
+	ldr r0, _080244D0  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl sub_8025CA4
+	ldr r0, _080244D4  @ gUnknown_0859D338
+	bl NewTargetSelection
+	movs r0, #7
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080244D0: .4byte gUnknown_03004E50
+_080244D4: .4byte gUnknown_0859D338
+
+	THUMB_FUNC_START sub_80244D8
+sub_80244D8: @ 0x080244D8
+	push {r4, r5, lr}
+	adds r5, r1, #0
+	ldr r4, _080244F8  @ gUnknown_0203A958
+	ldrb r0, [r4, #0xc]
+	bl GetUnitStruct
+	movs r0, #7
+	strb r0, [r4, #0x11]
+	ldrb r0, [r5]
+	strb r0, [r4, #0x13]
+	ldrb r0, [r5, #1]
+	strb r0, [r4, #0x14]
+	movs r0, #0x17
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080244F8: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START sub_80244FC
+sub_80244FC: @ 0x080244FC
+	push {r4, r5, lr}
+	ldr r0, _08024518  @ gUnknown_03004E50
+	ldr r1, [r0]
+	ldr r0, [r1, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x66
+	bne _08024514
+	ldr r0, [r1, #0xc]
+	movs r1, #0x40
+	ands r0, r1
+	cmp r0, #0
+	beq _0802451C
+_08024514:
+	movs r0, #3
+	b _08024542
+	.align 2, 0
+_08024518: .4byte gUnknown_03004E50
+_0802451C:
+	movs r5, #0
+	movs r4, #0x81
+_08024520:
+	adds r0, r4, #0
+	bl GetUnitStruct
+	cmp r0, #0
+	beq _0802453A
+	ldr r0, [r0]
+	cmp r0, #0
+	beq _0802453A
+	cmp r5, #0x27
+	bhi _08024514
+	adds r0, r5, #1
+	lsls r0, r0, #0x10
+	lsrs r5, r0, #0x10
+_0802453A:
+	adds r4, #1
+	cmp r4, #0xbf
+	ble _08024520
+	movs r0, #1
+_08024542:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024548
+sub_8024548: @ 0x08024548
+	push {r4, lr}
+	ldr r4, _08024560  @ gUnknown_0203A958
+	ldrb r0, [r4, #0xc]
+	bl GetUnitStruct
+	movs r0, #8
+	strb r0, [r4, #0x11]
+	movs r0, #0x17
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08024560: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START sub_8024564
+sub_8024564: @ 0x08024564
+	push {r4, r5, lr}
+	adds r5, r1, #0
+	ldr r4, _08024584  @ gUnknown_0203A958
+	ldrb r0, [r4, #0xc]
+	bl GetUnitStruct
+	movs r0, #8
+	strb r0, [r4, #0x11]
+	ldrb r0, [r5]
+	strb r0, [r4, #0x13]
+	ldrb r0, [r5, #1]
+	strb r0, [r4, #0x14]
+	movs r0, #0x17
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08024584: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START sub_8024588
+sub_8024588: @ 0x08024588
+	push {r4, lr}
+	adds r4, r1, #0
+	adds r4, #0x3c
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	cmp r0, #4
+	ble _080245B4
+	movs r2, #0x2a
+	ldrsh r0, [r1, r2]
+	lsls r0, r0, #3
+	movs r2, #0x2c
+	ldrsh r1, [r1, r2]
+	lsls r1, r1, #3
+	ldr r2, _080245B0  @ gUnknown_0202BCB0
+	ldrh r2, [r2, #0x2c]
+	bl sub_8088E60
+	movs r0, #0
+	b _080245D4
+	.align 2, 0
+_080245B0: .4byte gUnknown_0202BCB0
+_080245B4:
+	movs r2, #0x2a
+	ldrsh r0, [r1, r2]
+	lsls r0, r0, #3
+	movs r2, #0x2c
+	ldrsh r1, [r1, r2]
+	lsls r1, r1, #3
+	ldr r2, _080245DC  @ gUnknown_03004E50
+	ldr r3, [r2]
+	movs r2, #0
+	ldrsb r2, [r4, r2]
+	lsls r2, r2, #1
+	adds r3, #0x1e
+	adds r3, r3, r2
+	ldrh r2, [r3]
+	bl sub_8088E60
+_080245D4:
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080245DC: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_80245E0
+sub_80245E0: @ 0x080245E0
+	push {r4, lr}
+	adds r4, r1, #0
+	ldr r0, _08024614  @ gUnknown_0203A958
+	ldrb r0, [r0, #0xd]
+	bl GetUnitStruct
+	movs r1, #0x2a
+	ldrsh r3, [r4, r1]
+	lsls r3, r3, #3
+	movs r2, #0x2c
+	ldrsh r1, [r4, r2]
+	lsls r1, r1, #3
+	adds r4, #0x3c
+	movs r2, #0
+	ldrsb r2, [r4, r2]
+	lsls r2, r2, #1
+	adds r0, #0x1e
+	adds r0, r0, r2
+	ldrh r2, [r0]
+	adds r0, r3, #0
+	bl sub_8088E60
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08024614: .4byte gUnknown_0203A958
+
+	THUMB_FUNC_START sub_8024618
+sub_8024618: @ 0x08024618
+	push {r4, r5, lr}
+	movs r0, #0x2a
+	ldrsh r5, [r1, r0]
+	lsls r5, r5, #3
+	movs r0, #0x2c
+	ldrsh r4, [r1, r0]
+	lsls r4, r4, #3
+	ldr r0, _08024648  @ gUnknown_03004E50
+	ldr r1, [r0]
+	movs r0, #0x10
+	ldrsb r0, [r1, r0]
+	ldrb r1, [r1, #0x11]
+	lsls r1, r1, #0x18
+	asrs r1, r1, #0x18
+	bl GetBallistaItemAt
+	adds r2, r0, #0
+	adds r0, r5, #0
+	adds r1, r4, #0
+	bl sub_8088E60
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08024648: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_802464C
+sub_802464C: @ 0x0802464C
+	push {lr}
+	bl sub_8034F9C
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_8024658
+sub_8024658: @ 0x08024658
+	push {r4, lr}
+	adds r4, r1, #0
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	movs r1, #1
+	ldrsb r1, [r4, r1]
+	bl ChangeActiveUnitFacing
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	bl sub_8034FB0
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START RescueSelection_OnConstruction
+RescueSelection_OnConstruction: @ 0x0802467C
+	push {r4, lr}
+	adds r4, r0, #0
+	bl sub_80351CC
+	ldr r0, _08024698  @ 0x00000868
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08024698: .4byte 0x00000868
+
+	THUMB_FUNC_START RescueSelection_OnChange
+RescueSelection_OnChange: @ 0x0802469C
+	push {r4, lr}
+	adds r4, r1, #0
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	movs r1, #1
+	ldrsb r1, [r4, r1]
+	bl ChangeActiveUnitFacing
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	bl SetupUnitRescueWindow
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START DropSelection_OnConstruction
+DropSelection_OnConstruction: @ 0x080246C0
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _080246D8  @ 0x00000869
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080246D8: .4byte 0x00000869
+
+	THUMB_FUNC_START sub_80246DC
+sub_80246DC: @ 0x080246DC
+	bx lr
+
+	THUMB_FUNC_START sub_80246E0
+sub_80246E0: @ 0x080246E0
+	push {r4, lr}
+	adds r4, r0, #0
+	bl sub_8035380
+	ldr r0, _080246FC  @ 0x0000086B
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080246FC: .4byte 0x0000086B
+
+	THUMB_FUNC_START sub_8024700
+sub_8024700: @ 0x08024700
+	push {r4, lr}
+	adds r4, r1, #0
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	movs r1, #1
+	ldrsb r1, [r4, r1]
+	bl ChangeActiveUnitFacing
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	bl sub_80353B8
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024724
+sub_8024724: @ 0x08024724
+	push {r4, lr}
+	adds r4, r0, #0
+	bl sub_80351CC
+	ldr r0, _08024740  @ 0x0000086A
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08024740: .4byte 0x0000086A
+
+	THUMB_FUNC_START sub_8024744
+sub_8024744: @ 0x08024744
+	push {r4, lr}
+	adds r4, r1, #0
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	movs r1, #1
+	ldrsb r1, [r4, r1]
+	bl ChangeActiveUnitFacing
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	bl sub_80352BC
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START TradeTargetSelection_OnInit
+TradeTargetSelection_OnInit: @ 0x08024768
+	push {r4, lr}
+	adds r4, r0, #0
+	bl NewUnitInfoWindow_WithAllLines
+	ldr r0, _08024784  @ 0x0000086C
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08024784: .4byte 0x0000086C
+
+	THUMB_FUNC_START sub_8024788
+sub_8024788: @ 0x08024788
+	push {r4, lr}
+	adds r4, r1, #0
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	movs r1, #1
+	ldrsb r1, [r4, r1]
+	bl ChangeActiveUnitFacing
+	bl ResetIconGraphics
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	bl sub_8034C3C
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_80247B0
+sub_80247B0: @ 0x080247B0
+	push {r4, lr}
+	adds r4, r0, #0
+	bl sub_8034F9C
+	ldr r0, _080247CC  @ 0x0000086F
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080247CC: .4byte 0x0000086F
+
+	THUMB_FUNC_START sub_80247D0
+sub_80247D0: @ 0x080247D0
+	push {r4, lr}
+	adds r4, r1, #0
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	movs r1, #1
+	ldrsb r1, [r4, r1]
+	bl ChangeActiveUnitFacing
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	bl sub_8034FB0
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_80247F4
+sub_80247F4: @ 0x080247F4
+	push {r4, lr}
+	adds r4, r0, #0
+	bl sub_8034F9C
+	movs r0, #0x87
+	lsls r0, r0, #4
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_8024814
+sub_8024814: @ 0x08024814
+	push {r4, lr}
+	adds r4, r1, #0
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	movs r1, #1
+	ldrsb r1, [r4, r1]
+	bl ChangeActiveUnitFacing
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	bl sub_8034FB0
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024838
+sub_8024838: @ 0x08024838
+	push {lr}
+	bl sub_8034F9C
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_8024844
+sub_8024844: @ 0x08024844
+	push {r4, lr}
+	adds r4, r1, #0
+	movs r0, #0
+	ldrsb r0, [r4, r0]
+	movs r1, #1
+	ldrsb r1, [r4, r1]
+	bl ChangeActiveUnitFacing
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	bl sub_8034FB0
+	pop {r4}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024868
+sub_8024868: @ 0x08024868
+	push {r4, lr}
+	adds r4, r0, #0
+	movs r0, #0x88
+	lsls r0, r0, #4
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START nullsub_27
+nullsub_27: @ 0x08024884
+	bx lr
+
+	THUMB_FUNC_START sub_8024888
+sub_8024888: @ 0x08024888
+	push {r4, lr}
+	adds r4, r0, #0
+	movs r0, #0x88
+	lsls r0, r0, #4
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_80248A4
+sub_80248A4: @ 0x080248A4
+	bx lr
+
+	THUMB_FUNC_START sub_80248A8
+sub_80248A8: @ 0x080248A8
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _080248C0  @ 0x00000881
+	bl GetStringFromIndex
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl NewBottomHelpText
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080248C0: .4byte 0x00000881
+
+	THUMB_FUNC_START RideCommandUsability
+RideCommandUsability: @ 0x080248C4
+	push {lr}
+	ldr r0, _08024910  @ gUnknown_03004E50
+	ldr r2, [r0]
+	ldr r0, [r2]
+	ldr r1, [r2, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	ands r0, r1
+	cmp r0, #0
+	beq _08024918
+	ldr r0, [r2, #0xc]
+	movs r1, #0x83
+	lsls r1, r1, #4
+	ands r0, r1
+	cmp r0, #0
+	bne _08024918
+	ldr r0, _08024914  @ gUnknown_0202BCB0
+	adds r0, #0x3d
+	ldrb r1, [r0]
+	movs r0, #8
+	ands r0, r1
+	cmp r0, #0
+	bne _08024918
+	movs r0, #0x10
+	ldrsb r0, [r2, r0]
+	movs r1, #0x11
+	ldrsb r1, [r2, r1]
+	bl GetTrapAt
+	cmp r0, #0
+	beq _08024918
+	ldrb r0, [r0, #2]
+	cmp r0, #1
+	bne _08024918
+	movs r0, #1
+	b _0802491A
+	.align 2, 0
+_08024910: .4byte gUnknown_03004E50
+_08024914: .4byte gUnknown_0202BCB0
+_08024918:
+	movs r0, #3
+_0802491A:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START RideCommandEffect
+RideCommandEffect: @ 0x08024920
+	push {r4, lr}
+	ldr r1, _08024944  @ gUnknown_0203A958
+	movs r0, #0x21
+	strb r0, [r1, #0x11]
+	ldr r4, _08024948  @ gUnknown_03004E50
+	ldr r0, [r4]
+	bl RideBallista
+	bl ClearMOVEUNITs
+	ldr r0, [r4]
+	bl MakeMOVEUNITForMapUnit
+	movs r0, #0x17
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08024944: .4byte gUnknown_0203A958
+_08024948: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_802494C
+sub_802494C: @ 0x0802494C
+	push {lr}
+	ldr r0, _08024970  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldr r0, [r0, #0xc]
+	movs r1, #0x80
+	lsls r1, r1, #4
+	ands r0, r1
+	cmp r0, #0
+	beq _08024978
+	ldr r0, _08024974  @ gUnknown_0202BCB0
+	adds r0, #0x3d
+	ldrb r1, [r0]
+	movs r0, #8
+	ands r0, r1
+	cmp r0, #0
+	bne _08024978
+	movs r0, #1
+	b _0802497A
+	.align 2, 0
+_08024970: .4byte gUnknown_03004E50
+_08024974: .4byte gUnknown_0202BCB0
+_08024978:
+	movs r0, #3
+_0802497A:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024980
+sub_8024980: @ 0x08024980
+	push {r4, lr}
+	ldr r1, _080249A4  @ gUnknown_0203A958
+	movs r0, #0x22
+	strb r0, [r1, #0x11]
+	ldr r4, _080249A8  @ gUnknown_03004E50
+	ldr r0, [r4]
+	bl TryRemoveUnitFromBallista
+	bl ClearMOVEUNITs
+	ldr r0, [r4]
+	bl MakeMOVEUNITForMapUnit
+	movs r0, #0x17
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080249A4: .4byte gUnknown_0203A958
+_080249A8: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START AttackCommandUsability
+AttackCommandUsability: @ 0x080249AC
+	push {r4, r5, r6, lr}
+	ldr r0, _080249C8  @ gUnknown_03004E50
+	ldr r1, [r0]
+	ldr r2, [r1, #0xc]
+	movs r0, #0x40
+	ands r0, r2
+	cmp r0, #0
+	bne _08024A1C
+	movs r0, #0x80
+	lsls r0, r0, #4
+	ands r2, r0
+	cmp r2, #0
+	beq _080249D0
+	b _08024A1C
+	.align 2, 0
+_080249C8: .4byte gUnknown_03004E50
+_080249CC:
+	movs r0, #1
+	b _08024A1E
+_080249D0:
+	movs r6, #0
+	ldrh r4, [r1, #0x1e]
+	cmp r4, #0
+	beq _08024A1C
+_080249D8:
+	adds r0, r4, #0
+	bl GetItemAttributes
+	movs r1, #1
+	ands r1, r0
+	cmp r1, #0
+	beq _08024A06
+	ldr r5, _08024A24  @ gUnknown_03004E50
+	ldr r0, [r5]
+	adds r1, r4, #0
+	bl CanUnitUseWeapon
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08024A06
+	ldr r0, [r5]
+	adds r1, r4, #0
+	bl MakeTargetListForWeapon
+	bl sub_804FD28
+	cmp r0, #0
+	bne _080249CC
+_08024A06:
+	adds r6, #1
+	cmp r6, #4
+	bgt _08024A1C
+	ldr r0, _08024A24  @ gUnknown_03004E50
+	ldr r0, [r0]
+	lsls r1, r6, #1
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r4, [r0]
+	cmp r4, #0
+	bne _080249D8
+_08024A1C:
+	movs r0, #3
+_08024A1E:
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08024A24: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START AttackBallistaCommandUsability
+AttackBallistaCommandUsability: @ 0x08024A28
+	push {r4, r5, lr}
+	ldr r5, _08024A6C  @ gUnknown_03004E50
+	ldr r2, [r5]
+	ldr r0, [r2, #0xc]
+	movs r1, #0x80
+	lsls r1, r1, #4
+	ands r0, r1
+	cmp r0, #0
+	beq _08024A66
+	movs r0, #0x10
+	ldrsb r0, [r2, r0]
+	movs r1, #0x11
+	ldrsb r1, [r2, r1]
+	bl GetTrapAt
+	adds r4, r0, #0
+	bl IsBallista
+	cmp r0, #0
+	beq _08024A66
+	ldr r0, [r5]
+	ldrb r1, [r4, #3]
+	movs r2, #0x80
+	lsls r2, r2, #1
+	adds r1, r1, r2
+	bl MakeTargetListForWeapon
+	bl sub_804FD28
+	cmp r0, #0
+	bne _08024A70
+_08024A66:
+	movs r0, #3
+	b _08024A80
+	.align 2, 0
+_08024A6C: .4byte gUnknown_03004E50
+_08024A70:
+	adds r0, r4, #0
+	bl GetBallistaItemUses
+	cmp r0, #0
+	beq _08024A7E
+	movs r0, #1
+	b _08024A80
+_08024A7E:
+	movs r0, #2
+_08024A80:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024A88
+sub_8024A88: @ 0x08024A88
+	push {lr}
+	ldr r0, _08024AA0  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl sub_8025B6C
+	bl sub_804FD28
+	cmp r0, #0
+	beq _08024AA4
+	movs r0, #1
+	b _08024AA6
+	.align 2, 0
+_08024AA0: .4byte gUnknown_03004E50
+_08024AA4:
+	movs r0, #3
+_08024AA6:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024AAC
+sub_8024AAC: @ 0x08024AAC
+	push {r4, r5, lr}
+	adds r4, r1, #0
+	adds r5, r4, #0
+	adds r5, #0x34
+	ldr r0, _08024AE8  @ gUnknown_0202BCB0
+	ldrh r0, [r0, #0x2c]
+	bl GetItemNameString
+	adds r3, r0, #0
+	adds r0, r5, #0
+	movs r1, #0x10
+	movs r2, #0
+	bl Text_InsertString
+	movs r0, #0x2c
+	ldrsh r1, [r4, r0]
+	lsls r1, r1, #5
+	movs r2, #0x2a
+	ldrsh r0, [r4, r2]
+	adds r1, r1, r0
+	lsls r1, r1, #1
+	ldr r0, _08024AEC  @ gBG0TilemapBuffer
+	adds r1, r1, r0
+	adds r0, r5, #0
+	bl Text_Draw
+	movs r0, #0
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08024AE8: .4byte gUnknown_0202BCB0
+_08024AEC: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_8024AF0
+sub_8024AF0: @ 0x08024AF0
+	push {lr}
+	adds r1, #0x3d
+	ldrb r0, [r1]
+	cmp r0, #2
+	beq _08024B14
+	ldr r0, _08024B0C  @ gUnknown_03004E50
+	ldr r0, [r0]
+	bl sub_8025B6C
+	ldr r0, _08024B10  @ gUnknown_0859D2B8
+	bl NewTargetSelection
+	movs r0, #0x27
+	b _08024B16
+	.align 2, 0
+_08024B0C: .4byte gUnknown_03004E50
+_08024B10: .4byte gUnknown_0859D2B8
+_08024B14:
+	movs r0, #8
+_08024B16:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024B1C
+sub_8024B1C: @ 0x08024B1C
+	push {r4, r5, lr}
+	ldr r5, _08024B48  @ gUnknown_03004E50
+	ldr r0, [r5]
+	subs r1, #1
+	lsls r1, r1, #1
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r4, [r0]
+	adds r0, r4, #0
+	bl GetItemWType
+	cmp r0, #0xc
+	bne _08024B4C
+	ldr r0, [r5]
+	adds r1, r4, #0
+	bl CanUnitUseItem
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08024B4C
+	movs r0, #1
+	b _08024B4E
+	.align 2, 0
+_08024B48: .4byte gUnknown_03004E50
+_08024B4C:
+	movs r0, #3
+_08024B4E:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024B54
+sub_8024B54: @ 0x08024B54
+	push {r4, lr}
+	adds r2, r1, #0
+	ldr r0, _08024B94  @ gUnknown_03004E50
+	ldr r1, [r0]
+	adds r0, r2, #0
+	adds r0, #0x3c
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	subs r0, #1
+	lsls r0, r0, #1
+	adds r1, #0x1e
+	adds r1, r1, r0
+	ldrh r1, [r1]
+	adds r0, r2, #0
+	adds r0, #0x34
+	movs r4, #0x2c
+	ldrsh r3, [r2, r4]
+	lsls r3, r3, #5
+	movs r4, #0x2a
+	ldrsh r2, [r2, r4]
+	adds r3, r3, r2
+	lsls r3, r3, #1
+	ldr r2, _08024B98  @ gBG0TilemapBuffer
+	adds r3, r3, r2
+	movs r2, #1
+	bl DrawItemMenuCommand
+	movs r0, #0
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08024B94: .4byte gUnknown_03004E50
+_08024B98: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_8024B9C
+sub_8024B9C: @ 0x08024B9C
+	push {r4, lr}
+	ldr r4, _08024BC8  @ gUnknown_0203A958
+	adds r1, #0x3c
+	ldrb r0, [r1]
+	subs r0, #1
+	strb r0, [r4, #0x12]
+	bl ClearBG0BG1
+	ldr r0, _08024BCC  @ gUnknown_03004E50
+	ldr r0, [r0]
+	ldrb r2, [r4, #0x12]
+	lsls r2, r2, #1
+	adds r1, r0, #0
+	adds r1, #0x1e
+	adds r1, r1, r2
+	ldrh r1, [r1]
+	bl ItemEffect_Call
+	movs r0, #7
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08024BC8: .4byte gUnknown_0203A958
+_08024BCC: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_8024BD0
+sub_8024BD0: @ 0x08024BD0
+	push {lr}
+	adds r1, #0x3c
+	movs r0, #0
+	ldrsb r0, [r1, r0]
+	cmp r0, #0
+	bne _08024BE4
+	movs r0, #5
+	bl sub_801E748
+	b _08024BEE
+_08024BE4:
+	movs r0, #0
+	ldrsb r0, [r1, r0]
+	subs r0, #1
+	bl sub_801E748
+_08024BEE:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START nullsub_26
+nullsub_26: @ 0x08024BF4
+	bx lr
+
+	THUMB_FUNC_START sub_8024BF8
+sub_8024BF8: @ 0x08024BF8
+	push {r4, lr}
+	adds r3, r1, #0
+	adds r2, r3, #0
+	adds r2, #0x3c
+	movs r0, #0
+	ldrsb r0, [r2, r0]
+	cmp r0, #0
+	bne _08024C14
+	ldr r0, _08024C10  @ gUnknown_0202BCB0
+	ldrh r2, [r0, #0x2c]
+	b _08024C26
+	.align 2, 0
+_08024C10: .4byte gUnknown_0202BCB0
+_08024C14:
+	ldr r0, _08024C3C  @ gUnknown_03004E50
+	ldr r1, [r0]
+	movs r0, #0
+	ldrsb r0, [r2, r0]
+	subs r0, #1
+	lsls r0, r0, #1
+	adds r1, #0x1e
+	adds r1, r1, r0
+	ldrh r2, [r1]
+_08024C26:
+	movs r1, #0x2a
+	ldrsh r0, [r3, r1]
+	lsls r0, r0, #3
+	movs r4, #0x2c
+	ldrsh r1, [r3, r4]
+	lsls r1, r1, #3
+	bl sub_8088E60
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08024C3C: .4byte gUnknown_03004E50
+
+	THUMB_FUNC_START sub_8024C40
+sub_8024C40: @ 0x08024C40
+	push {lr}
+	bl GetChapterThing
+	cmp r0, #1
+	bne _08024CAC
+	ldr r0, _08024CB0  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xe]
+	subs r0, #0x24
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+	cmp r0, #9
+	bhi _08024CB4
+	movs r0, #0x71
+	bl CheckEventId
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08024CAC
+	movs r0, #0x72
+	bl CheckEventId
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08024CAC
+	movs r0, #0x73
+	bl CheckEventId
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08024CAC
+	movs r0, #0x74
+	bl CheckEventId
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08024CAC
+	movs r0, #0x75
+	bl CheckEventId
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08024CAC
+	movs r0, #0x76
+	bl CheckEventId
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08024CAC
+	movs r0, #0x77
+	bl CheckEventId
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _08024CB4
+_08024CAC:
+	movs r0, #3
+	b _08024CB6
+	.align 2, 0
+_08024CB0: .4byte gUnknown_0202BCF0
+_08024CB4:
+	movs r0, #1
+_08024CB6:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024CBC
+sub_8024CBC: @ 0x08024CBC
+	push {lr}
+	movs r0, #3
+	bl sub_80381E0
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024CCC
+sub_8024CCC: @ 0x08024CCC
+	push {lr}
+	bl GetChapterThing
+	cmp r0, #0
+	beq _08024CDA
+	movs r0, #1
+	b _08024CDC
+_08024CDA:
+	movs r0, #3
+_08024CDC:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8024CE0
+sub_8024CE0: @ 0x08024CE0
+	push {lr}
+	bl CallRetreatPromptEvent
+	movs r0, #0x17
+	pop {r1}
+	bx r1
+
+.align 2, 0

--- a/asm/bmphase.s
+++ b/asm/bmphase.s
@@ -1,0 +1,151 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ various phase/allegience checks and utility routines
+
+	THUMB_FUNC_START GetPhaseAbleUnitCount
+GetPhaseAbleUnitCount: @ 0x08024CEC
+	push {r4, r5, r6, lr}
+	adds r5, r0, #0
+	movs r6, #0
+	adds r4, r5, #1
+	b _08024D3C
+_08024CF6:
+	adds r0, r4, #0
+	bl GetUnitStruct
+	adds r2, r0, #0
+	cmp r2, #0
+	beq _08024D38
+	ldr r3, [r2]
+	cmp r3, #0
+	beq _08024D38
+	ldr r0, [r2, #0xc]
+	ldr r1, _08024D4C  @ 0x000100AE
+	ands r0, r1
+	cmp r0, #0
+	bne _08024D38
+	adds r0, r2, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #2
+	beq _08024D38
+	cmp r1, #4
+	beq _08024D38
+	ldr r0, [r2, #4]
+	ldr r1, [r3, #0x28]
+	ldr r0, [r0, #0x28]
+	orrs r1, r0
+	movs r0, #0x80
+	lsls r0, r0, #0xd
+	ands r1, r0
+	cmp r1, #0
+	bne _08024D38
+	adds r6, #1
+_08024D38:
+	adds r4, #1
+	adds r0, r5, #0
+_08024D3C:
+	adds r0, #0x40
+	cmp r4, r0
+	blt _08024CF6
+	adds r0, r6, #0
+	pop {r4, r5, r6}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08024D4C: .4byte 0x000100AE
+
+	THUMB_FUNC_START sub_8024D50
+sub_8024D50: @ 0x08024D50
+	push {r4, r5, r6, r7, lr}
+	adds r5, r0, #0
+	adds r7, r1, #0
+	movs r6, #0
+	adds r4, r5, #1
+	b _08024D7C
+_08024D5C:
+	adds r0, r4, #0
+	bl GetUnitStruct
+	adds r1, r0, #0
+	cmp r1, #0
+	beq _08024D78
+	ldr r0, [r1]
+	cmp r0, #0
+	beq _08024D78
+	ldr r0, [r1, #0xc]
+	ands r0, r7
+	cmp r0, #0
+	bne _08024D78
+	adds r6, #1
+_08024D78:
+	adds r4, #1
+	adds r0, r5, #0
+_08024D7C:
+	adds r0, #0x40
+	cmp r4, r0
+	blt _08024D5C
+	adds r0, r6, #0
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START AreUnitsAllied
+AreUnitsAllied: @ 0x08024D8C
+	push {lr}
+	movs r2, #0x80
+	ands r1, r2
+	movs r3, #0
+	ands r2, r0
+	cmp r2, r1
+	bne _08024D9C
+	movs r3, #1
+_08024D9C:
+	adds r0, r3, #0
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START IsSameAllegience
+IsSameAllegience: @ 0x08024DA4
+	push {lr}
+	movs r2, #0xc0
+	ands r1, r2
+	movs r3, #0
+	ands r2, r0
+	cmp r2, r1
+	bne _08024DB4
+	movs r3, #1
+_08024DB4:
+	adds r0, r3, #0
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START GetCurrentPhase
+GetCurrentPhase: @ 0x08024DBC
+	ldr r0, _08024DCC  @ gUnknown_0202BCF0
+	ldrb r1, [r0, #0xf]
+	movs r0, #0x80
+	ands r0, r1
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+	bx lr
+	.align 2, 0
+_08024DCC: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START IsNotEnemyPhaseMaybe
+IsNotEnemyPhaseMaybe: @ 0x08024DD0
+	ldr r0, _08024DE4  @ gUnknown_0202BCF0
+	ldrb r1, [r0, #0xf]
+	movs r2, #0x80
+	movs r0, #0x80
+	ands r0, r1
+	eors r0, r2
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+	bx lr
+	.align 2, 0
+_08024DE4: .4byte gUnknown_0202BCF0
+
+.align 2, 0

--- a/asm/bmreliance.s
+++ b/asm/bmreliance.s
@@ -1,0 +1,845 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ Unit supports
+
+	THUMB_FUNC_START GetROMUnitSupportCount
+GetROMUnitSupportCount: @ 0x080281C8
+	push {lr}
+	ldr r0, [r0]
+	ldr r0, [r0, #0x2c]
+	cmp r0, #0
+	beq _080281D6
+	ldrb r0, [r0, #0x15]
+	b _080281D8
+_080281D6:
+	movs r0, #0
+_080281D8:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START GetROMUnitSupportingId
+GetROMUnitSupportingId: @ 0x080281DC
+	push {lr}
+	ldr r0, [r0]
+	ldr r0, [r0, #0x2c]
+	cmp r0, #0
+	beq _080281EC
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	b _080281EE
+_080281EC:
+	movs r0, #0
+_080281EE:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START GetUnitSupportingUnit
+GetUnitSupportingUnit: @ 0x080281F4
+	push {r4, r5, r6, r7, lr}
+	adds r4, r0, #0
+	bl GetROMUnitSupportingId
+	lsls r0, r0, #0x18
+	lsrs r7, r0, #0x18
+	movs r0, #0xb
+	ldrsb r0, [r4, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	adds r5, r0, #1
+	adds r6, r0, #0
+	adds r6, #0x40
+	cmp r5, r6
+	bge _08028234
+_08028212:
+	adds r0, r5, #0
+	bl GetUnitStruct
+	adds r4, r0, #0
+	cmp r4, #0
+	beq _0802822E
+	ldr r0, [r4]
+	cmp r0, #0
+	beq _0802822E
+	ldrb r0, [r0, #4]
+	cmp r0, r7
+	bne _0802822E
+	adds r0, r4, #0
+	b _08028236
+_0802822E:
+	adds r5, #1
+	cmp r5, r6
+	blt _08028212
+_08028234:
+	movs r0, #0
+_08028236:
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START GetSupportLevelBySupportIndex
+GetSupportLevelBySupportIndex: @ 0x0802823C
+	push {lr}
+	adds r0, #0x32
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	cmp r0, #0xf0
+	ble _0802824C
+	movs r0, #3
+	b _0802825E
+_0802824C:
+	cmp r0, #0xa0
+	ble _08028254
+	movs r0, #2
+	b _0802825E
+_08028254:
+	cmp r0, #0x50
+	bgt _0802825C
+	movs r0, #0
+	b _0802825E
+_0802825C:
+	movs r0, #1
+_0802825E:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START GetUnitTotalSupportLevels
+GetUnitTotalSupportLevels: @ 0x08028264
+	push {r4, r5, r6, r7, lr}
+	adds r7, r0, #0
+	bl GetROMUnitSupportCount
+	adds r5, r0, #0
+	movs r4, #0
+	movs r6, #0
+	cmp r6, r5
+	bge _08028286
+_08028276:
+	adds r0, r7, #0
+	adds r1, r4, #0
+	bl GetSupportLevelBySupportIndex
+	adds r6, r6, r0
+	adds r4, #1
+	cmp r4, r5
+	blt _08028276
+_08028286:
+	adds r0, r6, #0
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START AddSupportPoints
+AddSupportPoints: @ 0x08028290
+	push {r4, r5, r6, r7, lr}
+	adds r2, r0, #0
+	ldr r0, [r2]
+	ldr r0, [r0, #0x2c]
+	cmp r0, #0
+	beq _080282CC
+	adds r0, #0xe
+	adds r0, r0, r1
+	ldrb r6, [r0]
+	adds r0, r2, #0
+	adds r0, #0x32
+	adds r7, r0, r1
+	ldrb r5, [r7]
+	ldr r4, _080282D4  @ gUnknown_0859B9A8
+	adds r0, r2, #0
+	bl GetSupportLevelBySupportIndex
+	lsls r0, r0, #2
+	adds r0, r0, r4
+	ldr r1, [r0]
+	adds r0, r5, r6
+	cmp r0, r1
+	ble _080282C0
+	subs r6, r1, r5
+_080282C0:
+	adds r0, r5, r6
+	strb r0, [r7]
+	ldr r1, _080282D8  @ gUnknown_0202BCF0
+	ldrh r0, [r1, #0x16]
+	adds r0, r0, r6
+	strh r0, [r1, #0x16]
+_080282CC:
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080282D4: .4byte gUnknown_0859B9A8
+_080282D8: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START sub_80282DC
+sub_80282DC: @ 0x080282DC
+	push {r4, lr}
+	adds r3, r0, #0
+	adds r3, #0x32
+	adds r3, r3, r1
+	ldrb r2, [r3]
+	adds r2, #1
+	strb r2, [r3]
+	ldr r3, _0802830C  @ gUnknown_0202BCF0
+	ldrh r2, [r3, #0x16]
+	adds r2, #1
+	strh r2, [r3, #0x16]
+	ldr r2, [r0]
+	ldrb r4, [r2, #4]
+	bl GetROMUnitSupportingId
+	adds r1, r0, #0
+	lsls r1, r1, #0x18
+	lsrs r1, r1, #0x18
+	adds r0, r4, #0
+	bl sub_802873C
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802830C: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START CanUnitSupportCommandWith
+CanUnitSupportCommandWith: @ 0x08028310
+	push {r4, r5, r6, r7, lr}
+	adds r5, r0, #0
+	adds r6, r1, #0
+	ldr r0, _08028374  @ gUnknown_0202BCF0
+	ldrb r1, [r0, #0x14]
+	movs r0, #0x80
+	ands r0, r1
+	cmp r0, #0
+	bne _0802836E
+	movs r0, #8
+	ands r0, r1
+	cmp r0, #0
+	bne _0802836E
+	adds r0, r5, #0
+	adds r1, r6, #0
+	bl CanUnitsStillSupportThisChapter
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802836E
+	adds r0, r5, #0
+	bl GetUnitTotalSupportLevels
+	cmp r0, #4
+	bgt _0802836E
+	adds r0, r5, #0
+	adds r1, r6, #0
+	bl GetUnitSupportingUnit
+	bl GetUnitTotalSupportLevels
+	cmp r0, #4
+	bgt _0802836E
+	adds r0, r5, #0
+	adds r0, #0x32
+	adds r0, r0, r6
+	ldrb r7, [r0]
+	ldr r4, _08028378  @ gUnknown_0859B9A8
+	adds r0, r5, #0
+	adds r1, r6, #0
+	bl GetSupportLevelBySupportIndex
+	lsls r0, r0, #2
+	adds r0, r0, r4
+	ldr r0, [r0]
+	cmp r7, #0xf1
+	bne _0802837C
+_0802836E:
+	movs r0, #0
+	b _08028386
+	.align 2, 0
+_08028374: .4byte gUnknown_0202BCF0
+_08028378: .4byte gUnknown_0859B9A8
+_0802837C:
+	movs r1, #0
+	cmp r7, r0
+	bne _08028384
+	movs r1, #1
+_08028384:
+	adds r0, r1, #0
+_08028386:
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START GetUnitStartingSupportValue
+GetUnitStartingSupportValue: @ 0x0802838C
+	push {lr}
+	ldr r0, [r0]
+	ldr r0, [r0, #0x2c]
+	cmp r0, #0
+	beq _0802839E
+	adds r0, #7
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	b _080283A2
+_0802839E:
+	movs r0, #1
+	negs r0, r0
+_080283A2:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START GetSupportDataIdForOtherUnit
+GetSupportDataIdForOtherUnit: @ 0x080283A8
+	push {r4, r5, r6, r7, lr}
+	adds r6, r0, #0
+	lsls r1, r1, #0x18
+	lsrs r7, r1, #0x18
+	bl GetROMUnitSupportCount
+	adds r5, r0, #0
+	movs r4, #0
+	cmp r4, r5
+	bge _080283D6
+_080283BC:
+	adds r0, r6, #0
+	adds r1, r4, #0
+	bl GetROMUnitSupportingId
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+	cmp r0, r7
+	bne _080283D0
+	adds r0, r4, #0
+	b _080283DA
+_080283D0:
+	adds r4, #1
+	cmp r4, r5
+	blt _080283BC
+_080283D6:
+	movs r0, #1
+	negs r0, r0
+_080283DA:
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_80283E0
+sub_80283E0: @ 0x080283E0
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	adds r5, r0, #0
+	bl GetROMUnitSupportCount
+	adds r7, r0, #0
+	movs r6, #0
+	cmp r6, r7
+	bge _08028428
+	mov r8, r6
+_080283F6:
+	adds r0, r5, #0
+	adds r1, r6, #0
+	bl GetUnitSupportingUnit
+	adds r4, r0, #0
+	cmp r4, #0
+	beq _08028422
+	ldr r0, [r5]
+	ldrb r1, [r0, #4]
+	adds r0, r4, #0
+	bl GetSupportDataIdForOtherUnit
+	adds r1, r4, #0
+	adds r1, #0x32
+	adds r1, r1, r0
+	mov r0, r8
+	strb r0, [r1]
+	adds r0, r5, #0
+	adds r0, #0x32
+	adds r0, r0, r6
+	mov r1, r8
+	strb r1, [r0]
+_08028422:
+	adds r6, #1
+	cmp r6, r7
+	blt _080283F6
+_08028428:
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START HandleSupportGains
+HandleSupportGains: @ 0x08028434
+	push {r4, r5, r6, r7, lr}
+	mov r7, r9
+	mov r6, r8
+	push {r6, r7}
+	ldr r1, _080284D4  @ gUnknown_0202BCF0
+	ldrh r0, [r1, #0x10]
+	cmp r0, #1
+	beq _08028520
+	ldrb r1, [r1, #0x14]
+	movs r0, #0x80
+	ands r0, r1
+	cmp r0, #0
+	bne _08028520
+	movs r4, #1
+_08028450:
+	adds r0, r4, #0
+	bl GetUnitStruct
+	adds r5, r0, #0
+	adds r4, #1
+	mov r9, r4
+	cmp r5, #0
+	beq _0802851A
+	ldr r0, [r5]
+	cmp r0, #0
+	beq _0802851A
+	ldr r0, [r5, #0xc]
+	ldr r1, _080284D8  @ 0x0001000C
+	ands r0, r1
+	cmp r0, #0
+	bne _0802851A
+	adds r0, r5, #0
+	bl GetUnitTotalSupportLevels
+	cmp r0, #4
+	bgt _0802851A
+	adds r0, r5, #0
+	bl GetROMUnitSupportCount
+	mov r8, r0
+	movs r7, #0
+	cmp r7, r8
+	bge _0802851A
+_08028488:
+	adds r0, r5, #0
+	adds r1, r7, #0
+	bl GetUnitSupportingUnit
+	adds r4, r0, #0
+	cmp r4, #0
+	beq _08028514
+	ldr r1, [r4, #0xc]
+	ldr r0, _080284D8  @ 0x0001000C
+	ands r0, r1
+	adds r6, r1, #0
+	cmp r0, #0
+	bne _08028514
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	movs r0, #0xc0
+	ands r0, r1
+	mov ip, r1
+	cmp r0, #0
+	bne _08028514
+	movs r2, #0x10
+	ldrsb r2, [r5, r2]
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	subs r1, r2, r0
+	cmp r1, #0
+	bge _080284C0
+	subs r1, r0, r2
+_080284C0:
+	movs r3, #0x11
+	ldrsb r3, [r5, r3]
+	movs r0, #0x11
+	ldrsb r0, [r4, r0]
+	subs r2, r3, r0
+	cmp r2, #0
+	blt _080284DC
+	adds r0, r1, r2
+	b _080284E0
+	.align 2, 0
+_080284D4: .4byte gUnknown_0202BCF0
+_080284D8: .4byte 0x0001000C
+_080284DC:
+	subs r0, r0, r3
+	adds r0, r1, r0
+_080284E0:
+	cmp r0, #0
+	beq _080284EA
+	cmp r0, #1
+	beq _080284F2
+	b _08028514
+_080284EA:
+	ldrb r0, [r5, #0x1b]
+	cmp r0, ip
+	bne _08028514
+	b _08028502
+_080284F2:
+	ldr r0, [r5, #0xc]
+	movs r1, #0x20
+	ands r0, r1
+	cmp r0, #0
+	bne _08028514
+	ands r6, r1
+	cmp r6, #0
+	bne _08028514
+_08028502:
+	adds r0, r4, #0
+	bl GetUnitTotalSupportLevels
+	cmp r0, #4
+	bgt _08028514
+	adds r0, r5, #0
+	adds r1, r7, #0
+	bl AddSupportPoints
+_08028514:
+	adds r7, #1
+	cmp r7, r8
+	blt _08028488
+_0802851A:
+	mov r4, r9
+	cmp r4, #0x3f
+	ble _08028450
+_08028520:
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START GetSupportBonusEntryPtr
+GetSupportBonusEntryPtr: @ 0x0802852C
+	push {lr}
+	adds r3, r0, #0
+	ldr r2, _08028534  @ gUnknown_088B05F8
+	b _08028544
+	.align 2, 0
+_08028534: .4byte gUnknown_088B05F8
+_08028538:
+	ldrb r1, [r2]
+	cmp r1, r3
+	bne _08028542
+	adds r0, r2, #0
+	b _0802854A
+_08028542:
+	adds r2, #8
+_08028544:
+	ldrb r1, [r2]
+	cmp r1, #0
+	bne _08028538
+_0802854A:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START StoreAddedAffinityBonusesForSupportLevel
+StoreAddedAffinityBonusesForSupportLevel: @ 0x08028550
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	adds r0, r1, #0
+	adds r5, r2, #0
+	bl GetSupportBonusEntryPtr
+	ldrb r1, [r0, #1]
+	muls r1, r5, r1
+	ldrb r2, [r4, #1]
+	adds r1, r1, r2
+	strb r1, [r4, #1]
+	ldrb r1, [r0, #2]
+	muls r1, r5, r1
+	ldrb r2, [r4, #2]
+	adds r1, r1, r2
+	strb r1, [r4, #2]
+	ldrb r1, [r0, #3]
+	muls r1, r5, r1
+	ldrb r2, [r4, #3]
+	adds r1, r1, r2
+	strb r1, [r4, #3]
+	ldrb r1, [r0, #4]
+	muls r1, r5, r1
+	ldrb r2, [r4, #4]
+	adds r1, r1, r2
+	strb r1, [r4, #4]
+	ldrb r1, [r0, #5]
+	muls r1, r5, r1
+	ldrb r2, [r4, #5]
+	adds r1, r1, r2
+	strb r1, [r4, #5]
+	ldrb r0, [r0, #6]
+	muls r0, r5, r0
+	ldrb r1, [r4, #6]
+	adds r0, r0, r1
+	strb r0, [r4, #6]
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_80285A0
+sub_80285A0: @ 0x080285A0
+	movs r1, #0
+	strb r1, [r0, #1]
+	strb r1, [r0, #2]
+	strb r1, [r0, #3]
+	strb r1, [r0, #4]
+	strb r1, [r0, #5]
+	strb r1, [r0, #6]
+	bx lr
+
+	THUMB_FUNC_START GetUnitSupportBonuses
+GetUnitSupportBonuses: @ 0x080285B0
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #4
+	adds r7, r0, #0
+	adds r6, r1, #0
+	movs r0, #0
+	mov r9, r0
+	adds r0, r6, #0
+	bl sub_80285A0
+	adds r0, r7, #0
+	bl GetROMUnitSupportCount
+	mov sl, r0
+	movs r1, #0
+	mov r8, r1
+	cmp r9, sl
+	bge _0802867C
+	subs r0, #1
+	str r0, [sp]
+_080285DE:
+	mov r1, r9
+	asrs r1, r1, #1
+	mov r9, r1
+	adds r0, r7, #0
+	mov r1, r8
+	bl GetUnitSupportingUnit
+	adds r5, r0, #0
+	cmp r5, #0
+	beq _08028674
+	ldr r0, _080286B4  @ gUnknown_0202BCB0
+	ldrb r1, [r0, #4]
+	movs r0, #0x40
+	ands r0, r1
+	cmp r0, #0
+	bne _08028624
+	movs r2, #0x10
+	ldrsb r2, [r7, r2]
+	movs r0, #0x10
+	ldrsb r0, [r5, r0]
+	subs r1, r2, r0
+	cmp r1, #0
+	bge _0802860E
+	subs r1, r0, r2
+_0802860E:
+	movs r3, #0x11
+	ldrsb r3, [r7, r3]
+	movs r2, #0x11
+	ldrsb r2, [r5, r2]
+	subs r0, r3, r2
+	cmp r0, #0
+	bge _0802861E
+	subs r0, r2, r3
+_0802861E:
+	adds r0, r1, r0
+	cmp r0, #3
+	bgt _08028674
+_08028624:
+	ldr r0, [r5, #0xc]
+	ldr r1, _080286B8  @ 0x0001002C
+	ands r0, r1
+	cmp r0, #0
+	bne _08028674
+	ldr r0, [r7]
+	ldrb r1, [r0, #4]
+	adds r0, r5, #0
+	bl GetSupportDataIdForOtherUnit
+	adds r1, r0, #0
+	adds r0, r5, #0
+	bl GetSupportLevelBySupportIndex
+	adds r4, r0, #0
+	ldr r0, [r5]
+	ldrb r1, [r0, #9]
+	adds r0, r6, #0
+	adds r2, r4, #0
+	bl StoreAddedAffinityBonusesForSupportLevel
+	adds r0, r7, #0
+	mov r1, r8
+	bl GetSupportLevelBySupportIndex
+	adds r5, r0, #0
+	ldr r0, [r7]
+	ldrb r1, [r0, #9]
+	adds r0, r6, #0
+	adds r2, r5, #0
+	bl StoreAddedAffinityBonusesForSupportLevel
+	cmp r4, #0
+	beq _08028674
+	cmp r5, #0
+	beq _08028674
+	movs r0, #1
+	ldr r1, [sp]
+	lsls r0, r1
+	add r9, r0
+_08028674:
+	movs r0, #1
+	add r8, r0
+	cmp r8, sl
+	blt _080285DE
+_0802867C:
+	ldrb r0, [r6, #1]
+	lsrs r0, r0, #1
+	strb r0, [r6, #1]
+	ldrb r0, [r6, #2]
+	lsrs r0, r0, #1
+	strb r0, [r6, #2]
+	ldrb r0, [r6, #3]
+	lsrs r0, r0, #1
+	strb r0, [r6, #3]
+	ldrb r0, [r6, #4]
+	lsrs r0, r0, #1
+	strb r0, [r6, #4]
+	ldrb r0, [r6, #5]
+	lsrs r0, r0, #1
+	strb r0, [r6, #5]
+	ldrb r0, [r6, #6]
+	lsrs r0, r0, #1
+	strb r0, [r6, #6]
+	mov r0, r9
+	add sp, #4
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080286B4: .4byte gUnknown_0202BCB0
+_080286B8: .4byte 0x0001002C
+
+	THUMB_FUNC_START sub_80286BC
+sub_80286BC: @ 0x080286BC
+	push {lr}
+	ldr r0, [r0]
+	ldrb r0, [r0, #9]
+	cmp r0, #0
+	beq _080286CA
+	adds r0, #0x79
+	b _080286CE
+_080286CA:
+	movs r0, #1
+	negs r0, r0
+_080286CE:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_80286D4
+sub_80286D4: @ 0x080286D4
+	push {lr}
+	bl GetROMCharStruct
+	ldrb r0, [r0, #9]
+	cmp r0, #0
+	beq _080286E4
+	adds r0, #0x79
+	b _080286E8
+_080286E4:
+	movs r0, #1
+	negs r0, r0
+_080286E8:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_80286EC
+sub_80286EC: @ 0x080286EC
+	push {r4, lr}
+	sub sp, #4
+	adds r4, r0, #0
+	ldr r1, _0802870C  @ gUnknown_080D7C14
+	mov r0, sp
+	movs r2, #4
+	bl memcpy
+	mov r1, sp
+	adds r0, r1, r4
+	ldrb r0, [r0]
+	add sp, #4
+	pop {r4}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_0802870C: .4byte gUnknown_080D7C14
+
+	THUMB_FUNC_START sub_8028710
+sub_8028710: @ 0x08028710
+	push {r4, r5, lr}
+	sub sp, #0x20
+	mov r2, sp
+	ldr r1, _08028738  @ gUnknown_080D7C18
+	ldm r1!, {r3, r4, r5}
+	stm r2!, {r3, r4, r5}
+	ldm r1!, {r3, r4, r5}
+	stm r2!, {r3, r4, r5}
+	ldm r1!, {r3, r4}
+	stm r2!, {r3, r4}
+	lsls r0, r0, #2
+	add r0, sp
+	ldr r0, [r0]
+	bl GetStringFromIndex
+	add sp, #0x20
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08028738: .4byte gUnknown_080D7C18
+
+	THUMB_FUNC_START sub_802873C
+sub_802873C: @ 0x0802873C
+	push {r4, r5, r6, r7, lr}
+	adds r6, r0, #0
+	adds r5, r1, #0
+	lsls r6, r6, #0x18
+	lsrs r6, r6, #0x18
+	lsls r5, r5, #0x18
+	lsrs r5, r5, #0x18
+	adds r0, r6, #0
+	bl GetUnitByCharId
+	adds r7, r0, #0
+	adds r1, r5, #0
+	bl GetSupportDataIdForOtherUnit
+	adds r3, r0, #0
+	adds r2, r7, #0
+	adds r2, #0x39
+	movs r4, #1
+	adds r0, r4, #0
+	lsls r0, r3
+	ldrb r1, [r2]
+	orrs r0, r1
+	strb r0, [r2]
+	adds r0, r5, #0
+	bl GetUnitByCharId
+	adds r7, r0, #0
+	adds r1, r6, #0
+	bl GetSupportDataIdForOtherUnit
+	adds r3, r0, #0
+	adds r1, r7, #0
+	adds r1, #0x39
+	lsls r4, r3
+	ldrb r0, [r1]
+	orrs r4, r0
+	strb r4, [r1]
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START CanUnitsStillSupportThisChapter
+CanUnitsStillSupportThisChapter: @ 0x0802878C
+	adds r0, #0x39
+	movs r2, #1
+	lsls r2, r1
+	ldrb r0, [r0]
+	ands r2, r0
+	lsls r2, r2, #0x18
+	asrs r2, r2, #0x18
+	negs r0, r2
+	orrs r0, r2
+	lsrs r0, r0, #0x1f
+	bx lr
+
+	THUMB_FUNC_START sub_80287A4
+sub_80287A4: @ 0x080287A4
+	push {r4, r5, lr}
+	adds r4, r1, #0
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+	lsls r4, r4, #0x18
+	lsrs r4, r4, #0x18
+	bl GetUnitByCharId
+	adds r5, r0, #0
+	adds r1, r4, #0
+	bl GetSupportDataIdForOtherUnit
+	adds r1, r0, #0
+	adds r0, r5, #0
+	bl GetSupportLevelBySupportIndex
+	cmp r0, #2
+	bgt _080287CC
+	movs r0, #0
+	b _080287CE
+_080287CC:
+	movs r0, #1
+_080287CE:
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+.align 2, 0

--- a/asm/bmreliance.s
+++ b/asm/bmreliance.s
@@ -842,4 +842,85 @@ _080287CE:
 	pop {r1}
 	bx r1
 
+	THUMB_FUNC_START sub_80287D4
+sub_80287D4: @ 0x080287D4
+	push {lr}
+	adds r2, r0, #0
+	adds r3, r1, #0
+	cmp r2, #0
+	beq _0802886A
+	cmp r3, #0
+	beq _0802886A
+	ldrb r1, [r2, #8]
+	ldrb r0, [r3, #8]
+	strb r0, [r2, #8]
+	strb r1, [r3, #8]
+	ldrb r1, [r2, #9]
+	ldrb r0, [r3, #9]
+	strb r0, [r2, #9]
+	strb r1, [r3, #9]
+	ldrb r1, [r2, #0x12]
+	ldrb r0, [r3, #0x12]
+	strb r0, [r2, #0x12]
+	strb r1, [r3, #0x12]
+	ldrb r1, [r2, #0x13]
+	ldrb r0, [r3, #0x13]
+	strb r0, [r2, #0x13]
+	strb r1, [r3, #0x13]
+	ldrb r1, [r2, #0x14]
+	ldrb r0, [r3, #0x14]
+	strb r0, [r2, #0x14]
+	strb r1, [r3, #0x14]
+	ldrb r1, [r2, #0x15]
+	ldrb r0, [r3, #0x15]
+	strb r0, [r2, #0x15]
+	strb r1, [r3, #0x15]
+	ldrb r1, [r2, #0x16]
+	ldrb r0, [r3, #0x16]
+	strb r0, [r2, #0x16]
+	strb r1, [r3, #0x16]
+	ldrb r1, [r2, #0x17]
+	ldrb r0, [r3, #0x17]
+	strb r0, [r2, #0x17]
+	strb r1, [r3, #0x17]
+	ldrb r1, [r2, #0x18]
+	ldrb r0, [r3, #0x18]
+	strb r0, [r2, #0x18]
+	strb r1, [r3, #0x18]
+	ldrb r1, [r2, #0x19]
+	ldrb r0, [r3, #0x19]
+	strb r0, [r2, #0x19]
+	strb r1, [r3, #0x19]
+	ldrb r1, [r2, #0x1a]
+	ldrb r0, [r3, #0x1a]
+	strb r0, [r2, #0x1a]
+	strb r1, [r3, #0x1a]
+	ldrb r1, [r2, #0x1d]
+	ldrb r0, [r3, #0x1d]
+	strb r0, [r2, #0x1d]
+	strb r1, [r3, #0x1d]
+	ldrh r1, [r2, #0x1e]
+	ldrh r0, [r3, #0x1e]
+	strh r0, [r2, #0x1e]
+	strh r1, [r3, #0x1e]
+	ldrh r1, [r2, #0x20]
+	ldrh r0, [r3, #0x20]
+	strh r0, [r2, #0x20]
+	strh r1, [r3, #0x20]
+	ldrh r1, [r2, #0x22]
+	ldrh r0, [r3, #0x22]
+	strh r0, [r2, #0x22]
+	strh r1, [r3, #0x22]
+	ldrh r1, [r2, #0x24]
+	ldrh r0, [r3, #0x24]
+	strh r0, [r2, #0x24]
+	strh r1, [r3, #0x24]
+	ldrh r1, [r2, #0x26]
+	ldrh r0, [r3, #0x26]
+	strh r0, [r2, #0x26]
+	strh r1, [r3, #0x26]
+_0802886A:
+	pop {r0}
+	bx r0
+
 .align 2, 0

--- a/asm/bmtarget.s
+++ b/asm/bmtarget.s
@@ -1,0 +1,3032 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ Make list of valid targets for everything
+
+	THUMB_FUNC_START sub_8024E40
+sub_8024E40: @ 0x08024E40
+	push {r4, r5, r6, r7, lr}
+	adds r7, r0, #0
+	ldr r0, _08024EA0  @ gUnknown_0202E4D4
+	movs r1, #2
+	ldrsh r0, [r0, r1]
+	subs r1, r0, #1
+	cmp r1, #0
+	blt _08024E98
+_08024E50:
+	ldr r0, _08024EA0  @ gUnknown_0202E4D4
+	movs r2, #0
+	ldrsh r0, [r0, r2]
+	subs r4, r0, #1
+	subs r6, r1, #1
+	cmp r4, #0
+	blt _08024E92
+	lsls r5, r1, #2
+_08024E60:
+	ldr r0, _08024EA4  @ gUnknown_0202E4E0
+	ldr r0, [r0]
+	adds r0, r5, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0
+	beq _08024E8C
+	ldr r0, _08024EA8  @ gUnknown_0202E4D8
+	ldr r0, [r0]
+	adds r0, r5, r0
+	ldr r0, [r0]
+	adds r1, r0, r4
+	ldrb r0, [r1]
+	cmp r0, #0
+	beq _08024E8C
+	bl GetUnitStruct
+	bl _call_via_r7
+_08024E8C:
+	subs r4, #1
+	cmp r4, #0
+	bge _08024E60
+_08024E92:
+	adds r1, r6, #0
+	cmp r1, #0
+	bge _08024E50
+_08024E98:
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08024EA0: .4byte gUnknown_0202E4D4
+_08024EA4: .4byte gUnknown_0202E4E0
+_08024EA8: .4byte gUnknown_0202E4D8
+
+	THUMB_FUNC_START ForEachUnitInRange
+ForEachUnitInRange: @ 0x08024EAC
+	push {r4, r5, r6, r7, lr}
+	adds r7, r0, #0
+	ldr r0, _08024F0C  @ gUnknown_0202E4D4
+	movs r1, #2
+	ldrsh r0, [r0, r1]
+	subs r1, r0, #1
+	cmp r1, #0
+	blt _08024F04
+_08024EBC:
+	ldr r0, _08024F0C  @ gUnknown_0202E4D4
+	movs r2, #0
+	ldrsh r0, [r0, r2]
+	subs r4, r0, #1
+	subs r6, r1, #1
+	cmp r4, #0
+	blt _08024EFE
+	lsls r5, r1, #2
+_08024ECC:
+	ldr r0, _08024F10  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	adds r0, r5, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0
+	beq _08024EF8
+	ldr r0, _08024F14  @ gUnknown_0202E4D8
+	ldr r0, [r0]
+	adds r0, r5, r0
+	ldr r0, [r0]
+	adds r1, r0, r4
+	ldrb r0, [r1]
+	cmp r0, #0
+	beq _08024EF8
+	bl GetUnitStruct
+	bl _call_via_r7
+_08024EF8:
+	subs r4, #1
+	cmp r4, #0
+	bge _08024ECC
+_08024EFE:
+	adds r1, r6, #0
+	cmp r1, #0
+	bge _08024EBC
+_08024F04:
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08024F0C: .4byte gUnknown_0202E4D4
+_08024F10: .4byte gUnknown_0202E4E4
+_08024F14: .4byte gUnknown_0202E4D8
+
+	THUMB_FUNC_START ForEachPosInRange
+ForEachPosInRange: @ 0x08024F18
+	push {r4, r5, r6, r7, lr}
+	adds r7, r0, #0
+	ldr r0, _08024F68  @ gUnknown_0202E4D4
+	movs r1, #2
+	ldrsh r0, [r0, r1]
+	subs r5, r0, #1
+	cmp r5, #0
+	blt _08024F60
+_08024F28:
+	ldr r0, _08024F68  @ gUnknown_0202E4D4
+	movs r1, #0
+	ldrsh r0, [r0, r1]
+	subs r4, r0, #1
+	subs r6, r5, #1
+	cmp r4, #0
+	blt _08024F5A
+_08024F36:
+	ldr r0, _08024F6C  @ gUnknown_0202E4E4
+	ldr r1, [r0]
+	lsls r0, r5, #2
+	adds r0, r0, r1
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0
+	beq _08024F54
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl _call_via_r7
+_08024F54:
+	subs r4, #1
+	cmp r4, #0
+	bge _08024F36
+_08024F5A:
+	adds r5, r6, #0
+	cmp r5, #0
+	bge _08024F28
+_08024F60:
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08024F68: .4byte gUnknown_0202E4D4
+_08024F6C: .4byte gUnknown_0202E4E4
+
+	THUMB_FUNC_START ForEachAdjacentUnit
+ForEachAdjacentUnit: @ 0x08024F70
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	adds r6, r2, #0
+	bl InitTargets
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #1
+	movs r3, #1
+	bl MapAddInRange
+	movs r3, #1
+	negs r3, r3
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #0
+	bl MapAddInRange
+	adds r0, r6, #0
+	bl ForEachUnitInRange
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START ForEachAdjacentPosition
+ForEachAdjacentPosition: @ 0x08024FA4
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	adds r6, r2, #0
+	bl InitTargets
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #1
+	movs r3, #1
+	bl MapAddInRange
+	movs r3, #1
+	negs r3, r3
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #0
+	bl MapAddInRange
+	adds r0, r6, #0
+	bl ForEachPosInRange
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_8024FD8
+sub_8024FD8: @ 0x08024FD8
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	mov r8, r2
+	bl InitTargets
+	movs r1, #0xff
+	ldr r7, _08025034  @ gUnknown_030049A0
+	lsls r6, r5, #2
+_08024FEE:
+	movs r2, #0xff
+	lsls r3, r1, #0x18
+_08024FF2:
+	cmp r4, #0
+	blt _08025008
+	cmp r5, #0
+	blt _08025008
+	ldr r0, [r7]
+	adds r0, r6, r0
+	ldr r1, [r0]
+	adds r1, r1, r4
+	ldrb r0, [r1]
+	adds r0, #1
+	strb r0, [r1]
+_08025008:
+	lsls r0, r2, #0x18
+	movs r1, #0x80
+	lsls r1, r1, #0x11
+	adds r0, r0, r1
+	lsrs r2, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #1
+	ble _08024FF2
+	adds r0, r3, r1
+	lsrs r1, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #1
+	ble _08024FEE
+	mov r0, r8
+	bl ForEachPosInRange
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025034: .4byte gUnknown_030049A0
+
+	THUMB_FUNC_START ForEachPosIn12Range
+ForEachPosIn12Range: @ 0x08025038
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	adds r6, r2, #0
+	bl InitTargets
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #2
+	movs r3, #1
+	bl MapAddInRange
+	movs r3, #1
+	negs r3, r3
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #0
+	bl MapAddInRange
+	adds r0, r6, #0
+	bl ForEachPosInRange
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START ForEachUnitInMagBy2Range
+ForEachUnitInMagBy2Range: @ 0x0802506C
+	push {r4, r5, r6, lr}
+	mov r6, r8
+	push {r6}
+	mov r8, r0
+	ldr r6, _080250B8  @ gUnknown_02033F3C
+	ldr r0, [r6]
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl InitTargets
+	ldr r0, [r6]
+	bl GetUnitMagBy2Range
+	adds r2, r0, #0
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r3, #1
+	bl MapAddInRange
+	movs r3, #1
+	negs r3, r3
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #0
+	bl MapAddInRange
+	mov r0, r8
+	bl ForEachUnitInRange
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080250B8: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START TryAddTrapsToTargetList
+TryAddTrapsToTargetList: @ 0x080250BC
+	push {r4, r5, r6, lr}
+	movs r0, #0
+	bl GetTrap
+	adds r4, r0, #0
+	ldrb r0, [r4, #2]
+	cmp r0, #0
+	beq _0802516E
+	ldr r6, _08025174  @ gUnknown_0202E4DC
+	ldr r5, _08025178  @ gUnknown_0202E4E4
+_080250D0:
+	cmp r0, #2
+	bne _08025166
+	ldrb r1, [r4, #1]
+	ldr r0, [r6]
+	lsls r3, r1, #2
+	adds r0, r3, r0
+	ldrb r2, [r4]
+	ldr r0, [r0]
+	adds r0, r0, r2
+	ldrb r0, [r0]
+	cmp r0, #0x1b
+	bne _08025104
+	ldr r0, [r5]
+	adds r0, r3, r0
+	ldr r0, [r0]
+	adds r0, r0, r2
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0
+	beq _08025104
+	ldrb r3, [r4, #3]
+	adds r0, r2, #0
+	movs r2, #0
+	bl AddTarget
+_08025104:
+	ldrb r1, [r4, #1]
+	ldr r0, [r6]
+	lsls r3, r1, #2
+	adds r0, r3, r0
+	ldrb r2, [r4]
+	ldr r0, [r0, #4]
+	adds r0, r0, r2
+	ldrb r0, [r0]
+	cmp r0, #0x1b
+	bne _08025136
+	ldr r0, [r5]
+	adds r0, r3, r0
+	ldr r0, [r0, #4]
+	adds r0, r0, r2
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0
+	beq _08025136
+	adds r1, #1
+	ldrb r3, [r4, #3]
+	adds r0, r2, #0
+	movs r2, #0
+	bl AddTarget
+_08025136:
+	ldrb r1, [r4, #1]
+	ldr r0, [r6]
+	lsls r3, r1, #2
+	adds r0, r3, r0
+	ldrb r2, [r4]
+	ldr r0, [r0]
+	adds r0, r0, r2
+	ldrb r0, [r0]
+	cmp r0, #0x33
+	bne _08025166
+	ldr r0, [r5]
+	adds r0, r3, r0
+	ldr r0, [r0]
+	adds r0, r0, r2
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0
+	beq _08025166
+	ldrb r3, [r4, #3]
+	adds r0, r2, #0
+	movs r2, #0
+	bl AddTarget
+_08025166:
+	adds r4, #8
+	ldrb r0, [r4, #2]
+	cmp r0, #0
+	bne _080250D0
+_0802516E:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025174: .4byte gUnknown_0202E4DC
+_08025178: .4byte gUnknown_0202E4E4
+
+	THUMB_FUNC_START AddUnitToTargetListIfNotAllied
+AddUnitToTargetListIfNotAllied: @ 0x0802517C
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _080251B0  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	bl AreUnitsAllied
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _080251AA
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	movs r3, #0
+	bl AddTarget
+_080251AA:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080251B0: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START MakeTargetListForWeapon
+MakeTargetListForWeapon: @ 0x080251B4
+	push {r4, r5, r6, lr}
+	mov r6, r8
+	push {r6}
+	mov r8, r1
+	movs r5, #0x10
+	ldrsb r5, [r0, r5]
+	movs r6, #0x11
+	ldrsb r6, [r0, r6]
+	ldr r1, _08025210  @ gUnknown_02033F3C
+	str r0, [r1]
+	adds r0, r5, #0
+	adds r1, r6, #0
+	bl InitTargets
+	ldr r0, _08025214  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	mov r0, r8
+	bl GetItemMinRange
+	adds r4, r0, #0
+	lsls r4, r4, #0x10
+	asrs r4, r4, #0x10
+	mov r0, r8
+	bl GetItemMaxRange
+	adds r3, r0, #0
+	lsls r3, r3, #0x10
+	asrs r3, r3, #0x10
+	adds r0, r5, #0
+	adds r1, r6, #0
+	adds r2, r4, #0
+	bl FillRangeMap
+	ldr r0, _08025218  @ AddUnitToTargetListIfNotAllied
+	bl ForEachUnitInRange
+	bl TryAddTrapsToTargetList
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025210: .4byte gUnknown_02033F3C
+_08025214: .4byte gUnknown_0202E4E4
+_08025218: .4byte AddUnitToTargetListIfNotAllied
+
+	THUMB_FUNC_START TryAddUnitToTradeTargetList
+TryAddUnitToTradeTargetList: @ 0x0802521C
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	ldr r5, _080252CC  @ gUnknown_02033F3C
+	ldr r0, [r5]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	bl IsSameAllegience
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _080252C4
+	ldr r2, [r5]
+	ldr r0, [r2, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x51
+	beq _080252C4
+	ldr r3, [r4, #4]
+	ldrb r0, [r3, #4]
+	cmp r0, #0x51
+	beq _080252C4
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r1, [r0]
+	movs r0, #0xf
+	ands r0, r1
+	cmp r0, #4
+	beq _08025288
+	ldrh r0, [r2, #0x1e]
+	cmp r0, #0
+	bne _08025264
+	ldrh r0, [r4, #0x1e]
+	cmp r0, #0
+	beq _08025288
+_08025264:
+	ldr r0, [r4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r3, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #2
+	ands r0, r1
+	cmp r0, #0
+	bne _08025288
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	movs r3, #0
+	bl AddTarget
+_08025288:
+	ldr r0, [r4, #0xc]
+	movs r1, #0x10
+	ands r0, r1
+	cmp r0, #0
+	beq _080252C4
+	ldrb r0, [r4, #0x1b]
+	bl GetUnitStruct
+	adds r1, r0, #0
+	movs r2, #0xb
+	ldrsb r2, [r1, r2]
+	movs r0, #0xc0
+	ands r0, r2
+	cmp r0, #0
+	bne _080252C4
+	ldr r0, _080252CC  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldrh r0, [r0, #0x1e]
+	cmp r0, #0
+	bne _080252B6
+	ldrh r0, [r1, #0x1e]
+	cmp r0, #0
+	beq _080252C4
+_080252B6:
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r3, #0
+	bl AddTarget
+_080252C4:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080252CC: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START MakeTradeTargetList
+MakeTradeTargetList: @ 0x080252D0
+	push {r4, r5, r6, r7, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r6, _08025338  @ gUnknown_02033F3C
+	str r0, [r6]
+	ldr r0, _0802533C  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r7, _08025340  @ TryAddUnitToTradeTargetList
+	adds r0, r4, #0
+	adds r1, r5, #0
+	adds r2, r7, #0
+	bl ForEachAdjacentUnit
+	ldr r0, [r6]
+	ldr r0, [r0, #0xc]
+	movs r1, #0x10
+	ands r0, r1
+	cmp r0, #0
+	beq _08025332
+	bl sub_804FD28
+	adds r4, r0, #0
+	ldr r0, [r6]
+	ldrb r0, [r0, #0x1b]
+	bl GetUnitStruct
+	bl _call_via_r7
+	bl sub_804FD28
+	cmp r4, r0
+	beq _08025332
+	adds r0, r4, #0
+	bl GetTarget
+	ldr r1, [r6]
+	ldrb r1, [r1, #0x10]
+	strb r1, [r0]
+	adds r0, r4, #0
+	bl GetTarget
+	ldr r1, [r6]
+	ldrb r1, [r1, #0x11]
+	strb r1, [r0, #1]
+_08025332:
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025338: .4byte gUnknown_02033F3C
+_0802533C: .4byte gUnknown_0202E4E4
+_08025340: .4byte TryAddUnitToTradeTargetList
+
+	THUMB_FUNC_START TryAddUnitToRescueTargetList
+TryAddUnitToRescueTargetList: @ 0x08025344
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	ldr r5, _080253B0  @ gUnknown_02033F3C
+	ldr r0, [r5]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	bl AreUnitsAllied
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _080253AA
+	ldr r2, [r5]
+	ldr r0, [r2, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x51
+	beq _080253AA
+	ldr r0, [r4, #4]
+	ldrb r0, [r0, #4]
+	cmp r0, #0x51
+	beq _080253AA
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r1, [r0]
+	movs r0, #0xf
+	ands r0, r1
+	cmp r0, #4
+	beq _080253AA
+	ldr r0, [r4, #0xc]
+	movs r1, #0x30
+	ands r0, r1
+	cmp r0, #0
+	bne _080253AA
+	adds r0, r2, #0
+	adds r1, r4, #0
+	bl CanUnitRescue
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _080253AA
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	movs r3, #0
+	bl AddTarget
+_080253AA:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080253B0: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START MakeRescueTargetList
+MakeRescueTargetList: @ 0x080253B4
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _080253DC  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _080253E0  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _080253E4  @ TryAddUnitToRescueTargetList
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentUnit
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080253DC: .4byte gUnknown_02033F3C
+_080253E0: .4byte gUnknown_0202E4E4
+_080253E4: .4byte TryAddUnitToRescueTargetList
+
+	THUMB_FUNC_START TryAddToDropTargetList
+TryAddToDropTargetList: @ 0x080253E8
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	adds r6, r1, #0
+	ldr r0, _08025434  @ gUnknown_0202E4D8
+	ldr r0, [r0]
+	lsls r5, r6, #2
+	adds r0, r5, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0
+	bne _0802542C
+	ldr r0, _08025438  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldrb r0, [r0, #0x1b]
+	bl GetUnitStruct
+	ldr r1, _0802543C  @ gUnknown_0202E4DC
+	ldr r1, [r1]
+	adds r1, r5, r1
+	ldr r1, [r1]
+	adds r1, r1, r4
+	ldrb r1, [r1]
+	bl CanUnitCrossTerrain
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802542C
+	adds r0, r4, #0
+	adds r1, r6, #0
+	movs r2, #0
+	movs r3, #0
+	bl AddTarget
+_0802542C:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025434: .4byte gUnknown_0202E4D8
+_08025438: .4byte gUnknown_02033F3C
+_0802543C: .4byte gUnknown_0202E4DC
+
+	THUMB_FUNC_START MakeDropTargetList
+MakeDropTargetList: @ 0x08025440
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _08025468  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _0802546C  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _08025470  @ TryAddToDropTargetList
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentPosition
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025468: .4byte gUnknown_02033F3C
+_0802546C: .4byte gUnknown_0202E4E4
+_08025470: .4byte TryAddToDropTargetList
+
+	THUMB_FUNC_START TryAddRescuedUnitToTakeTargetList
+TryAddRescuedUnitToTakeTargetList: @ 0x08025474
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	ldr r4, _080254DC  @ gUnknown_02033F3C
+	ldr r0, [r4]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r5, r1]
+	bl IsSameAllegience
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _080254D6
+	ldr r0, [r5, #0xc]
+	movs r1, #0x10
+	ands r0, r1
+	cmp r0, #0
+	beq _080254D6
+	ldr r0, [r5]
+	ldr r1, [r5, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #2
+	ands r0, r1
+	cmp r0, #0
+	bne _080254D6
+	ldr r4, [r4]
+	ldrb r0, [r5, #0x1b]
+	bl GetUnitStruct
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl CanUnitRescue
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _080254D6
+	movs r0, #0x10
+	ldrsb r0, [r5, r0]
+	movs r1, #0x11
+	ldrsb r1, [r5, r1]
+	movs r2, #0xb
+	ldrsb r2, [r5, r2]
+	movs r3, #0
+	bl AddTarget
+_080254D6:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080254DC: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START MakeTakeTargetList
+MakeTakeTargetList: @ 0x080254E0
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _08025508  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _0802550C  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _08025510  @ TryAddRescuedUnitToTakeTargetList
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentUnit
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025508: .4byte gUnknown_02033F3C
+_0802550C: .4byte gUnknown_0202E4E4
+_08025510: .4byte TryAddRescuedUnitToTakeTargetList
+
+	THUMB_FUNC_START sub_8025514
+sub_8025514: @ 0x08025514
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	ldr r5, _08025590  @ gUnknown_02033F3C
+	ldr r0, [r5]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	bl IsSameAllegience
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08025588
+	ldr r0, [r4, #0xc]
+	movs r1, #0x10
+	ands r0, r1
+	cmp r0, #0
+	bne _08025588
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #4
+	beq _08025588
+	cmp r1, #2
+	beq _08025588
+	ldr r0, [r4]
+	ldr r1, [r4, #4]
+	ldr r0, [r0, #0x28]
+	ldr r1, [r1, #0x28]
+	orrs r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #2
+	ands r0, r1
+	cmp r0, #0
+	bne _08025588
+	ldr r0, [r5]
+	ldrb r0, [r0, #0x1b]
+	bl GetUnitStruct
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl CanUnitRescue
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08025588
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	movs r3, #0
+	bl AddTarget
+_08025588:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025590: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START sub_8025594
+sub_8025594: @ 0x08025594
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _080255BC  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _080255C0  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _080255C4  @ sub_8025514
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentUnit
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080255BC: .4byte gUnknown_02033F3C
+_080255C0: .4byte gUnknown_0202E4E4
+_080255C4: .4byte sub_8025514
+
+	THUMB_FUNC_START sub_80255C8
+sub_80255C8: @ 0x080255C8
+	push {r4, lr}
+	adds r4, r0, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #4
+	beq _08025606
+	cmp r1, #2
+	beq _08025606
+	ldr r0, _0802560C  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldr r0, [r0]
+	ldrb r0, [r0, #4]
+	ldr r1, [r4]
+	ldrb r1, [r1, #4]
+	bl sub_8083F68
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08025606
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	ldr r3, [r4]
+	ldrb r3, [r3, #4]
+	bl AddTarget
+_08025606:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802560C: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START sub_8025610
+sub_8025610: @ 0x08025610
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _08025638  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _0802563C  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _08025640  @ sub_80255C8
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentUnit
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025638: .4byte gUnknown_02033F3C
+_0802563C: .4byte gUnknown_0202E4E4
+_08025640: .4byte sub_80255C8
+
+	THUMB_FUNC_START MakeTargetListForSupport
+MakeTargetListForSupport: @ 0x08025644
+	push {r4, r5, r6, r7, lr}
+	ldr r4, _080256E8  @ gUnknown_02033F3C
+	str r0, [r4]
+	movs r2, #0x10
+	ldrsb r2, [r0, r2]
+	movs r1, #0x11
+	ldrsb r1, [r0, r1]
+	adds r0, r2, #0
+	bl InitTargets
+	ldr r0, [r4]
+	bl GetROMUnitSupportCount
+	adds r6, r0, #0
+	movs r5, #0
+	cmp r5, r6
+	bge _080256E2
+	adds r7, r4, #0
+_08025668:
+	ldr r0, [r7]
+	adds r1, r5, #0
+	bl GetUnitSupportingUnit
+	adds r4, r0, #0
+	cmp r4, #0
+	beq _080256DC
+	ldr r3, [r7]
+	movs r2, #0x10
+	ldrsb r2, [r3, r2]
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	subs r1, r2, r0
+	cmp r1, #0
+	bge _08025688
+	subs r1, r0, r2
+_08025688:
+	ldrb r3, [r3, #0x11]
+	lsls r3, r3, #0x18
+	asrs r3, r3, #0x18
+	movs r2, #0x11
+	ldrsb r2, [r4, r2]
+	subs r0, r3, r2
+	cmp r0, #0
+	bge _0802569A
+	subs r0, r2, r3
+_0802569A:
+	adds r0, r1, r0
+	cmp r0, #1
+	bne _080256DC
+	ldr r0, [r7]
+	adds r1, r5, #0
+	bl CanUnitSupportCommandWith
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _080256DC
+	ldr r0, [r4, #0xc]
+	ldr r1, _080256EC  @ 0x0001002C
+	ands r0, r1
+	cmp r0, #0
+	bne _080256DC
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #4
+	beq _080256DC
+	cmp r1, #2
+	beq _080256DC
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	adds r3, r5, #0
+	bl AddTarget
+_080256DC:
+	adds r5, #1
+	cmp r5, r6
+	blt _08025668
+_080256E2:
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080256E8: .4byte gUnknown_02033F3C
+_080256EC: .4byte 0x0001002C
+
+	THUMB_FUNC_START AddUnitToTargetListIfAllied
+AddUnitToTargetListIfAllied: @ 0x080256F0
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _08025724  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	bl AreUnitsAllied
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802571E
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	movs r3, #1
+	bl AddTarget
+_0802571E:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025724: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START FillBallistaRangeMaybe
+FillBallistaRangeMaybe: @ 0x08025728
+	push {r4, r5, r6, r7, lr}
+	movs r5, #0x10
+	ldrsb r5, [r0, r5]
+	movs r6, #0x11
+	ldrsb r6, [r0, r6]
+	ldr r1, _08025788  @ gUnknown_02033F3C
+	str r0, [r1]
+	adds r0, r5, #0
+	adds r1, r6, #0
+	bl InitTargets
+	adds r0, r5, #0
+	adds r1, r6, #0
+	bl GetSomeBallistaItemAt
+	adds r7, r0, #0
+	cmp r7, #0
+	beq _08025782
+	ldr r0, _0802578C  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	adds r0, r7, #0
+	bl GetItemMinRange
+	adds r4, r0, #0
+	lsls r4, r4, #0x10
+	asrs r4, r4, #0x10
+	adds r0, r7, #0
+	bl GetItemMaxRange
+	adds r3, r0, #0
+	lsls r3, r3, #0x10
+	asrs r3, r3, #0x10
+	adds r0, r5, #0
+	adds r1, r6, #0
+	adds r2, r4, #0
+	bl FillRangeMap
+	ldr r0, _08025790  @ AddUnitToTargetListIfAllied
+	bl ForEachUnitInRange
+	bl TryAddTrapsToTargetList
+_08025782:
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025788: .4byte gUnknown_02033F3C
+_0802578C: .4byte gUnknown_0202E4E4
+_08025790: .4byte AddUnitToTargetListIfAllied
+
+	THUMB_FUNC_START TryAddClosedDoorToTargetList
+TryAddClosedDoorToTargetList: @ 0x08025794
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	ldr r0, _080257D0  @ gUnknown_0202E4DC
+	ldr r1, [r0]
+	lsls r0, r5, #2
+	adds r0, r0, r1
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0x1e
+	bne _080257CA
+	lsls r0, r4, #0x18
+	asrs r0, r0, #0x18
+	lsls r1, r5, #0x18
+	asrs r1, r1, #0x18
+	bl IsThereClosedDoorAt
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _080257CA
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #0x1e
+	movs r3, #0
+	bl AddTarget
+_080257CA:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080257D0: .4byte gUnknown_0202E4DC
+
+	THUMB_FUNC_START TryAddBridgeToTargetList
+TryAddBridgeToTargetList: @ 0x080257D4
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	ldr r0, _08025810  @ gUnknown_0202E4DC
+	ldr r1, [r0]
+	lsls r0, r5, #2
+	adds r0, r0, r1
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0x14
+	bne _0802580A
+	lsls r0, r4, #0x18
+	asrs r0, r0, #0x18
+	lsls r1, r5, #0x18
+	asrs r1, r1, #0x18
+	bl IsThereClosedDoorAt
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802580A
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #0x14
+	movs r3, #0
+	bl AddTarget
+_0802580A:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025810: .4byte gUnknown_0202E4DC
+
+	THUMB_FUNC_START MakeTargetListForDoorAndBridges
+MakeTargetListForDoorAndBridges: @ 0x08025814
+	push {r4, r5, r6, lr}
+	adds r4, r1, #0
+	movs r5, #0x10
+	ldrsb r5, [r0, r5]
+	movs r6, #0x11
+	ldrsb r6, [r0, r6]
+	ldr r1, _08025844  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _08025848  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	cmp r4, #0x14
+	beq _08025850
+	cmp r4, #0x1e
+	bne _0802585A
+	ldr r2, _0802584C  @ TryAddClosedDoorToTargetList
+	adds r0, r5, #0
+	adds r1, r6, #0
+	bl ForEachAdjacentPosition
+	b _0802585A
+	.align 2, 0
+_08025844: .4byte gUnknown_02033F3C
+_08025848: .4byte gUnknown_0202E4E4
+_0802584C: .4byte TryAddClosedDoorToTargetList
+_08025850:
+	ldr r2, _08025860  @ TryAddBridgeToTargetList
+	adds r0, r5, #0
+	adds r1, r6, #0
+	bl ForEachAdjacentPosition
+_0802585A:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025860: .4byte TryAddBridgeToTargetList
+
+	THUMB_FUNC_START sub_8025864
+sub_8025864: @ 0x08025864
+	push {lr}
+	adds r2, r0, #0
+	adds r3, r1, #0
+	ldr r0, _08025890  @ gUnknown_0202E4DC
+	ldr r1, [r0]
+	lsls r0, r3, #2
+	adds r0, r0, r1
+	ldr r0, [r0]
+	adds r0, r0, r2
+	ldrb r0, [r0]
+	cmp r0, #0x14
+	beq _08025894
+	cmp r0, #0x1e
+	bne _080258A0
+	adds r0, r2, #0
+	adds r1, r3, #0
+	movs r2, #0x1e
+	movs r3, #0
+	bl AddTarget
+	b _080258A0
+	.align 2, 0
+_08025890: .4byte gUnknown_0202E4DC
+_08025894:
+	adds r0, r2, #0
+	adds r1, r3, #0
+	movs r2, #0x14
+	movs r3, #0
+	bl AddTarget
+_080258A0:
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_80258A4
+sub_80258A4: @ 0x080258A4
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	movs r5, #0x10
+	ldrsb r5, [r4, r5]
+	movs r6, #0x11
+	ldrsb r6, [r4, r6]
+	ldr r0, _080258F4  @ gUnknown_02033F3C
+	str r4, [r0]
+	ldr r0, _080258F8  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _080258FC  @ sub_8025864
+	adds r0, r5, #0
+	adds r1, r6, #0
+	bl ForEachAdjacentPosition
+	movs r0, #0x11
+	ldrsb r0, [r4, r0]
+	ldr r1, _08025900  @ gUnknown_0202E4DC
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r1, #0x10
+	ldrsb r1, [r4, r1]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	cmp r0, #0x21
+	bne _080258EE
+	adds r0, r5, #0
+	adds r1, r6, #0
+	movs r2, #0x21
+	movs r3, #0
+	bl AddTarget
+_080258EE:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080258F4: .4byte gUnknown_02033F3C
+_080258F8: .4byte gUnknown_0202E4E4
+_080258FC: .4byte sub_8025864
+_08025900: .4byte gUnknown_0202E4DC
+
+	THUMB_FUNC_START sub_8025904
+sub_8025904: @ 0x08025904
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	mov r8, r0
+	movs r0, #0
+	movs r1, #0
+	bl InitTargets
+	mov r7, r8
+	b _080259CE
+_08025918:
+	adds r0, r7, #0
+	bl GetUnitStruct
+	adds r5, r0, #0
+	cmp r5, #0
+	beq _080259CE
+	ldr r0, [r5]
+	cmp r0, #0
+	beq _080259CE
+	ldr r0, [r5, #0xc]
+	ldr r1, _080259E4  @ 0x0001002C
+	ands r0, r1
+	cmp r0, #0
+	bne _080259CE
+	movs r1, #0x11
+	ldrsb r1, [r5, r1]
+	ldr r0, _080259E8  @ gUnknown_0202E4DC
+	ldr r0, [r0]
+	lsls r1, r1, #2
+	adds r1, r1, r0
+	movs r2, #0x10
+	ldrsb r2, [r5, r2]
+	ldr r0, [r1]
+	adds r0, r0, r2
+	ldrb r6, [r0]
+	adds r0, r6, #0
+	bl GetTerrainHealAmount
+	cmp r0, #0
+	beq _0802598E
+	adds r0, r5, #0
+	bl GetUnitCurrentHP
+	adds r4, r0, #0
+	adds r0, r5, #0
+	bl GetUnitMaxHP
+	cmp r4, r0
+	beq _0802598E
+	adds r0, r6, #0
+	bl GetTerrainHealAmount
+	adds r4, r0, #0
+	adds r0, r5, #0
+	bl GetUnitMaxHP
+	muls r0, r4, r0
+	movs r1, #0x64
+	bl __divsi3
+	adds r3, r0, #0
+	movs r0, #0x10
+	ldrsb r0, [r5, r0]
+	movs r1, #0x11
+	ldrsb r1, [r5, r1]
+	movs r2, #0xb
+	ldrsb r2, [r5, r2]
+	bl AddTarget
+_0802598E:
+	adds r0, r6, #0
+	bl GetTerrainSomething
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _080259CE
+	adds r2, r5, #0
+	adds r2, #0x30
+	ldrb r1, [r2]
+	movs r0, #0xf
+	ands r0, r1
+	cmp r0, #0
+	beq _080259CE
+	cmp r0, #0xd
+	bne _080259BA
+	movs r3, #0x10
+	negs r3, r3
+	adds r0, r3, #0
+	ands r0, r1
+	movs r1, #0xb
+	orrs r0, r1
+	strb r0, [r2]
+_080259BA:
+	movs r0, #0x10
+	ldrsb r0, [r5, r0]
+	movs r1, #0x11
+	ldrsb r1, [r5, r1]
+	movs r2, #0xb
+	ldrsb r2, [r5, r2]
+	movs r3, #1
+	negs r3, r3
+	bl AddTarget
+_080259CE:
+	adds r7, #1
+	mov r0, r8
+	adds r0, #0x40
+	cmp r7, r0
+	blt _08025918
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080259E4: .4byte 0x0001002C
+_080259E8: .4byte gUnknown_0202E4DC
+
+	THUMB_FUNC_START sub_80259EC
+sub_80259EC: @ 0x080259EC
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	mov r8, r0
+	movs r0, #0
+	movs r1, #0
+	bl InitTargets
+	mov r7, r8
+	b _08025A4A
+_08025A00:
+	adds r0, r7, #0
+	bl GetUnitStruct
+	adds r2, r0, #0
+	cmp r2, #0
+	beq _08025A4A
+	ldr r0, [r2]
+	cmp r0, #0
+	beq _08025A4A
+	ldr r0, [r2, #0xc]
+	ldr r1, _08025A60  @ 0x0001002C
+	ands r0, r1
+	cmp r0, #0
+	bne _08025A4A
+	adds r0, r2, #0
+	adds r0, #0x30
+	ldrb r1, [r0]
+	movs r0, #0xf
+	ands r0, r1
+	cmp r0, #1
+	bne _08025A4A
+	movs r4, #0x10
+	ldrsb r4, [r2, r4]
+	movs r5, #0x11
+	ldrsb r5, [r2, r5]
+	movs r6, #0xb
+	ldrsb r6, [r2, r6]
+	movs r0, #3
+	bl NextRN_N
+	adds r3, r0, #0
+	adds r3, #1
+	adds r0, r4, #0
+	adds r1, r5, #0
+	adds r2, r6, #0
+	bl AddTarget
+_08025A4A:
+	adds r7, #1
+	mov r0, r8
+	adds r0, #0x40
+	cmp r7, r0
+	blt _08025A00
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025A60: .4byte 0x0001002C
+
+	THUMB_FUNC_START sub_8025A64
+sub_8025A64: @ 0x08025A64
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	adds r7, r0, #0
+	movs r0, #0
+	movs r1, #0
+	bl InitTargets
+	adds r6, r7, #1
+	adds r0, r7, #0
+	adds r0, #0x40
+	cmp r6, r0
+	bge _08025B0C
+	movs r0, #5
+	lsls r0, r0, #0x18
+	mov r8, r0
+_08025A84:
+	adds r0, r6, #0
+	bl GetUnitStruct
+	adds r4, r0, #0
+	cmp r4, #0
+	beq _08025B02
+	ldr r0, [r4]
+	cmp r0, #0
+	beq _08025B02
+	ldr r5, [r4, #0xc]
+	ldr r0, _08025AD4  @ 0x0001002C
+	ands r5, r0
+	cmp r5, #0
+	bne _08025B02
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r1, [r0]
+	movs r0, #0xf
+	ands r0, r1
+	cmp r0, #0xa
+	bne _08025B02
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xc
+	bl GetSpecificTrapAt
+	adds r2, r0, #0
+	cmp r2, #0
+	beq _08025B02
+	ldrb r0, [r2, #4]
+	subs r0, #1
+	cmp r0, #0
+	ble _08025AD8
+	strb r0, [r2, #4]
+	ldrb r0, [r2, #5]
+	strb r0, [r2, #6]
+	b _08025B02
+	.align 2, 0
+_08025AD4: .4byte 0x0001002C
+_08025AD8:
+	strb r5, [r2, #4]
+	ldrb r0, [r2, #6]
+	adds r0, #1
+	strb r0, [r2, #6]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #5
+	ldrsb r1, [r2, r1]
+	cmp r0, r1
+	blt _08025B02
+	strb r5, [r2, #6]
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	mov r4, r8
+	asrs r3, r4, #0x18
+	bl AddTarget
+_08025B02:
+	adds r6, #1
+	adds r0, r7, #0
+	adds r0, #0x40
+	cmp r6, r0
+	blt _08025A84
+_08025B0C:
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_8025B18
+sub_8025B18: @ 0x08025B18
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _08025B68  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	bl IsSameAllegience
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08025B62
+	ldr r0, [r4, #0xc]
+	movs r1, #2
+	ands r0, r1
+	cmp r0, #0
+	beq _08025B62
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #0xb
+	beq _08025B62
+	cmp r1, #0xd
+	beq _08025B62
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	movs r3, #0
+	bl AddTarget
+_08025B62:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025B68: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START sub_8025B6C
+sub_8025B6C: @ 0x08025B6C
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _08025B94  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _08025B98  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _08025B9C  @ sub_8025B18
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentUnit
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025B94: .4byte gUnknown_02033F3C
+_08025B98: .4byte gUnknown_0202E4E4
+_08025B9C: .4byte sub_8025B18
+
+	THUMB_FUNC_START AddAsTarget_IfCanStealFrom
+AddAsTarget_IfCanStealFrom: @ 0x08025BA0
+	push {r4, r5, r6, lr}
+	adds r5, r0, #0
+	movs r0, #0xb
+	ldrsb r0, [r5, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, #0x80
+	bne _08025BF8
+	ldr r0, _08025BEC  @ gUnknown_03004E50
+	ldr r0, [r0]
+	movs r1, #0x16
+	ldrsb r1, [r0, r1]
+	movs r0, #0x16
+	ldrsb r0, [r5, r0]
+	cmp r1, r0
+	blt _08025BF8
+	movs r6, #0
+	adds r4, r5, #0
+	adds r4, #0x1e
+_08025BC6:
+	ldrh r0, [r4]
+	cmp r0, #0
+	beq _08025BF8
+	bl IsItemStealable
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08025BF0
+	movs r0, #0x10
+	ldrsb r0, [r5, r0]
+	movs r1, #0x11
+	ldrsb r1, [r5, r1]
+	movs r2, #0xb
+	ldrsb r2, [r5, r2]
+	movs r3, #0
+	bl AddTarget
+	b _08025BF8
+	.align 2, 0
+_08025BEC: .4byte gUnknown_03004E50
+_08025BF0:
+	adds r4, #2
+	adds r6, #1
+	cmp r6, #4
+	ble _08025BC6
+_08025BF8:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START MakeTargetListForSteal
+MakeTargetListForSteal: @ 0x08025C00
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _08025C28  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _08025C2C  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _08025C30  @ AddAsTarget_IfCanStealFrom
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentUnit
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025C28: .4byte gUnknown_02033F3C
+_08025C2C: .4byte gUnknown_0202E4E4
+_08025C30: .4byte AddAsTarget_IfCanStealFrom
+
+	THUMB_FUNC_START sub_8025C34
+sub_8025C34: @ 0x08025C34
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	ldr r0, _08025C90  @ gUnknown_0202E4D8
+	ldr r0, [r0]
+	lsls r2, r5, #2
+	adds r0, r2, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0
+	bne _08025C8A
+	ldr r0, _08025C94  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xd]
+	cmp r0, #0
+	beq _08025C64
+	ldr r0, _08025C98  @ gUnknown_0202E4E8
+	ldr r0, [r0]
+	adds r0, r2, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0
+	beq _08025C8A
+_08025C64:
+	ldr r0, _08025C9C  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldr r1, _08025CA0  @ gUnknown_0202E4DC
+	ldr r1, [r1]
+	adds r1, r2, r1
+	ldr r1, [r1]
+	adds r1, r1, r4
+	ldrb r1, [r1]
+	bl CanUnitCrossTerrain
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08025C8A
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #0
+	movs r3, #0
+	bl AddTarget
+_08025C8A:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025C90: .4byte gUnknown_0202E4D8
+_08025C94: .4byte gUnknown_0202BCF0
+_08025C98: .4byte gUnknown_0202E4E8
+_08025C9C: .4byte gUnknown_02033F3C
+_08025CA0: .4byte gUnknown_0202E4DC
+
+	THUMB_FUNC_START sub_8025CA4
+sub_8025CA4: @ 0x08025CA4
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _08025CCC  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _08025CD0  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _08025CD4  @ sub_8025C34
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentPosition
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025CCC: .4byte gUnknown_02033F3C
+_08025CD0: .4byte gUnknown_0202E4E4
+_08025CD4: .4byte sub_8025C34
+
+	THUMB_FUNC_START sub_8025CD8
+sub_8025CD8: @ 0x08025CD8
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	ldr r0, _08025D34  @ gUnknown_0202E4D8
+	ldr r0, [r0]
+	lsls r2, r5, #2
+	adds r0, r2, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0
+	bne _08025D2E
+	ldr r0, _08025D38  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xd]
+	cmp r0, #0
+	beq _08025D08
+	ldr r0, _08025D3C  @ gUnknown_0202E4E8
+	ldr r0, [r0]
+	adds r0, r2, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0
+	beq _08025D2E
+_08025D08:
+	ldr r0, _08025D40  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldr r1, _08025D44  @ gUnknown_0202E4DC
+	ldr r1, [r1]
+	adds r1, r2, r1
+	ldr r1, [r1]
+	adds r1, r1, r4
+	ldrb r1, [r1]
+	bl CanUnitCrossTerrain
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08025D2E
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #0
+	movs r3, #0
+	bl AddTarget
+_08025D2E:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025D34: .4byte gUnknown_0202E4D8
+_08025D38: .4byte gUnknown_0202BCF0
+_08025D3C: .4byte gUnknown_0202E4E8
+_08025D40: .4byte gUnknown_02033F3C
+_08025D44: .4byte gUnknown_0202E4DC
+
+	THUMB_FUNC_START sub_8025D48
+sub_8025D48: @ 0x08025D48
+	push {r4, r5, lr}
+	movs r5, #0x10
+	ldrsb r5, [r0, r5]
+	movs r4, #0x11
+	ldrsb r4, [r0, r4]
+	ldr r1, _08025D74  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _08025D78  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	adds r4, #4
+	ldr r2, _08025D7C  @ sub_8025CD8
+	adds r0, r5, #0
+	adds r1, r4, #0
+	bl sub_8024FD8
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025D74: .4byte gUnknown_02033F3C
+_08025D78: .4byte gUnknown_0202E4E4
+_08025D7C: .4byte sub_8025CD8
+
+	THUMB_FUNC_START sub_8025D80
+sub_8025D80: @ 0x08025D80
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _08025DAC  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _08025DB0  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	subs r4, #4
+	ldr r2, _08025DB4  @ sub_8025CD8
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl sub_8024FD8
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025DAC: .4byte gUnknown_02033F3C
+_08025DB0: .4byte gUnknown_0202E4E4
+_08025DB4: .4byte sub_8025CD8
+
+	THUMB_FUNC_START sub_8025DB8
+sub_8025DB8: @ 0x08025DB8
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _08025DE4  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _08025DE8  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	adds r4, #4
+	ldr r2, _08025DEC  @ sub_8025CD8
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl sub_8024FD8
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025DE4: .4byte gUnknown_02033F3C
+_08025DE8: .4byte gUnknown_0202E4E4
+_08025DEC: .4byte sub_8025CD8
+
+	THUMB_FUNC_START sub_8025DF0
+sub_8025DF0: @ 0x08025DF0
+	push {r4, r5, lr}
+	movs r5, #0x10
+	ldrsb r5, [r0, r5]
+	movs r4, #0x11
+	ldrsb r4, [r0, r4]
+	ldr r1, _08025E1C  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _08025E20  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	subs r4, #4
+	ldr r2, _08025E24  @ sub_8025CD8
+	adds r0, r5, #0
+	adds r1, r4, #0
+	bl sub_8024FD8
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025E1C: .4byte gUnknown_02033F3C
+_08025E20: .4byte gUnknown_0202E4E4
+_08025E24: .4byte sub_8025CD8
+
+	THUMB_FUNC_START TryAddUnitToHealTargetList
+TryAddUnitToHealTargetList: @ 0x08025E28
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	ldr r0, _08025E78  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r5, r1]
+	bl AreUnitsAllied
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08025E72
+	ldr r0, [r5, #0xc]
+	movs r1, #0x20
+	ands r0, r1
+	cmp r0, #0
+	bne _08025E72
+	adds r0, r5, #0
+	bl GetUnitCurrentHP
+	adds r4, r0, #0
+	adds r0, r5, #0
+	bl GetUnitMaxHP
+	cmp r4, r0
+	beq _08025E72
+	movs r0, #0x10
+	ldrsb r0, [r5, r0]
+	movs r1, #0x11
+	ldrsb r1, [r5, r1]
+	movs r2, #0xb
+	ldrsb r2, [r5, r2]
+	movs r3, #0
+	bl AddTarget
+_08025E72:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025E78: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START MakeTargetListForAdjacentHeal
+MakeTargetListForAdjacentHeal: @ 0x08025E7C
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _08025EA4  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _08025EA8  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _08025EAC  @ TryAddUnitToHealTargetList
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentUnit
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025EA4: .4byte gUnknown_02033F3C
+_08025EA8: .4byte gUnknown_0202E4E4
+_08025EAC: .4byte TryAddUnitToHealTargetList
+
+	THUMB_FUNC_START MakeTargetListForRangedHeal
+MakeTargetListForRangedHeal: @ 0x08025EB0
+	push {r4, r5, r6, lr}
+	movs r5, #0x10
+	ldrsb r5, [r0, r5]
+	movs r6, #0x11
+	ldrsb r6, [r0, r6]
+	ldr r4, _08025EF0  @ gUnknown_02033F3C
+	str r0, [r4]
+	adds r0, r5, #0
+	adds r1, r6, #0
+	bl InitTargets
+	ldr r0, _08025EF4  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r0, [r4]
+	bl GetUnitMagBy2Range
+	adds r2, r0, #0
+	adds r0, r5, #0
+	adds r1, r6, #0
+	movs r3, #1
+	bl MapAddInRange
+	ldr r0, _08025EF8  @ TryAddUnitToHealTargetList
+	bl ForEachUnitInRange
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025EF0: .4byte gUnknown_02033F3C
+_08025EF4: .4byte gUnknown_0202E4E4
+_08025EF8: .4byte TryAddUnitToHealTargetList
+
+	THUMB_FUNC_START AddToTargetListIfNotAllied
+AddToTargetListIfNotAllied: @ 0x08025EFC
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _08025F40  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	bl AreUnitsAllied
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #1
+	beq _08025F3A
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r1, [r0]
+	movs r0, #0xf
+	ands r0, r1
+	cmp r0, #0
+	bne _08025F3A
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	movs r3, #0
+	bl AddTarget
+_08025F3A:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025F40: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START MakeTargetListForFuckingNightmare
+MakeTargetListForFuckingNightmare: @ 0x08025F44
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _08025F8C  @ gUnknown_02033F3C
+	str r0, [r1]
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl InitTargets
+	ldr r0, _08025F90  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #3
+	movs r3, #1
+	bl MapAddInRange
+	movs r3, #1
+	negs r3, r3
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #0
+	bl MapAddInRange
+	ldr r0, _08025F94  @ AddToTargetListIfNotAllied
+	bl ForEachUnitInRange
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025F8C: .4byte gUnknown_02033F3C
+_08025F90: .4byte gUnknown_0202E4E4
+_08025F94: .4byte AddToTargetListIfNotAllied
+
+	THUMB_FUNC_START TryAddUnitToRestoreTargetList
+TryAddUnitToRestoreTargetList: @ 0x08025F98
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _08025FE4  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	bl AreUnitsAllied
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08025FDE
+	ldr r0, [r4, #0xc]
+	movs r1, #0x20
+	ands r0, r1
+	cmp r0, #0
+	bne _08025FDE
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r1, [r0]
+	movs r0, #0xf
+	ands r0, r1
+	cmp r0, #0
+	beq _08025FDE
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	movs r3, #0
+	bl AddTarget
+_08025FDE:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08025FE4: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START MakeTargetListForRestore
+MakeTargetListForRestore: @ 0x08025FE8
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _08026010  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _08026014  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _08026018  @ TryAddUnitToRestoreTargetList
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentUnit
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026010: .4byte gUnknown_02033F3C
+_08026014: .4byte gUnknown_0202E4E4
+_08026018: .4byte TryAddUnitToRestoreTargetList
+
+	THUMB_FUNC_START TryAddUnitToBarrierTargetList
+TryAddUnitToBarrierTargetList: @ 0x0802601C
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _08026068  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	bl AreUnitsAllied
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08026060
+	ldr r0, [r4, #0xc]
+	movs r1, #0x20
+	ands r0, r1
+	cmp r0, #0
+	bne _08026060
+	adds r0, r4, #0
+	adds r0, #0x31
+	ldrb r0, [r0]
+	lsrs r0, r0, #4
+	cmp r0, #6
+	bhi _08026060
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	movs r3, #0
+	bl AddTarget
+_08026060:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026068: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START MakeTargetListForBarrier
+MakeTargetListForBarrier: @ 0x0802606C
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _08026094  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _08026098  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _0802609C  @ TryAddUnitToBarrierTargetList
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentUnit
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026094: .4byte gUnknown_02033F3C
+_08026098: .4byte gUnknown_0202E4E4
+_0802609C: .4byte TryAddUnitToBarrierTargetList
+
+	THUMB_FUNC_START TryAddUnitToRescueStaffTargetList
+TryAddUnitToRescueStaffTargetList: @ 0x080260A0
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _080260D4  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	bl AreUnitsAllied
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _080260CE
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	movs r3, #0
+	bl AddTarget
+_080260CE:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080260D4: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START MakeTargetListForRescueStaff
+MakeTargetListForRescueStaff: @ 0x080260D8
+	push {lr}
+	ldr r1, _080260F4  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _080260F8  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r0, _080260FC  @ TryAddUnitToRescueStaffTargetList
+	bl ForEachUnitInMagBy2Range
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080260F4: .4byte gUnknown_02033F3C
+_080260F8: .4byte gUnknown_0202E4E4
+_080260FC: .4byte TryAddUnitToRescueStaffTargetList
+
+	THUMB_FUNC_START TryAddUnitToSilenceTargetList
+TryAddUnitToSilenceTargetList: @ 0x08026100
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _08026148  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	bl AreUnitsAllied
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _08026140
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #0
+	beq _0802612E
+	cmp r1, #3
+	bne _08026140
+_0802612E:
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	movs r3, #0
+	bl AddTarget
+_08026140:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026148: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START TryAddUnitToSleepTargetList
+TryAddUnitToSleepTargetList: @ 0x0802614C
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _08026194  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	bl AreUnitsAllied
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _0802618C
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #0
+	beq _0802617A
+	cmp r1, #2
+	bne _0802618C
+_0802617A:
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	movs r3, #0
+	bl AddTarget
+_0802618C:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026194: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START TryAddUnitToBerzerkTargetList
+TryAddUnitToBerzerkTargetList: @ 0x08026198
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _080261E0  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	bl AreUnitsAllied
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	bne _080261D8
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #0
+	beq _080261C6
+	cmp r1, #4
+	bne _080261D8
+_080261C6:
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	movs r3, #0
+	bl AddTarget
+_080261D8:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080261E0: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START MakeTargetListForSilence
+MakeTargetListForSilence: @ 0x080261E4
+	push {lr}
+	ldr r1, _08026200  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _08026204  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r0, _08026208  @ TryAddUnitToSilenceTargetList
+	bl ForEachUnitInMagBy2Range
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026200: .4byte gUnknown_02033F3C
+_08026204: .4byte gUnknown_0202E4E4
+_08026208: .4byte TryAddUnitToSilenceTargetList
+
+	THUMB_FUNC_START MakeTargetListForSleep
+MakeTargetListForSleep: @ 0x0802620C
+	push {lr}
+	ldr r1, _08026228  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _0802622C  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r0, _08026230  @ TryAddUnitToSleepTargetList
+	bl ForEachUnitInMagBy2Range
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026228: .4byte gUnknown_02033F3C
+_0802622C: .4byte gUnknown_0202E4E4
+_08026230: .4byte TryAddUnitToSleepTargetList
+
+	THUMB_FUNC_START MakeTargetListForBerserk
+MakeTargetListForBerserk: @ 0x08026234
+	push {lr}
+	ldr r1, _08026250  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _08026254  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r0, _08026258  @ TryAddUnitToBerzerkTargetList
+	bl ForEachUnitInMagBy2Range
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026250: .4byte gUnknown_02033F3C
+_08026254: .4byte gUnknown_0202E4E4
+_08026258: .4byte TryAddUnitToBerzerkTargetList
+
+	THUMB_FUNC_START TryAddUnitToWarpTargetList
+TryAddUnitToWarpTargetList: @ 0x0802625C
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _08026290  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	bl AreUnitsAllied
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802628A
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	movs r3, #0
+	bl AddTarget
+_0802628A:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026290: .4byte gUnknown_02033F3C
+
+	THUMB_FUNC_START MakeTargetListForWarp
+MakeTargetListForWarp: @ 0x08026294
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _080262BC  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _080262C0  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _080262C4  @ TryAddUnitToWarpTargetList
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentUnit
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080262BC: .4byte gUnknown_02033F3C
+_080262C0: .4byte gUnknown_0202E4E4
+_080262C4: .4byte TryAddUnitToWarpTargetList
+
+	THUMB_FUNC_START MakeTargetListForUnlock
+MakeTargetListForUnlock: @ 0x080262C8
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _080262F0  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _080262F4  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _080262F8  @ TryAddClosedDoorToTargetList
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachPosIn12Range
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080262F0: .4byte gUnknown_02033F3C
+_080262F4: .4byte gUnknown_0202E4E4
+_080262F8: .4byte TryAddClosedDoorToTargetList
+
+	THUMB_FUNC_START TryAddUnitToHammerneTargetList
+TryAddUnitToHammerneTargetList: @ 0x080262FC
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	ldr r0, _0802631C  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldrb r0, [r0, #0xb]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	bl IsSameAllegience
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802634C
+	movs r5, #0
+	b _08026322
+	.align 2, 0
+_0802631C: .4byte gUnknown_02033F3C
+_08026320:
+	adds r5, #1
+_08026322:
+	cmp r5, #4
+	bgt _0802634C
+	lsls r1, r5, #1
+	adds r0, r4, #0
+	adds r0, #0x1e
+	adds r0, r0, r1
+	ldrh r0, [r0]
+	bl IsItemHammernable
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _08026320
+	movs r0, #0x10
+	ldrsb r0, [r4, r0]
+	movs r1, #0x11
+	ldrsb r1, [r4, r1]
+	movs r2, #0xb
+	ldrsb r2, [r4, r2]
+	movs r3, #0
+	bl AddTarget
+_0802634C:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START MakeTargetListForHammerne
+MakeTargetListForHammerne: @ 0x08026354
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _0802637C  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _08026380  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _08026384  @ TryAddUnitToHammerneTargetList
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentUnit
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802637C: .4byte gUnknown_02033F3C
+_08026380: .4byte gUnknown_0202E4E4
+_08026384: .4byte TryAddUnitToHammerneTargetList
+
+	THUMB_FUNC_START MakeTargetListForLatona
+MakeTargetListForLatona: @ 0x08026388
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	mov r8, r0
+	ldrb r0, [r0, #0x10]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	mov r2, r8
+	movs r1, #0x11
+	ldrsb r1, [r2, r1]
+	bl InitTargets
+	bl GetCurrentPhase
+	adds r7, r0, #0
+	adds r6, r7, #1
+	b _08026400
+_080263AA:
+	adds r0, r6, #0
+	bl GetUnitStruct
+	adds r5, r0, #0
+	cmp r5, #0
+	beq _080263FC
+	ldr r0, [r5]
+	cmp r0, #0
+	beq _080263FC
+	ldr r0, [r5, #0xc]
+	ldr r1, _08026410  @ 0x0001000C
+	ands r0, r1
+	cmp r0, #0
+	bne _080263FC
+	adds r0, r5, #0
+	bl GetUnitCurrentHP
+	adds r4, r0, #0
+	adds r0, r5, #0
+	bl GetUnitMaxHP
+	cmp r4, r0
+	bne _080263E6
+	adds r0, r5, #0
+	adds r0, #0x30
+	ldrb r1, [r0]
+	movs r0, #0xf
+	ands r0, r1
+	cmp r0, #0
+	beq _080263FC
+_080263E6:
+	cmp r5, r8
+	beq _080263FC
+	movs r0, #0x10
+	ldrsb r0, [r5, r0]
+	movs r1, #0x11
+	ldrsb r1, [r5, r1]
+	movs r2, #0xb
+	ldrsb r2, [r5, r2]
+	movs r3, #0
+	bl AddTarget
+_080263FC:
+	adds r6, #1
+	adds r0, r7, #0
+_08026400:
+	adds r0, #0x80
+	cmp r6, r0
+	blt _080263AA
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026410: .4byte 0x0001000C
+
+	THUMB_FUNC_START sub_8026414
+sub_8026414: @ 0x08026414
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	mov r8, r0
+	bl sub_804FD28
+	adds r7, r0, #0
+	movs r6, #0
+	cmp r6, r7
+	bge _08026460
+_08026428:
+	adds r0, r6, #0
+	bl GetTarget
+	adds r4, r0, #0
+	movs r0, #2
+	ldrsb r0, [r4, r0]
+	bl GetUnitStruct
+	adds r5, r0, #0
+	bl GetUnitCurrentHP
+	movs r1, #3
+	ldrsb r1, [r4, r1]
+	cmp r0, r1
+	bgt _0802645A
+	ldr r0, [r5]
+	ldrb r0, [r0, #4]
+	movs r1, #0
+	mov r2, r8
+	bl BWL_AddWinOrLossIdk
+	ldr r0, [r5]
+	ldrb r0, [r0, #4]
+	bl sub_80A4594
+_0802645A:
+	adds r6, #1
+	cmp r6, r7
+	blt _08026428
+_08026460:
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_802646C
+sub_802646C: @ 0x0802646C
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	ldr r0, _080264DC  @ gUnknown_0202E4D8
+	ldr r0, [r0]
+	lsls r2, r5, #2
+	adds r0, r2, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0
+	bne _080264D4
+	ldr r0, _080264E0  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xd]
+	cmp r0, #0
+	beq _0802649C
+	ldr r0, _080264E4  @ gUnknown_0202E4E8
+	ldr r0, [r0]
+	adds r0, r2, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0
+	beq _080264D4
+_0802649C:
+	ldr r0, _080264E8  @ gUnknown_02033F3C
+	ldr r0, [r0]
+	ldr r1, _080264EC  @ gUnknown_0202E4DC
+	ldr r1, [r1]
+	adds r1, r2, r1
+	ldr r1, [r1]
+	adds r1, r1, r4
+	ldrb r1, [r1]
+	bl CanUnitCrossTerrain
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _080264D4
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl GetTrapAt
+	cmp r0, #0
+	beq _080264C8
+	ldrb r0, [r0, #2]
+	cmp r0, #0xa
+	bne _080264D4
+_080264C8:
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #0
+	movs r3, #0
+	bl AddTarget
+_080264D4:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080264DC: .4byte gUnknown_0202E4D8
+_080264E0: .4byte gUnknown_0202BCF0
+_080264E4: .4byte gUnknown_0202E4E8
+_080264E8: .4byte gUnknown_02033F3C
+_080264EC: .4byte gUnknown_0202E4DC
+
+	THUMB_FUNC_START MakeTargetListForMine
+MakeTargetListForMine: @ 0x080264F0
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _08026518  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _0802651C  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _08026520  @ sub_802646C
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentPosition
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026518: .4byte gUnknown_02033F3C
+_0802651C: .4byte gUnknown_0202E4E4
+_08026520: .4byte sub_802646C
+
+	THUMB_FUNC_START sub_8026524
+sub_8026524: @ 0x08026524
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	ldr r0, _08026574  @ gUnknown_0202E4D8
+	ldr r0, [r0]
+	lsls r6, r5, #2
+	adds r0, r6, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0
+	bne _0802656C
+	adds r0, r4, #0
+	bl GetTrapAt
+	cmp r0, #0
+	bne _0802656C
+	ldr r1, _08026578  @ gUnknown_0880BB96
+	ldr r0, _0802657C  @ gUnknown_0202E4DC
+	ldr r0, [r0]
+	adds r0, r6, r0
+	ldr r0, [r0]
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	cmp r0, #0
+	ble _0802656C
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #0
+	movs r3, #0
+	bl AddTarget
+_0802656C:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026574: .4byte gUnknown_0202E4D8
+_08026578: .4byte gUnknown_0880BB96
+_0802657C: .4byte gUnknown_0202E4DC
+
+	THUMB_FUNC_START MakeTargetListForLightRune
+MakeTargetListForLightRune: @ 0x08026580
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _080265A8  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _080265AC  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _080265B0  @ sub_8026524
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentPosition
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080265A8: .4byte gUnknown_02033F3C
+_080265AC: .4byte gUnknown_0202E4E4
+_080265B0: .4byte sub_8026524
+
+	THUMB_FUNC_START TryAddUnitToDanceRingTargetList
+TryAddUnitToDanceRingTargetList: @ 0x080265B4
+	push {lr}
+	adds r3, r0, #0
+	movs r2, #0xb
+	ldrsb r2, [r3, r2]
+	movs r0, #0xc0
+	ands r0, r2
+	cmp r0, #0
+	bne _080265E0
+	adds r0, r3, #0
+	adds r0, #0x30
+	ldrb r1, [r0]
+	movs r0, #0xf
+	ands r0, r1
+	cmp r0, #0
+	bne _080265E0
+	movs r0, #0x10
+	ldrsb r0, [r3, r0]
+	movs r1, #0x11
+	ldrsb r1, [r3, r1]
+	movs r3, #0
+	bl AddTarget
+_080265E0:
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START MakeTargetListForDanceRing
+MakeTargetListForDanceRing: @ 0x080265E4
+	push {r4, r5, lr}
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r1, _0802660C  @ gUnknown_02033F3C
+	str r0, [r1]
+	ldr r0, _08026610  @ gUnknown_0202E4E4
+	ldr r0, [r0]
+	movs r1, #0
+	bl ClearMapWith
+	ldr r2, _08026614  @ TryAddUnitToDanceRingTargetList
+	adds r0, r4, #0
+	adds r1, r5, #0
+	bl ForEachAdjacentUnit
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802660C: .4byte gUnknown_02033F3C
+_08026610: .4byte gUnknown_0202E4E4
+_08026614: .4byte TryAddUnitToDanceRingTargetList
+
+.align 2, 0

--- a/asm/bmudisp.s
+++ b/asm/bmudisp.s
@@ -1,0 +1,3575 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ Display standing map sprites and various tile/unit markers
+
+	THUMB_FUNC_START sub_8026618
+sub_8026618: @ 0x08026618
+	ldr r1, _08026624  @ gUnknown_0203A4CC
+	ldr r0, [r1]
+	adds r0, #1
+	str r0, [r1]
+	bx lr
+	.align 2, 0
+_08026624: .4byte gUnknown_0203A4CC
+
+	THUMB_FUNC_START SetupMapSpritesPalettes
+SetupMapSpritesPalettes: @ 0x08026628
+	push {lr}
+	ldr r0, _08026650  @ gUnknown_0859EE20
+	movs r1, #0xe0
+	lsls r1, r1, #2
+	movs r2, #0x80
+	bl CopyToPaletteBuffer
+	ldr r0, _08026654  @ gUnknown_0202BCB0
+	ldrb r1, [r0, #4]
+	movs r0, #0x40
+	ands r0, r1
+	cmp r0, #0
+	beq _0802665C
+	ldr r0, _08026658  @ gUnknown_0859EEA0
+	movs r1, #0xd8
+	lsls r1, r1, #2
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	b _08026668
+	.align 2, 0
+_08026650: .4byte gUnknown_0859EE20
+_08026654: .4byte gUnknown_0202BCB0
+_08026658: .4byte gUnknown_0859EEA0
+_0802665C:
+	ldr r0, _0802666C  @ gUnknown_0859EEC0
+	movs r1, #0xd8
+	lsls r1, r1, #2
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+_08026668:
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802666C: .4byte gUnknown_0859EEC0
+
+	THUMB_FUNC_START sub_8026670
+sub_8026670: @ 0x08026670
+	push {lr}
+	ldr r0, _08026684  @ gUnknown_0859EEE0
+	movs r1, #0xf0
+	lsls r1, r1, #2
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026684: .4byte gUnknown_0859EEE0
+
+	THUMB_FUNC_START SMS_ClearUsageTable
+SMS_ClearUsageTable: @ 0x08026688
+	push {r4, r5, r6, lr}
+	movs r2, #0xcf
+	ldr r5, _080266B0  @ gUnknown_0203A014
+	ldr r6, _080266B4  @ gUnknown_0203A010
+	ldr r4, _080266B8  @ gUnknown_02033F40
+	movs r3, #0xff
+_08026694:
+	adds r1, r2, r4
+	ldrb r0, [r1]
+	orrs r0, r3
+	strb r0, [r1]
+	subs r2, #1
+	cmp r2, #0
+	bge _08026694
+	movs r0, #0
+	str r0, [r5]
+	movs r0, #0x3f
+	str r0, [r6]
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080266B0: .4byte gUnknown_0203A014
+_080266B4: .4byte gUnknown_0203A010
+_080266B8: .4byte gUnknown_02033F40
+
+	THUMB_FUNC_START sub_80266BC
+sub_80266BC: @ 0x080266BC
+	push {r4, r5, r6, lr}
+	movs r2, #0xcf
+	ldr r5, _080266E4  @ gUnknown_0203A014
+	ldr r6, _080266E8  @ gUnknown_0203A010
+	ldr r4, _080266EC  @ gUnknown_02033F40
+	movs r3, #0xff
+_080266C8:
+	adds r1, r2, r4
+	ldrb r0, [r1]
+	orrs r0, r3
+	strb r0, [r1]
+	subs r2, #1
+	cmp r2, #0
+	bge _080266C8
+	movs r0, #0
+	str r0, [r5]
+	movs r0, #0x5f
+	str r0, [r6]
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080266E4: .4byte gUnknown_0203A014
+_080266E8: .4byte gUnknown_0203A010
+_080266EC: .4byte gUnknown_02033F40
+
+	THUMB_FUNC_START SMS_80266F0
+SMS_80266F0: @ 0x080266F0
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	adds r7, r0, #0
+	mov r8, r1
+	ldr r1, _0802672C  @ gUnknown_0859B66C
+	mov r2, r8
+	lsls r0, r2, #2
+	adds r0, r0, r1
+	ldr r6, [r0]
+	ldr r5, _08026730  @ gUnknown_088AF880
+	movs r4, #0x7f
+	ands r4, r7
+	lsls r4, r4, #3
+	adds r0, r5, #4
+	adds r0, r4, r0
+	ldr r0, [r0]
+	ldr r1, _08026734  @ gUnknown_0859B668
+	ldr r1, [r1]
+	bl CopyDataWithPossibleUncomp
+	adds r4, r4, r5
+	ldrh r0, [r4, #2]
+	cmp r0, #1
+	beq _08026748
+	cmp r0, #1
+	bgt _08026738
+	cmp r0, #0
+	beq _0802673E
+	b _08026766
+	.align 2, 0
+_0802672C: .4byte gUnknown_0859B66C
+_08026730: .4byte gUnknown_088AF880
+_08026734: .4byte gUnknown_0859B668
+_08026738:
+	cmp r0, #2
+	beq _08026752
+	b _08026766
+_0802673E:
+	adds r0, r6, #0
+	adds r1, r7, #0
+	bl SomethingSMS_16x16
+	b _0802675A
+_08026748:
+	adds r0, r6, #0
+	adds r1, r7, #0
+	bl SomethingSMS_16x32
+	b _0802675A
+_08026752:
+	adds r0, r6, #0
+	adds r1, r7, #0
+	bl SomethingSMS_32x32
+_0802675A:
+	ldr r2, _08026778  @ gUnknown_02033F40
+	add r2, r8
+	lsrs r1, r0, #0x1f
+	adds r0, r0, r1
+	asrs r0, r0, #1
+	strb r0, [r2]
+_08026766:
+	ldr r0, _08026778  @ gUnknown_02033F40
+	add r0, r8
+	ldrb r0, [r0]
+	lsls r0, r0, #1
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08026778: .4byte gUnknown_02033F40
+
+	THUMB_FUNC_START SMS_SomethingGmapUnit
+SMS_SomethingGmapUnit: @ 0x0802677C
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	adds r6, r0, #0
+	mov r8, r1
+	adds r7, r2, #0
+	ldr r5, _080267B0  @ gUnknown_088AF880
+	movs r4, #0x7f
+	ands r4, r6
+	lsls r4, r4, #3
+	adds r0, r5, #4
+	adds r0, r4, r0
+	ldr r0, [r0]
+	ldr r1, _080267B4  @ gUnknown_0859B668
+	ldr r1, [r1]
+	bl CopyDataWithPossibleUncomp
+	adds r4, r4, r5
+	ldrh r0, [r4, #2]
+	cmp r0, #1
+	beq _080267C8
+	cmp r0, #1
+	bgt _080267B8
+	cmp r0, #0
+	beq _080267BE
+	b _080267E6
+	.align 2, 0
+_080267B0: .4byte gUnknown_088AF880
+_080267B4: .4byte gUnknown_0859B668
+_080267B8:
+	cmp r0, #2
+	beq _080267D2
+	b _080267E6
+_080267BE:
+	adds r0, r7, #0
+	adds r1, r6, #0
+	bl SomethingSMS_16x16
+	b _080267DA
+_080267C8:
+	adds r0, r7, #0
+	adds r1, r6, #0
+	bl SomethingSMS_16x32
+	b _080267DA
+_080267D2:
+	adds r0, r7, #0
+	adds r1, r6, #0
+	bl SomethingSMS_32x32
+_080267DA:
+	ldr r2, _080267F8  @ gUnknown_02033F40
+	add r2, r8
+	lsrs r1, r0, #0x1f
+	adds r0, r0, r1
+	asrs r0, r0, #1
+	strb r0, [r2]
+_080267E6:
+	ldr r0, _080267F8  @ gUnknown_02033F40
+	add r0, r8
+	ldrb r0, [r0]
+	lsls r0, r0, #1
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080267F8: .4byte gUnknown_02033F40
+
+	THUMB_FUNC_START SMS_RegisterUsage
+SMS_RegisterUsage: @ 0x080267FC
+	push {r4, r5, r6, r7, lr}
+	adds r6, r0, #0
+	ldr r0, _08026834  @ gUnknown_02033F40
+	adds r7, r6, r0
+	ldrb r1, [r7]
+	cmp r1, #0xff
+	bne _080268B0
+	ldr r5, _08026838  @ gUnknown_088AF880
+	movs r4, #0x7f
+	ands r4, r6
+	lsls r4, r4, #3
+	adds r0, r5, #4
+	adds r0, r4, r0
+	ldr r0, [r0]
+	ldr r1, _0802683C  @ gUnknown_0859B668
+	ldr r1, [r1]
+	bl CopyDataWithPossibleUncomp
+	adds r4, r4, r5
+	ldrh r0, [r4, #2]
+	cmp r0, #1
+	beq _08026864
+	cmp r0, #1
+	bgt _08026840
+	cmp r0, #0
+	beq _08026846
+	b _080268A6
+	.align 2, 0
+_08026834: .4byte gUnknown_02033F40
+_08026838: .4byte gUnknown_088AF880
+_0802683C: .4byte gUnknown_0859B668
+_08026840:
+	cmp r0, #2
+	beq _08026880
+	b _080268A6
+_08026846:
+	ldr r4, _08026860  @ gUnknown_0203A010
+	ldr r0, [r4]
+	adds r1, r6, #0
+	bl SomethingSMS_16x16_0
+	lsrs r1, r0, #0x1f
+	adds r0, r0, r1
+	asrs r0, r0, #1
+	strb r0, [r7]
+	ldr r0, [r4]
+	subs r0, #1
+	b _080268A4
+	.align 2, 0
+_08026860: .4byte gUnknown_0203A010
+_08026864:
+	ldr r4, _0802687C  @ gUnknown_0203A014
+	ldr r0, [r4]
+	adds r1, r6, #0
+	bl SomethingSMS_16x32
+	lsrs r1, r0, #0x1f
+	adds r0, r0, r1
+	asrs r0, r0, #1
+	strb r0, [r7]
+	ldr r0, [r4]
+	adds r0, #2
+	b _080268A4
+	.align 2, 0
+_0802687C: .4byte gUnknown_0203A014
+_08026880:
+	ldr r4, _080268BC  @ gUnknown_0203A014
+	ldr r1, [r4]
+	movs r0, #0x1e
+	ands r0, r1
+	cmp r0, #0x1e
+	bne _08026890
+	adds r0, r1, #2
+	str r0, [r4]
+_08026890:
+	ldr r0, [r4]
+	adds r1, r6, #0
+	bl SomethingSMS_32x32
+	lsrs r1, r0, #0x1f
+	adds r0, r0, r1
+	asrs r0, r0, #1
+	strb r0, [r7]
+	ldr r0, [r4]
+	adds r0, #4
+_080268A4:
+	str r0, [r4]
+_080268A6:
+	ldr r1, _080268C0  @ gUnknown_0203A4CC
+	ldr r0, [r1]
+	adds r0, #1
+	str r0, [r1]
+	ldr r0, _080268C4  @ gUnknown_02033F40
+_080268B0:
+	adds r0, r6, r0
+	ldrb r0, [r0]
+	lsls r0, r0, #1
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_080268BC: .4byte gUnknown_0203A014
+_080268C0: .4byte gUnknown_0203A4CC
+_080268C4: .4byte gUnknown_02033F40
+
+	THUMB_FUNC_START SomethingSMS_16x16_0
+SomethingSMS_16x16_0: @ 0x080268C8
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #4
+	str r0, [sp]
+	adds r2, r1, #0
+	ldr r1, _08026950  @ gUnknown_0859B67C
+	lsls r0, r0, #1
+	adds r0, r0, r1
+	ldrh r0, [r0]
+	lsls r0, r0, #5
+	mov r9, r0
+	lsrs r0, r2, #7
+	movs r1, #1
+	bics r1, r0
+	movs r6, #0
+	ldr r0, _08026954  @ gUnknown_0859B668
+	mov sl, r0
+	movs r0, #0x80
+	lsls r0, r0, #3
+	add r0, r9
+	ldr r2, _08026958  @ gUnknown_02034010
+	adds r4, r0, r2
+	movs r3, #0x40
+	mov r8, r3
+	movs r7, #0
+	lsls r5, r1, #7
+_08026902:
+	mov r1, sl
+	ldr r0, [r1]
+	adds r0, r0, r7
+	lsls r1, r6, #0xd
+	ldr r2, _08026958  @ gUnknown_02034010
+	add r2, r9
+	adds r1, r1, r2
+	movs r2, #0x10
+	bl CpuFastSet
+	mov r2, sl
+	ldr r0, [r2]
+	add r0, r8
+	adds r1, r4, #0
+	movs r2, #0x10
+	bl CpuFastSet
+	movs r3, #0x80
+	lsls r3, r3, #6
+	adds r4, r4, r3
+	add r8, r5
+	adds r7, r7, r5
+	adds r6, #1
+	cmp r6, #2
+	ble _08026902
+	ldr r0, _08026950  @ gUnknown_0859B67C
+	ldr r2, [sp]
+	lsls r1, r2, #1
+	adds r1, r1, r0
+	ldrh r0, [r1]
+	add sp, #4
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08026950: .4byte gUnknown_0859B67C
+_08026954: .4byte gUnknown_0859B668
+_08026958: .4byte gUnknown_02034010
+
+	THUMB_FUNC_START SomethingSMS_16x16
+SomethingSMS_16x16: @ 0x0802695C
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #0x14
+	str r0, [sp, #8]
+	mov r9, r1
+	ldr r1, _08026A28  @ gUnknown_0859B67C
+	lsls r0, r0, #1
+	adds r0, r0, r1
+	ldrh r0, [r0]
+	lsls r5, r0, #5
+	mov r1, r9
+	lsrs r0, r1, #7
+	movs r2, #1
+	mov r9, r2
+	mov r1, r9
+	bics r1, r0
+	mov r9, r1
+	movs r7, #0
+	mov r2, sp
+	adds r2, #4
+	str r2, [sp, #0xc]
+	ldr r0, _08026A2C  @ gUnknown_02034010
+	mov r8, r0
+	movs r1, #0xc0
+	lsls r1, r1, #4
+	adds r0, r5, r1
+	mov r2, r8
+	adds r6, r0, r2
+	movs r0, #0x40
+	str r0, [sp, #0x10]
+	movs r1, #0
+	mov sl, r1
+_080269A2:
+	movs r2, #0
+	str r2, [sp]
+	lsls r4, r7, #0xd
+	mov r0, r8
+	adds r1, r5, r0
+	adds r1, r4, r1
+	mov r0, sp
+	ldr r2, _08026A30  @ 0x01000010
+	bl CpuFastSet
+	movs r1, #0
+	str r1, [sp, #4]
+	movs r1, #0x80
+	lsls r1, r1, #3
+	add r1, r8
+	adds r1, r4, r1
+	adds r1, r1, r5
+	ldr r0, [sp, #0xc]
+	ldr r2, _08026A30  @ 0x01000010
+	bl CpuFastSet
+	ldr r2, _08026A34  @ gUnknown_0859B668
+	ldr r0, [r2]
+	add r0, sl
+	movs r1, #0x80
+	lsls r1, r1, #4
+	add r1, r8
+	adds r4, r4, r1
+	adds r4, r4, r5
+	adds r1, r4, #0
+	movs r2, #0x10
+	bl CpuFastSet
+	ldr r1, _08026A34  @ gUnknown_0859B668
+	ldr r0, [r1]
+	ldr r2, [sp, #0x10]
+	adds r0, r0, r2
+	adds r1, r6, #0
+	movs r2, #0x10
+	bl CpuFastSet
+	movs r0, #0x80
+	lsls r0, r0, #6
+	adds r6, r6, r0
+	mov r1, r9
+	lsls r0, r1, #7
+	ldr r2, [sp, #0x10]
+	adds r2, r2, r0
+	str r2, [sp, #0x10]
+	add sl, r0
+	adds r7, #1
+	cmp r7, #2
+	ble _080269A2
+	ldr r0, _08026A28  @ gUnknown_0859B67C
+	ldr r2, [sp, #8]
+	lsls r1, r2, #1
+	adds r1, r1, r0
+	ldrh r0, [r1]
+	add sp, #0x14
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08026A28: .4byte gUnknown_0859B67C
+_08026A2C: .4byte gUnknown_02034010
+_08026A30: .4byte 0x01000010
+_08026A34: .4byte gUnknown_0859B668
+
+	THUMB_FUNC_START SomethingSMS_16x32
+SomethingSMS_16x32: @ 0x08026A38
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #0x14
+	str r0, [sp]
+	adds r2, r1, #0
+	ldr r1, _08026B1C  @ gUnknown_0859B67C
+	lsls r0, r0, #1
+	adds r0, r0, r1
+	ldrh r0, [r0]
+	lsls r6, r0, #5
+	lsrs r0, r2, #7
+	movs r1, #1
+	bics r1, r0
+	movs r0, #0
+	mov r9, r0
+	ldr r2, _08026B20  @ gUnknown_0859B668
+	mov r8, r2
+	ldr r3, _08026B24  @ gUnknown_02034010
+	mov sl, r3
+	movs r2, #0xc0
+	lsls r2, r2, #4
+	adds r0, r6, r2
+	adds r7, r0, r3
+	movs r3, #0xc0
+	str r3, [sp, #4]
+	movs r0, #0x80
+	str r0, [sp, #8]
+	movs r2, #0x40
+	str r2, [sp, #0xc]
+	movs r3, #0
+	str r3, [sp, #0x10]
+	lsls r5, r1, #8
+_08026A7E:
+	mov r1, r8
+	ldr r0, [r1]
+	ldr r2, [sp, #0x10]
+	adds r0, r0, r2
+	mov r3, r9
+	lsls r4, r3, #0xd
+	mov r2, sl
+	adds r1, r6, r2
+	adds r1, r4, r1
+	movs r2, #0x10
+	bl CpuFastSet
+	mov r3, r8
+	ldr r0, [r3]
+	ldr r1, [sp, #0xc]
+	adds r0, r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #3
+	add r1, sl
+	adds r1, r4, r1
+	adds r1, r1, r6
+	movs r2, #0x10
+	bl CpuFastSet
+	mov r2, r8
+	ldr r0, [r2]
+	ldr r3, [sp, #8]
+	adds r0, r0, r3
+	movs r1, #0x80
+	lsls r1, r1, #4
+	add r1, sl
+	adds r4, r4, r1
+	adds r4, r4, r6
+	adds r1, r4, #0
+	movs r2, #0x10
+	bl CpuFastSet
+	mov r1, r8
+	ldr r0, [r1]
+	ldr r2, [sp, #4]
+	adds r0, r0, r2
+	adds r1, r7, #0
+	movs r2, #0x10
+	bl CpuFastSet
+	movs r3, #0x80
+	lsls r3, r3, #6
+	adds r7, r7, r3
+	ldr r0, [sp, #4]
+	adds r0, r0, r5
+	str r0, [sp, #4]
+	ldr r1, [sp, #8]
+	adds r1, r1, r5
+	str r1, [sp, #8]
+	ldr r2, [sp, #0xc]
+	adds r2, r2, r5
+	str r2, [sp, #0xc]
+	ldr r3, [sp, #0x10]
+	adds r3, r3, r5
+	str r3, [sp, #0x10]
+	movs r0, #1
+	add r9, r0
+	mov r1, r9
+	cmp r1, #2
+	ble _08026A7E
+	ldr r0, _08026B1C  @ gUnknown_0859B67C
+	ldr r2, [sp]
+	lsls r1, r2, #1
+	adds r1, r1, r0
+	ldrh r0, [r1]
+	add sp, #0x14
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08026B1C: .4byte gUnknown_0859B67C
+_08026B20: .4byte gUnknown_0859B668
+_08026B24: .4byte gUnknown_02034010
+
+	THUMB_FUNC_START SomethingSMS_32x32
+SomethingSMS_32x32: @ 0x08026B28
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #0x14
+	str r0, [sp]
+	adds r2, r1, #0
+	ldr r1, _08026C10  @ gUnknown_0859B67C
+	lsls r0, r0, #1
+	adds r0, r0, r1
+	ldrh r0, [r0]
+	lsls r6, r0, #5
+	lsrs r0, r2, #7
+	movs r1, #1
+	bics r1, r0
+	movs r0, #0
+	mov r9, r0
+	ldr r2, _08026C14  @ gUnknown_0859B668
+	mov r8, r2
+	ldr r3, _08026C18  @ gUnknown_02034010
+	mov sl, r3
+	movs r2, #0xc0
+	lsls r2, r2, #4
+	adds r0, r6, r2
+	adds r7, r0, r3
+	movs r3, #0xc0
+	lsls r3, r3, #1
+	str r3, [sp, #4]
+	movs r0, #0x80
+	lsls r0, r0, #1
+	str r0, [sp, #8]
+	movs r2, #0x80
+	str r2, [sp, #0xc]
+	movs r3, #0
+	str r3, [sp, #0x10]
+	lsls r5, r1, #9
+_08026B72:
+	mov r1, r8
+	ldr r0, [r1]
+	ldr r2, [sp, #0x10]
+	adds r0, r0, r2
+	mov r3, r9
+	lsls r4, r3, #0xd
+	mov r2, sl
+	adds r1, r6, r2
+	adds r1, r4, r1
+	movs r2, #0x20
+	bl CpuFastSet
+	mov r3, r8
+	ldr r0, [r3]
+	ldr r1, [sp, #0xc]
+	adds r0, r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #3
+	add r1, sl
+	adds r1, r4, r1
+	adds r1, r1, r6
+	movs r2, #0x20
+	bl CpuFastSet
+	mov r2, r8
+	ldr r0, [r2]
+	ldr r3, [sp, #8]
+	adds r0, r0, r3
+	movs r1, #0x80
+	lsls r1, r1, #4
+	add r1, sl
+	adds r4, r4, r1
+	adds r4, r4, r6
+	adds r1, r4, #0
+	movs r2, #0x20
+	bl CpuFastSet
+	mov r1, r8
+	ldr r0, [r1]
+	ldr r2, [sp, #4]
+	adds r0, r0, r2
+	adds r1, r7, #0
+	movs r2, #0x20
+	bl CpuFastSet
+	movs r3, #0x80
+	lsls r3, r3, #6
+	adds r7, r7, r3
+	ldr r0, [sp, #4]
+	adds r0, r0, r5
+	str r0, [sp, #4]
+	ldr r1, [sp, #8]
+	adds r1, r1, r5
+	str r1, [sp, #8]
+	ldr r2, [sp, #0xc]
+	adds r2, r2, r5
+	str r2, [sp, #0xc]
+	ldr r3, [sp, #0x10]
+	adds r3, r3, r5
+	str r3, [sp, #0x10]
+	movs r0, #1
+	add r9, r0
+	mov r1, r9
+	cmp r1, #2
+	ble _08026B72
+	ldr r0, _08026C10  @ gUnknown_0859B67C
+	ldr r2, [sp]
+	lsls r1, r2, #1
+	adds r1, r1, r0
+	ldrh r0, [r1]
+	add sp, #0x14
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08026C10: .4byte gUnknown_0859B67C
+_08026C14: .4byte gUnknown_0859B668
+_08026C18: .4byte gUnknown_02034010
+
+	THUMB_FUNC_START sub_8026C1C
+sub_8026C1C: @ 0x08026C1C
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #0xc
+	str r1, [sp]
+	bl GetUnitSMSIndex
+	str r0, [sp, #4]
+	bl SMS_RegisterUsage
+	lsls r7, r0, #5
+	ldr r1, _08026C84  @ gUnknown_0859B73C
+	ldr r2, [sp]
+	lsls r0, r2, #1
+	adds r0, r0, r1
+	ldrh r6, [r0]
+	movs r4, #0
+	bl GetGameClock
+	movs r1, #0x48
+	bl __umodsi3
+	adds r1, r0, #0
+	cmp r1, #0x43
+	ble _08026C54
+	movs r4, #1
+_08026C54:
+	cmp r1, #0x23
+	ble _08026C5A
+	movs r4, #2
+_08026C5A:
+	cmp r1, #0x1f
+	ble _08026C60
+	movs r4, #1
+_08026C60:
+	cmp r1, #0
+	blt _08026C66
+	movs r4, #0
+_08026C66:
+	ldr r1, _08026C88  @ gUnknown_088AF880
+	movs r0, #0x7f
+	ldr r2, [sp, #4]
+	ands r0, r2
+	lsls r0, r0, #3
+	adds r0, r0, r1
+	ldrh r0, [r0, #2]
+	cmp r0, #1
+	beq _08026D18
+	cmp r0, #1
+	bgt _08026C8C
+	cmp r0, #0
+	beq _08026C94
+	b _08026EF2
+	.align 2, 0
+_08026C84: .4byte gUnknown_0859B73C
+_08026C88: .4byte gUnknown_088AF880
+_08026C8C:
+	cmp r0, #2
+	bne _08026C92
+	b _08026E10
+_08026C92:
+	b _08026EF2
+_08026C94:
+	movs r1, #0
+	lsls r4, r4, #0xd
+	str r4, [sp, #8]
+	ldr r0, _08026D0C  @ gUnknown_02034010
+	mov r8, r0
+	lsrs r5, r6, #1
+	movs r0, #1
+	bics r0, r6
+	lsls r0, r0, #2
+	movs r4, #0xf
+	lsls r4, r0
+_08026CAA:
+	movs r6, #0
+	lsls r2, r1, #0xd
+	adds r1, #1
+	mov r9, r1
+	adds r0, r7, r5
+	adds r0, r0, r2
+	mov r1, r8
+	adds r3, r0, r1
+	movs r1, #0x80
+	lsls r1, r1, #3
+	adds r0, r5, r1
+	adds r0, r7, r0
+	adds r0, r0, r2
+	mov r1, r8
+	adds r2, r0, r1
+_08026CC8:
+	ldrb r1, [r3]
+	adds r0, r4, #0
+	ands r0, r1
+	strb r0, [r3]
+	ldrb r1, [r2]
+	adds r0, r4, #0
+	ands r0, r1
+	strb r0, [r2]
+	adds r3, #0x20
+	adds r2, #0x20
+	adds r6, #1
+	cmp r6, #1
+	ble _08026CC8
+	mov r1, r9
+	cmp r1, #2
+	ble _08026CAA
+	ldr r2, _08026D0C  @ gUnknown_02034010
+	adds r0, r7, r2
+	ldr r1, [sp, #8]
+	adds r0, r1, r0
+	ldr r2, _08026D10  @ 0x06011000
+	adds r1, r7, r2
+	movs r2, #0x10
+	bl CpuFastSet
+	ldr r1, _08026D0C  @ gUnknown_02034010
+	movs r2, #0x80
+	lsls r2, r2, #3
+	adds r0, r1, r2
+	ldr r1, [sp, #8]
+	adds r0, r1, r0
+	adds r0, r0, r7
+	ldr r2, _08026D14  @ 0x06011400
+	b _08026DF2
+	.align 2, 0
+_08026D0C: .4byte gUnknown_02034010
+_08026D10: .4byte 0x06011000
+_08026D14: .4byte 0x06011400
+_08026D18:
+	movs r1, #0
+	lsls r4, r4, #0xd
+	str r4, [sp, #8]
+	ldr r2, _08026DFC  @ gUnknown_02034010
+	mov sl, r2
+	lsrs r2, r6, #1
+	mov ip, r2
+	bics r0, r6
+	lsls r0, r0, #2
+	movs r2, #0xf
+	mov r8, r2
+	lsls r2, r0
+	mov r8, r2
+_08026D32:
+	movs r6, #0
+	lsls r2, r1, #0xd
+	adds r1, #1
+	mov r9, r1
+	adds r5, r2, #0
+	mov r1, ip
+	adds r0, r7, r1
+	adds r0, r0, r5
+	mov r2, sl
+	adds r4, r0, r2
+_08026D46:
+	lsls r2, r6, #5
+	ldrb r1, [r4]
+	mov r0, r8
+	ands r0, r1
+	strb r0, [r4]
+	movs r1, #0x80
+	lsls r1, r1, #3
+	adds r0, r2, r1
+	adds r0, r7, r0
+	add r0, ip
+	adds r0, r0, r5
+	add r0, sl
+	ldrb r3, [r0]
+	mov r1, r8
+	ands r1, r3
+	strb r1, [r0]
+	movs r1, #0x80
+	lsls r1, r1, #4
+	adds r0, r2, r1
+	adds r0, r7, r0
+	add r0, ip
+	adds r0, r0, r5
+	add r0, sl
+	ldrb r3, [r0]
+	mov r1, r8
+	ands r1, r3
+	strb r1, [r0]
+	movs r0, #0xc0
+	lsls r0, r0, #4
+	adds r2, r2, r0
+	adds r2, r7, r2
+	add r2, ip
+	adds r2, r2, r5
+	add r2, sl
+	ldrb r1, [r2]
+	mov r0, r8
+	ands r0, r1
+	strb r0, [r2]
+	adds r4, #0x20
+	adds r6, #1
+	cmp r6, #1
+	ble _08026D46
+	mov r1, r9
+	cmp r1, #2
+	ble _08026D32
+	ldr r1, _08026DFC  @ gUnknown_02034010
+	adds r0, r7, r1
+	ldr r2, [sp, #8]
+	adds r0, r2, r0
+	ldr r2, _08026E00  @ 0x06011000
+	adds r1, r7, r2
+	movs r2, #0x10
+	bl CpuFastSet
+	ldr r1, _08026DFC  @ gUnknown_02034010
+	movs r2, #0x80
+	lsls r2, r2, #3
+	adds r0, r1, r2
+	ldr r1, [sp, #8]
+	adds r0, r1, r0
+	adds r0, r0, r7
+	ldr r2, _08026E04  @ 0x06011400
+	adds r1, r7, r2
+	movs r2, #0x10
+	bl CpuFastSet
+	ldr r1, _08026DFC  @ gUnknown_02034010
+	movs r2, #0x80
+	lsls r2, r2, #4
+	adds r0, r1, r2
+	ldr r1, [sp, #8]
+	adds r0, r1, r0
+	adds r0, r0, r7
+	ldr r2, _08026E08  @ 0x06011800
+	adds r1, r7, r2
+	movs r2, #0x10
+	bl CpuFastSet
+	ldr r1, _08026DFC  @ gUnknown_02034010
+	movs r2, #0xc0
+	lsls r2, r2, #4
+	adds r0, r1, r2
+	ldr r1, [sp, #8]
+	adds r0, r1, r0
+	adds r0, r0, r7
+	ldr r2, _08026E0C  @ 0x06011C00
+_08026DF2:
+	adds r1, r7, r2
+	movs r2, #0x10
+	bl CpuFastSet
+	b _08026EF2
+	.align 2, 0
+_08026DFC: .4byte gUnknown_02034010
+_08026E00: .4byte 0x06011000
+_08026E04: .4byte 0x06011400
+_08026E08: .4byte 0x06011800
+_08026E0C: .4byte 0x06011C00
+_08026E10:
+	movs r1, #0
+	lsls r4, r4, #0xd
+	str r4, [sp, #8]
+	ldr r0, _08026F14  @ gUnknown_02034010
+	mov sl, r0
+	lsrs r2, r6, #1
+	mov ip, r2
+	movs r0, #1
+	bics r0, r6
+	lsls r0, r0, #2
+	movs r2, #0xf
+	mov r8, r2
+	lsls r2, r0
+	mov r8, r2
+_08026E2C:
+	movs r6, #0
+	adds r0, r1, #1
+	mov r9, r0
+	lsls r5, r1, #0xd
+	mov r1, ip
+	adds r0, r7, r1
+	adds r0, r0, r5
+	mov r2, sl
+	adds r4, r0, r2
+_08026E3E:
+	lsls r2, r6, #5
+	ldrb r1, [r4]
+	mov r0, r8
+	ands r0, r1
+	strb r0, [r4]
+	movs r1, #0x80
+	lsls r1, r1, #3
+	adds r0, r2, r1
+	adds r0, r7, r0
+	add r0, ip
+	adds r0, r0, r5
+	add r0, sl
+	ldrb r3, [r0]
+	mov r1, r8
+	ands r1, r3
+	strb r1, [r0]
+	movs r1, #0x80
+	lsls r1, r1, #4
+	adds r0, r2, r1
+	adds r0, r7, r0
+	add r0, ip
+	adds r0, r0, r5
+	add r0, sl
+	ldrb r3, [r0]
+	mov r1, r8
+	ands r1, r3
+	strb r1, [r0]
+	movs r0, #0xc0
+	lsls r0, r0, #4
+	adds r2, r2, r0
+	adds r2, r7, r2
+	add r2, ip
+	adds r2, r2, r5
+	add r2, sl
+	ldrb r1, [r2]
+	mov r0, r8
+	ands r0, r1
+	strb r0, [r2]
+	adds r4, #0x20
+	adds r6, #1
+	cmp r6, #3
+	ble _08026E3E
+	mov r1, r9
+	cmp r1, #2
+	ble _08026E2C
+	ldr r1, _08026F14  @ gUnknown_02034010
+	adds r0, r7, r1
+	ldr r2, [sp, #8]
+	adds r0, r2, r0
+	ldr r2, _08026F18  @ 0x06011000
+	adds r1, r7, r2
+	movs r2, #0x20
+	bl CpuFastSet
+	ldr r1, _08026F14  @ gUnknown_02034010
+	movs r2, #0x80
+	lsls r2, r2, #3
+	adds r0, r1, r2
+	ldr r1, [sp, #8]
+	adds r0, r1, r0
+	adds r0, r0, r7
+	ldr r2, _08026F1C  @ 0x06011400
+	adds r1, r7, r2
+	movs r2, #0x20
+	bl CpuFastSet
+	ldr r1, _08026F14  @ gUnknown_02034010
+	movs r2, #0x80
+	lsls r2, r2, #4
+	adds r0, r1, r2
+	ldr r1, [sp, #8]
+	adds r0, r1, r0
+	adds r0, r0, r7
+	ldr r2, _08026F20  @ 0x06011800
+	adds r1, r7, r2
+	movs r2, #0x20
+	bl CpuFastSet
+	ldr r1, _08026F14  @ gUnknown_02034010
+	movs r2, #0xc0
+	lsls r2, r2, #4
+	adds r0, r1, r2
+	ldr r1, [sp, #8]
+	adds r0, r1, r0
+	adds r0, r0, r7
+	ldr r2, _08026F24  @ 0x06011C00
+	adds r1, r7, r2
+	movs r2, #0x20
+	bl CpuFastSet
+_08026EF2:
+	ldr r0, [sp]
+	cmp r0, #0x3f
+	bne _08026F02
+	ldr r0, _08026F28  @ gUnknown_02033F40
+	ldr r1, [sp, #4]
+	adds r0, r1, r0
+	movs r1, #0xff
+	strb r1, [r0]
+_08026F02:
+	add sp, #0xc
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026F14: .4byte gUnknown_02034010
+_08026F18: .4byte 0x06011000
+_08026F1C: .4byte 0x06011400
+_08026F20: .4byte 0x06011800
+_08026F24: .4byte 0x06011C00
+_08026F28: .4byte gUnknown_02033F40
+
+	THUMB_FUNC_START SMS_FlushDirect
+SMS_FlushDirect: @ 0x08026F2C
+	push {r4, r5, lr}
+	bl GetGameClock
+	movs r1, #0x48
+	bl __umodsi3
+	adds r4, r0, #0
+	adds r5, r4, #0
+	cmp r4, #0
+	bne _08026F4C
+	ldr r0, _08026F84  @ gUnknown_02034010
+	ldr r1, _08026F88  @ 0x06011000
+	movs r2, #0x80
+	lsls r2, r2, #4
+	bl CpuFastSet
+_08026F4C:
+	cmp r4, #0x20
+	bne _08026F5C
+	ldr r0, _08026F8C  @ gUnknown_02036010
+	ldr r1, _08026F88  @ 0x06011000
+	movs r2, #0x80
+	lsls r2, r2, #4
+	bl CpuFastSet
+_08026F5C:
+	cmp r4, #0x24
+	bne _08026F6C
+	ldr r0, _08026F90  @ gUnknown_02038010
+	ldr r1, _08026F88  @ 0x06011000
+	movs r2, #0x80
+	lsls r2, r2, #4
+	bl CpuFastSet
+_08026F6C:
+	cmp r5, #0x44
+	bne _08026F7C
+	ldr r0, _08026F8C  @ gUnknown_02036010
+	ldr r1, _08026F88  @ 0x06011000
+	movs r2, #0x80
+	lsls r2, r2, #4
+	bl CpuFastSet
+_08026F7C:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026F84: .4byte gUnknown_02034010
+_08026F88: .4byte 0x06011000
+_08026F8C: .4byte gUnknown_02036010
+_08026F90: .4byte gUnknown_02038010
+
+	THUMB_FUNC_START SMS_FlushIndirect
+SMS_FlushIndirect: @ 0x08026F94
+	push {lr}
+	ldr r0, _08026FB4  @ gUnknown_0203A4CC
+	movs r1, #0
+	str r1, [r0]
+	bl GetGameClock
+	movs r1, #0x48
+	bl __umodsi3
+	adds r1, r0, #0
+	cmp r0, #0x43
+	bgt _08026FC0
+	cmp r0, #0x23
+	ble _08026FBC
+	ldr r0, _08026FB8  @ gUnknown_02038010
+	b _08026FC2
+	.align 2, 0
+_08026FB4: .4byte gUnknown_0203A4CC
+_08026FB8: .4byte gUnknown_02038010
+_08026FBC:
+	cmp r0, #0x1f
+	ble _08026FD8
+_08026FC0:
+	ldr r0, _08026FD0  @ gUnknown_02036010
+_08026FC2:
+	ldr r1, _08026FD4  @ 0x06011000
+	movs r2, #0x80
+	lsls r2, r2, #6
+	bl RegisterTileGraphics
+	b _08026FE8
+	.align 2, 0
+_08026FD0: .4byte gUnknown_02036010
+_08026FD4: .4byte 0x06011000
+_08026FD8:
+	cmp r1, #0
+	blt _08026FE8
+	ldr r0, _08026FEC  @ gUnknown_02034010
+	ldr r1, _08026FF0  @ 0x06011000
+	movs r2, #0x80
+	lsls r2, r2, #6
+	bl RegisterTileGraphics
+_08026FE8:
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08026FEC: .4byte gUnknown_02034010
+_08026FF0: .4byte 0x06011000
+
+	THUMB_FUNC_START sub_8026FF4
+sub_8026FF4: @ 0x08026FF4
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	bl GetGameClock
+	movs r1, #0x48
+	bl __umodsi3
+	adds r1, r0, #0
+	movs r2, #0
+	cmp r0, #0
+	bne _0802700E
+	ldr r2, _08027058  @ gUnknown_02034010
+_0802700E:
+	cmp r0, #0x20
+	bne _08027014
+	ldr r2, _0802705C  @ gUnknown_02036010
+_08027014:
+	cmp r0, #0x24
+	bne _0802701A
+	ldr r2, _08027060  @ gUnknown_02038010
+_0802701A:
+	cmp r1, #0x44
+	bne _08027020
+	ldr r2, _0802705C  @ gUnknown_02036010
+_08027020:
+	cmp r2, #0
+	beq _08027050
+	ldr r1, _08027064  @ gUnknown_0859B66C
+	lsls r0, r4, #2
+	adds r0, r0, r1
+	ldr r0, [r0]
+	lsls r0, r0, #5
+	adds r1, r5, #0
+	adds r1, #0x20
+	adds r5, r0, r1
+	adds r4, r0, r2
+	movs r6, #3
+_08027038:
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #0x10
+	bl CpuFastSet
+	movs r0, #0x80
+	lsls r0, r0, #3
+	adds r5, r5, r0
+	adds r4, r4, r0
+	subs r6, #1
+	cmp r6, #0
+	bge _08027038
+_08027050:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08027058: .4byte gUnknown_02034010
+_0802705C: .4byte gUnknown_02036010
+_08027060: .4byte gUnknown_02038010
+_08027064: .4byte gUnknown_0859B66C
+
+	THUMB_FUNC_START sub_8027068
+sub_8027068: @ 0x08027068
+	push {r4, r5, r6, lr}
+	adds r4, r0, #0
+	adds r5, r1, #0
+	bl GetGameClock
+	movs r1, #0x48
+	bl __umodsi3
+	adds r1, r0, #0
+	movs r2, #0
+	cmp r0, #0x43
+	bgt _08027090
+	cmp r0, #0x23
+	ble _0802708C
+	ldr r2, _08027088  @ gUnknown_02038010
+	b _0802709E
+	.align 2, 0
+_08027088: .4byte gUnknown_02038010
+_0802708C:
+	cmp r0, #0x1f
+	ble _08027098
+_08027090:
+	ldr r2, _08027094  @ gUnknown_02036010
+	b _0802709E
+	.align 2, 0
+_08027094: .4byte gUnknown_02036010
+_08027098:
+	cmp r1, #0
+	blt _0802709E
+	ldr r2, _080270D4  @ gUnknown_02034010
+_0802709E:
+	cmp r2, #0
+	beq _080270CE
+	ldr r1, _080270D8  @ gUnknown_0859B66C
+	lsls r0, r4, #2
+	adds r0, r0, r1
+	ldr r0, [r0]
+	lsls r0, r0, #5
+	adds r1, r5, #0
+	adds r1, #0x20
+	adds r5, r0, r1
+	adds r4, r0, r2
+	movs r6, #3
+_080270B6:
+	adds r0, r4, #0
+	adds r1, r5, #0
+	movs r2, #0x40
+	bl RegisterTileGraphics
+	movs r0, #0x80
+	lsls r0, r0, #3
+	adds r5, r5, r0
+	adds r4, r4, r0
+	subs r6, #1
+	cmp r6, #0
+	bge _080270B6
+_080270CE:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080270D4: .4byte gUnknown_02034010
+_080270D8: .4byte gUnknown_0859B66C
+
+	THUMB_FUNC_START sub_80270DC
+sub_80270DC: @ 0x080270DC
+	push {r4, r5, r6, r7, lr}
+	adds r4, r0, #0
+	adds r7, r1, #0
+	bl GetGameClock
+	movs r1, #0x48
+	bl __umodsi3
+	adds r1, r0, #0
+	movs r5, #0
+	cmp r0, #0x43
+	bgt _08027104
+	cmp r0, #0x23
+	ble _08027100
+	ldr r5, _080270FC  @ gUnknown_02038010
+	b _08027112
+	.align 2, 0
+_080270FC: .4byte gUnknown_02038010
+_08027100:
+	cmp r0, #0x1f
+	ble _0802710C
+_08027104:
+	ldr r5, _08027108  @ gUnknown_02036010
+	b _08027112
+	.align 2, 0
+_08027108: .4byte gUnknown_02036010
+_0802710C:
+	cmp r1, #0
+	blt _08027112
+	ldr r5, _08027138  @ gUnknown_02034010
+_08027112:
+	cmp r5, #0
+	beq _08027130
+	lsls r4, r4, #5
+	movs r6, #3
+_0802711A:
+	adds r0, r5, r4
+	adds r1, r7, r4
+	movs r2, #0x80
+	bl RegisterTileGraphics
+	movs r0, #0x80
+	lsls r0, r0, #3
+	adds r4, r4, r0
+	subs r6, #1
+	cmp r6, #0
+	bge _0802711A
+_08027130:
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08027138: .4byte gUnknown_02034010
+
+	THUMB_FUNC_START GetUnitSpritePaletteIndexWrapper
+GetUnitSpritePaletteIndexWrapper: @ 0x0802713C
+	push {lr}
+	adds r2, r0, #0
+	ldr r1, [r2, #0xc]
+	movs r0, #0x80
+	lsls r0, r0, #0x14
+	ands r0, r1
+	cmp r0, #0
+	beq _08027150
+	movs r0, #0xb
+	b _08027162
+_08027150:
+	movs r0, #2
+	ands r1, r0
+	cmp r1, #0
+	bne _08027160
+	adds r0, r2, #0
+	bl GetUnitMapSpritePaletteIndex
+	b _08027162
+_08027160:
+	movs r0, #0xf
+_08027162:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START GetUnitMapSpritePaletteIndex
+GetUnitMapSpritePaletteIndex: @ 0x08027168
+	push {lr}
+	adds r1, r0, #0
+	movs r2, #0xb
+	ldrsb r2, [r1, r2]
+	movs r1, #0xc0
+	ands r2, r1
+	cmp r2, #0x40
+	beq _08027194
+	cmp r2, #0x40
+	bgt _08027182
+	cmp r2, #0
+	beq _0802718C
+	b _0802719A
+_08027182:
+	cmp r2, #0x80
+	beq _08027190
+	cmp r2, #0xc0
+	beq _08027198
+	b _0802719A
+_0802718C:
+	movs r0, #0xc
+	b _0802719A
+_08027190:
+	movs r0, #0xd
+	b _0802719A
+_08027194:
+	movs r0, #0xe
+	b _0802719A
+_08027198:
+	movs r0, #0xb
+_0802719A:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START SMS_UpdateFromGameData
+SMS_UpdateFromGameData: @ 0x080271A0
+	push {r4, r5, r6, r7, lr}
+	mov r7, r9
+	mov r6, r8
+	push {r6, r7}
+	movs r0, #0
+	mov r8, r0
+	ldr r0, _080272C0  @ gUnknown_0203A4C8
+	ldr r1, _080272C4  @ gUnknown_0203A018
+	mov r2, r8
+	str r2, [r1]
+	movs r2, #0x80
+	lsls r2, r2, #3
+	strh r2, [r1, #6]
+	adds r1, #0xc
+	str r1, [r0]
+	movs r7, #1
+_080271C0:
+	adds r0, r7, #0
+	bl GetUnitStruct
+	adds r6, r0, #0
+	cmp r6, #0
+	beq _08027282
+	ldr r0, [r6]
+	cmp r0, #0
+	beq _08027282
+	movs r0, #0
+	str r0, [r6, #0x3c]
+	ldr r3, [r6, #0xc]
+	ldr r0, _080272C8  @ 0x00000201
+	ands r0, r3
+	cmp r0, #0
+	bne _08027282
+	movs r2, #0x11
+	ldrsb r2, [r6, r2]
+	ldr r0, _080272CC  @ gUnknown_0202E4D8
+	ldr r1, [r0]
+	lsls r0, r2, #2
+	adds r0, r0, r1
+	movs r1, #0x10
+	ldrsb r1, [r6, r1]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	cmp r0, #0
+	beq _08027282
+	adds r0, r6, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #0xb
+	beq _0802720C
+	cmp r1, #0xd
+	bne _08027212
+_0802720C:
+	movs r0, #2
+	orrs r3, r0
+	str r3, [r6, #0xc]
+_08027212:
+	lsls r0, r2, #4
+	bl SMS_GetNewInfoStruct
+	adds r5, r0, #0
+	movs r0, #0x11
+	ldrsb r0, [r6, r0]
+	lsls r0, r0, #4
+	strh r0, [r5, #6]
+	movs r0, #0x10
+	ldrsb r0, [r6, r0]
+	lsls r0, r0, #4
+	strh r0, [r5, #4]
+	adds r0, r6, #0
+	bl GetUnitSMSIndex
+	bl SMS_RegisterUsage
+	adds r4, r0, #0
+	adds r0, r6, #0
+	bl GetUnitSpritePaletteIndexWrapper
+	adds r4, #0x80
+	movs r1, #0xf
+	ands r1, r0
+	lsls r1, r1, #0xc
+	adds r4, r4, r1
+	strh r4, [r5, #8]
+	adds r0, r6, #0
+	bl GetUnitSMSIndex
+	ldr r2, _080272D0  @ gUnknown_088AF880
+	movs r1, #0x7f
+	ands r1, r0
+	lsls r1, r1, #3
+	adds r1, r1, r2
+	ldrh r0, [r1, #2]
+	adds r2, r0, #0
+	strb r0, [r5, #0xb]
+	ldr r0, [r6, #0xc]
+	movs r1, #0x80
+	lsls r1, r1, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _0802726E
+	adds r0, r2, #3
+	strb r0, [r5, #0xb]
+_0802726E:
+	ldr r0, [r6, #0xc]
+	movs r1, #0x80
+	lsls r1, r1, #0x11
+	ands r0, r1
+	cmp r0, #0
+	beq _08027280
+	ldrb r0, [r5, #0xb]
+	adds r0, #0x40
+	strb r0, [r5, #0xb]
+_08027280:
+	str r5, [r6, #0x3c]
+_08027282:
+	adds r7, #1
+	cmp r7, #0xc5
+	ble _080271C0
+	movs r0, #0
+	bl GetTrap
+	adds r4, r0, #0
+	ldrb r0, [r4, #2]
+	cmp r0, #0
+	beq _0802734C
+	ldr r1, _080272D4  @ 0xFFFFC080
+	adds r6, r1, #0
+	ldr r7, _080272D8  @ gUnknown_088AFB5A
+	movs r2, #0x58
+	adds r2, r2, r7
+	mov r9, r2
+_080272A2:
+	cmp r0, #1
+	bne _08027316
+	movs r0, #5
+	ldrsb r0, [r4, r0]
+	cmp r0, #0
+	bne _08027316
+	ldrb r0, [r4, #3]
+	cmp r0, #0x36
+	beq _080272E6
+	cmp r0, #0x36
+	bgt _080272DC
+	cmp r0, #0x35
+	beq _080272E2
+	b _080272F8
+	.align 2, 0
+_080272C0: .4byte gUnknown_0203A4C8
+_080272C4: .4byte gUnknown_0203A018
+_080272C8: .4byte 0x00000201
+_080272CC: .4byte gUnknown_0202E4D8
+_080272D0: .4byte gUnknown_088AF880
+_080272D4: .4byte 0xFFFFC080
+_080272D8: .4byte gUnknown_088AFB5A
+_080272DC:
+	cmp r0, #0x37
+	beq _080272EA
+	b _080272F8
+_080272E2:
+	movs r0, #0x5b
+	b _080272EC
+_080272E6:
+	movs r0, #0x5c
+	b _080272EC
+_080272EA:
+	movs r0, #0x5d
+_080272EC:
+	bl SMS_RegisterUsage
+	adds r0, r0, r6
+	lsls r0, r0, #0x10
+	lsrs r0, r0, #0x10
+	mov r8, r0
+_080272F8:
+	ldrb r0, [r4, #1]
+	lsls r0, r0, #4
+	bl SMS_GetNewInfoStruct
+	adds r5, r0, #0
+	ldrb r0, [r4, #1]
+	lsls r0, r0, #4
+	strh r0, [r5, #6]
+	ldrb r0, [r4]
+	lsls r0, r0, #4
+	strh r0, [r5, #4]
+	mov r0, r8
+	strh r0, [r5, #8]
+	ldrh r0, [r7]
+	strb r0, [r5, #0xb]
+_08027316:
+	ldrb r0, [r4, #2]
+	cmp r0, #0xd
+	bne _08027344
+	ldrb r0, [r4, #1]
+	lsls r0, r0, #4
+	bl SMS_GetNewInfoStruct
+	adds r5, r0, #0
+	ldrb r0, [r4, #1]
+	lsls r0, r0, #4
+	strh r0, [r5, #6]
+	ldrb r0, [r4]
+	lsls r0, r0, #4
+	strh r0, [r5, #4]
+	movs r0, #0x66
+	bl SMS_RegisterUsage
+	ldr r1, _08027364  @ 0xFFFFB080
+	adds r0, r0, r1
+	strh r0, [r5, #8]
+	mov r2, r9
+	ldrh r0, [r2]
+	strb r0, [r5, #0xb]
+_08027344:
+	adds r4, #8
+	ldrb r0, [r4, #2]
+	cmp r0, #0
+	bne _080272A2
+_0802734C:
+	ldr r0, _08027368  @ gUnknown_0203A4CC
+	ldr r0, [r0]
+	cmp r0, #0
+	beq _08027358
+	bl SMS_FlushIndirect
+_08027358:
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08027364: .4byte 0xFFFFB080
+_08027368: .4byte gUnknown_0203A4CC
+
+	THUMB_FUNC_START SMS_GetNewInfoStruct
+SMS_GetNewInfoStruct: @ 0x0802736C
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	ldr r2, _08027388  @ gUnknown_0203A018
+	ldr r3, _0802738C  @ gUnknown_0203A4C8
+_08027374:
+	ldr r1, [r2]
+	cmp r1, #0
+	beq _08027390
+	movs r5, #6
+	ldrsh r0, [r1, r5]
+	cmp r0, r4
+	blt _08027390
+	adds r2, r1, #0
+	b _08027374
+	.align 2, 0
+_08027388: .4byte gUnknown_0203A018
+_0802738C: .4byte gUnknown_0203A4C8
+_08027390:
+	ldr r0, [r3]
+	str r1, [r0]
+	str r0, [r2]
+	adds r1, r0, #0
+	adds r1, #0xc
+	str r1, [r3]
+	pop {r4, r5}
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START SMS_DisplayAllFromInfoStructs
+SMS_DisplayAllFromInfoStructs: @ 0x080273A4
+	push {r4, r5, r6, lr}
+	ldr r0, _0802741C  @ gUnknown_0203A018
+	ldr r6, [r0]
+	bl DisplayUnitAdditionalBlinkingIcons
+	cmp r6, #0
+	bne _080273B4
+	b _08027526
+_080273B4:
+	movs r3, #0
+	movs r0, #4
+	ldrsh r1, [r6, r0]
+	ldr r2, _08027420  @ gUnknown_0202BCB0
+	movs r4, #0xc
+	ldrsh r0, [r2, r4]
+	subs r4, r1, r0
+	movs r5, #6
+	ldrsh r1, [r6, r5]
+	movs r5, #0xe
+	ldrsh r0, [r2, r5]
+	subs r5, r1, r0
+	adds r1, r4, #0
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	cmp r1, r0
+	bls _080273DA
+	b _0802751E
+_080273DA:
+	adds r0, r5, #0
+	adds r0, #0x20
+	cmp r0, #0xc0
+	bls _080273E4
+	b _0802751E
+_080273E4:
+	movs r0, #0xb
+	ldrsb r0, [r6, r0]
+	movs r1, #0x80
+	ands r0, r1
+	cmp r0, #0
+	beq _080273F2
+	b _0802751E
+_080273F2:
+	ldrb r1, [r6, #0xb]
+	movs r0, #0x40
+	ands r0, r1
+	cmp r0, #0
+	beq _08027406
+	bl GetGameClock
+	adds r3, r0, #0
+	movs r0, #2
+	ands r3, r0
+_08027406:
+	ldrb r0, [r6, #0xb]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #5
+	bls _08027412
+	b _0802751E
+_08027412:
+	lsls r0, r1, #2
+	ldr r1, _08027424  @ _08027428
+	adds r0, r0, r1
+	ldr r0, [r0]
+	mov pc, r0
+	.align 2, 0
+_0802741C: .4byte gUnknown_0203A018
+_08027420: .4byte gUnknown_0202BCB0
+_08027424: .4byte _08027428
+_08027428: @ jump table
+	.4byte _08027440 @ case 0
+	.4byte _08027464 @ case 1
+	.4byte _08027488 @ case 2
+	.4byte _080274B0 @ case 3
+	.4byte _080274D0 @ case 4
+	.4byte _080274F8 @ case 5
+_08027440:
+	adds r0, r4, r3
+	movs r1, #0x80
+	lsls r1, r1, #2
+	adds r0, r0, r1
+	subs r1, #1
+	ands r0, r1
+	movs r2, #0x80
+	lsls r2, r2, #1
+	adds r1, r5, r2
+	movs r2, #0xff
+	ands r1, r2
+	ldr r2, _08027460  @ gUnknown_08590F4C
+	ldrh r3, [r6, #8]
+	movs r4, #0x80
+	lsls r4, r4, #4
+	b _080274EC
+	.align 2, 0
+_08027460: .4byte gUnknown_08590F4C
+_08027464:
+	adds r0, r4, r3
+	movs r1, #0x80
+	lsls r1, r1, #2
+	adds r0, r0, r1
+	subs r1, #1
+	ands r0, r1
+	adds r1, r5, #0
+	adds r1, #0xf0
+	movs r2, #0xff
+	ands r1, r2
+	ldr r2, _08027484  @ gUnknown_08590F6C
+	ldrh r3, [r6, #8]
+	movs r4, #0x80
+	lsls r4, r4, #4
+	b _080274EC
+	.align 2, 0
+_08027484: .4byte gUnknown_08590F6C
+_08027488:
+	adds r0, r3, #0
+	subs r0, #8
+	adds r0, r4, r0
+	movs r1, #0x80
+	lsls r1, r1, #2
+	adds r0, r0, r1
+	subs r1, #1
+	ands r0, r1
+	adds r1, r5, #0
+	adds r1, #0xf0
+	movs r2, #0xff
+	ands r1, r2
+	ldr r2, _080274AC  @ gUnknown_08590F54
+	ldrh r3, [r6, #8]
+	movs r4, #0x80
+	lsls r4, r4, #4
+	b _080274EC
+	.align 2, 0
+_080274AC: .4byte gUnknown_08590F54
+_080274B0:
+	adds r0, r4, r3
+	movs r1, #0x80
+	lsls r1, r1, #2
+	adds r0, r0, r1
+	subs r1, #1
+	ands r0, r1
+	movs r2, #0x80
+	lsls r2, r2, #1
+	adds r1, r5, r2
+	movs r2, #0xff
+	ands r1, r2
+	ldr r2, _080274CC  @ gUnknown_08590F4C
+	b _080274E6
+	.align 2, 0
+_080274CC: .4byte gUnknown_08590F4C
+_080274D0:
+	adds r0, r4, r3
+	movs r1, #0x80
+	lsls r1, r1, #2
+	adds r0, r0, r1
+	subs r1, #1
+	ands r0, r1
+	adds r1, r5, #0
+	adds r1, #0xf0
+	movs r2, #0xff
+	ands r1, r2
+	ldr r2, _080274F4  @ gUnknown_08590F6C
+_080274E6:
+	ldrh r3, [r6, #8]
+	movs r4, #0xc0
+	lsls r4, r4, #4
+_080274EC:
+	adds r3, r3, r4
+	bl CallARM_PushToSecondaryOAM
+	b _0802751E
+	.align 2, 0
+_080274F4: .4byte gUnknown_08590F6C
+_080274F8:
+	adds r0, r3, #0
+	subs r0, #8
+	adds r0, r4, r0
+	movs r1, #0x80
+	lsls r1, r1, #2
+	adds r0, r0, r1
+	subs r1, #1
+	ands r0, r1
+	adds r1, r5, #0
+	adds r1, #0xf0
+	movs r2, #0xff
+	ands r1, r2
+	ldr r2, _0802752C  @ gUnknown_08590F54
+	ldrh r3, [r6, #8]
+	movs r4, #0xc0
+	lsls r4, r4, #4
+	adds r3, r3, r4
+	bl CallARM_PushToSecondaryOAM
+_0802751E:
+	ldr r6, [r6]
+	cmp r6, #0
+	beq _08027526
+	b _080273B4
+_08027526:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802752C: .4byte gUnknown_08590F54
+
+	THUMB_FUNC_START DisplayChapterTileMarker
+DisplayChapterTileMarker: @ 0x08027530
+	push {r4, r5, lr}
+	ldr r4, _080275CC  @ gUnknown_0202BCF0
+	movs r0, #0xe
+	ldrsb r0, [r4, r0]
+	bl GetROMChapterStruct
+	adds r0, #0x8f
+	ldrb r5, [r0]
+	movs r0, #0xe
+	ldrsb r0, [r4, r0]
+	bl GetROMChapterStruct
+	adds r0, #0x90
+	ldrb r4, [r0]
+	bl GetGameClock
+	movs r2, #0
+	movs r1, #0x1f
+	ands r1, r0
+	cmp r1, #0x13
+	bhi _0802755C
+	movs r2, #1
+_0802755C:
+	cmp r5, #0xff
+	beq _080275C6
+	cmp r2, #0
+	beq _080275C6
+	ldr r0, _080275D0  @ gUnknown_0202E4E8
+	ldr r0, [r0]
+	lsls r1, r4, #2
+	adds r0, r1, r0
+	ldr r0, [r0]
+	adds r0, r0, r5
+	ldrb r0, [r0]
+	cmp r0, #0
+	beq _080275C6
+	ldr r0, _080275D4  @ gUnknown_0202E4DC
+	ldr r0, [r0]
+	adds r0, r1, r0
+	ldr r0, [r0]
+	adds r0, r0, r5
+	ldrb r0, [r0]
+	cmp r0, #0x22
+	beq _080275C6
+	lsls r1, r5, #4
+	ldr r2, _080275D8  @ gUnknown_0202BCB0
+	movs r3, #0xc
+	ldrsh r0, [r2, r3]
+	subs r3, r1, r0
+	lsls r1, r4, #4
+	movs r4, #0xe
+	ldrsh r0, [r2, r4]
+	subs r2, r1, r0
+	adds r1, r3, #0
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	cmp r1, r0
+	bhi _080275C6
+	adds r0, r2, #0
+	adds r0, #0x10
+	cmp r0, #0xb0
+	bhi _080275C6
+	movs r1, #0x81
+	lsls r1, r1, #2
+	adds r0, r3, r1
+	subs r1, #5
+	ands r0, r1
+	ldr r3, _080275DC  @ 0x00000107
+	adds r1, r2, r3
+	movs r2, #0xff
+	ands r1, r2
+	ldr r2, _080275E0  @ gUnknown_08590F44
+	ldr r3, _080275E4  @ 0x00000C51
+	bl CallARM_PushToSecondaryOAM
+_080275C6:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080275CC: .4byte gUnknown_0202BCF0
+_080275D0: .4byte gUnknown_0202E4E8
+_080275D4: .4byte gUnknown_0202E4DC
+_080275D8: .4byte gUnknown_0202BCB0
+_080275DC: .4byte 0x00000107
+_080275E0: .4byte gUnknown_08590F44
+_080275E4: .4byte 0x00000C51
+
+	THUMB_FUNC_START DisplayUnitAdditionalBlinkingIcons
+DisplayUnitAdditionalBlinkingIcons: @ 0x080275E8
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #0x14
+	ldr r1, _08027618  @ gUnknown_080D7C0C
+	mov r0, sp
+	movs r2, #6
+	bl memcpy
+	bl GetChapterThing
+	cmp r0, #2
+	beq _08027620
+	ldr r0, _0802761C  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xe]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	bl GetROMChapterStruct
+	adds r0, #0x8e
+	ldrb r0, [r0]
+	b _08027622
+	.align 2, 0
+_08027618: .4byte gUnknown_080D7C0C
+_0802761C: .4byte gUnknown_0202BCF0
+_08027620:
+	movs r0, #0
+_08027622:
+	mov r9, r0
+	bl GetGameClock
+	movs r2, #0
+	movs r1, #0x1f
+	ands r1, r0
+	cmp r1, #0x13
+	bhi _08027634
+	movs r2, #1
+_08027634:
+	adds r7, r2, #0
+	bl GetGameClock
+	lsrs r0, r0, #3
+	movs r1, #0xc
+	bl __umodsi3
+	str r0, [sp, #8]
+	bl GetGameClock
+	lsrs r0, r0, #4
+	movs r1, #7
+	bl __umodsi3
+	str r0, [sp, #0xc]
+	bl GetGameClock
+	lsrs r0, r0, #3
+	movs r1, #9
+	bl __umodsi3
+	str r0, [sp, #0x10]
+	bl GetGameClock
+	lsrs r0, r0, #2
+	movs r1, #0x12
+	bl __umodsi3
+	mov sl, r0
+	movs r0, #0x84
+	bl CheckEventId
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _0802767C
+	b _08027A08
+_0802767C:
+	bl DisplayChapterTileMarker
+	movs r1, #1
+	mov r8, r1
+_08027684:
+	mov r0, r8
+	bl GetUnitStruct
+	adds r4, r0, #0
+	cmp r4, #0
+	bne _08027692
+	b _080279FC
+_08027692:
+	ldr r0, [r4]
+	cmp r0, #0
+	bne _0802769A
+	b _080279FC
+_0802769A:
+	ldr r0, [r4, #0xc]
+	movs r1, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _080276A6
+	b _080279FC
+_080276A6:
+	adds r0, r4, #0
+	bl GetUnitStandingSpriteDataFlagThing
+	lsls r0, r0, #0x18
+	cmp r0, #0
+	beq _080276B4
+	b _080279FC
+_080276B4:
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1c
+	lsrs r0, r0, #0x1c
+	subs r0, #1
+	lsls r6, r7, #0x18
+	cmp r0, #9
+	bls _080276C8
+	b _080278A6
+_080276C8:
+	lsls r0, r0, #2
+	ldr r1, _080276D4  @ _080276D8
+	adds r0, r0, r1
+	ldr r0, [r0]
+	mov pc, r0
+	.align 2, 0
+_080276D4: .4byte _080276D8
+_080276D8: @ jump table
+	.4byte _08027700 @ case 0
+	.4byte _080277A8 @ case 1
+	.4byte _08027754 @ case 2
+	.4byte _080277F8 @ case 3
+	.4byte _08027858 @ case 4
+	.4byte _08027858 @ case 5
+	.4byte _08027858 @ case 6
+	.4byte _08027858 @ case 7
+	.4byte _080278A6 @ case 8
+	.4byte _080278A6 @ case 9
+_08027700:
+	movs r1, #0x10
+	ldrsb r1, [r4, r1]
+	lsls r1, r1, #4
+	ldr r2, _0802774C  @ gUnknown_0202BCB0
+	movs r3, #0xc
+	ldrsh r0, [r2, r3]
+	subs r3, r1, r0
+	movs r0, #0x11
+	ldrsb r0, [r4, r0]
+	lsls r0, r0, #4
+	movs r5, #0xe
+	ldrsh r1, [r2, r5]
+	subs r2, r0, r1
+	adds r1, r3, #0
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	lsls r6, r7, #0x18
+	cmp r1, r0
+	bls _0802772A
+	b _080278A6
+_0802772A:
+	adds r0, r2, #0
+	adds r0, #0x10
+	cmp r0, #0xb0
+	bls _08027734
+	b _080278A6
+_08027734:
+	movs r1, #0xff
+	lsls r1, r1, #1
+	adds r0, r3, r1
+	adds r1, #1
+	ands r0, r1
+	adds r1, r2, #0
+	adds r1, #0xfc
+	movs r2, #0xff
+	ands r1, r2
+	ldr r3, _08027750  @ gUnknown_0859B938
+	ldr r5, [sp, #8]
+	b _0802783C
+	.align 2, 0
+_0802774C: .4byte gUnknown_0202BCB0
+_08027750: .4byte gUnknown_0859B938
+_08027754:
+	movs r1, #0x10
+	ldrsb r1, [r4, r1]
+	lsls r1, r1, #4
+	ldr r2, _080277A0  @ gUnknown_0202BCB0
+	movs r3, #0xc
+	ldrsh r0, [r2, r3]
+	subs r3, r1, r0
+	movs r0, #0x11
+	ldrsb r0, [r4, r0]
+	lsls r0, r0, #4
+	movs r5, #0xe
+	ldrsh r1, [r2, r5]
+	subs r2, r0, r1
+	adds r1, r3, #0
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	lsls r6, r7, #0x18
+	cmp r1, r0
+	bls _0802777E
+	b _080278A6
+_0802777E:
+	adds r0, r2, #0
+	adds r0, #0x10
+	cmp r0, #0xb0
+	bls _08027788
+	b _080278A6
+_08027788:
+	movs r1, #0xff
+	lsls r1, r1, #1
+	adds r0, r3, r1
+	adds r1, #1
+	ands r0, r1
+	adds r1, r2, #0
+	adds r1, #0xfc
+	movs r2, #0xff
+	ands r1, r2
+	ldr r3, _080277A4  @ gUnknown_0859B898
+	mov r5, sl
+	b _0802783C
+	.align 2, 0
+_080277A0: .4byte gUnknown_0202BCB0
+_080277A4: .4byte gUnknown_0859B898
+_080277A8:
+	movs r1, #0x10
+	ldrsb r1, [r4, r1]
+	lsls r1, r1, #4
+	ldr r2, _080277EC  @ gUnknown_0202BCB0
+	movs r3, #0xc
+	ldrsh r0, [r2, r3]
+	subs r3, r1, r0
+	movs r0, #0x11
+	ldrsb r0, [r4, r0]
+	lsls r0, r0, #4
+	movs r5, #0xe
+	ldrsh r1, [r2, r5]
+	subs r2, r0, r1
+	adds r0, r3, #0
+	adds r0, #0x10
+	movs r5, #0x80
+	lsls r5, r5, #1
+	lsls r6, r7, #0x18
+	cmp r0, r5
+	bhi _080278A6
+	adds r0, r2, #0
+	adds r0, #0x10
+	cmp r0, #0xb0
+	bhi _080278A6
+	ldr r1, _080277F0  @ 0x00000202
+	adds r0, r3, r1
+	subs r1, #3
+	ands r0, r1
+	adds r1, r2, r5
+	movs r2, #0xff
+	ands r1, r2
+	ldr r3, _080277F4  @ gUnknown_0859B7F4
+	ldr r5, [sp, #0xc]
+	b _0802783C
+	.align 2, 0
+_080277EC: .4byte gUnknown_0202BCB0
+_080277F0: .4byte 0x00000202
+_080277F4: .4byte gUnknown_0859B7F4
+_080277F8:
+	movs r1, #0x10
+	ldrsb r1, [r4, r1]
+	lsls r1, r1, #4
+	ldr r2, _0802784C  @ gUnknown_0202BCB0
+	movs r3, #0xc
+	ldrsh r0, [r2, r3]
+	subs r3, r1, r0
+	movs r0, #0x11
+	ldrsb r0, [r4, r0]
+	lsls r0, r0, #4
+	movs r5, #0xe
+	ldrsh r1, [r2, r5]
+	subs r2, r0, r1
+	adds r1, r3, #0
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	lsls r6, r7, #0x18
+	cmp r1, r0
+	bhi _080278A6
+	adds r0, r2, #0
+	adds r0, #0x10
+	cmp r0, #0xb0
+	bhi _080278A6
+	ldr r1, _08027850  @ 0x00000201
+	adds r0, r3, r1
+	subs r1, #2
+	ands r0, r1
+	adds r1, r2, #0
+	adds r1, #0xfb
+	movs r2, #0xff
+	ands r1, r2
+	ldr r3, _08027854  @ gUnknown_0859B858
+	ldr r5, [sp, #0x10]
+_0802783C:
+	lsls r2, r5, #2
+	adds r2, r2, r3
+	ldr r2, [r2]
+	movs r3, #0
+	bl CallARM_PushToSecondaryOAM
+	b _080278A6
+	.align 2, 0
+_0802784C: .4byte gUnknown_0202BCB0
+_08027850: .4byte 0x00000201
+_08027854: .4byte gUnknown_0859B858
+_08027858:
+	lsls r0, r7, #0x18
+	adds r6, r0, #0
+	cmp r6, #0
+	bne _08027862
+	b _080279FC
+_08027862:
+	movs r1, #0x10
+	ldrsb r1, [r4, r1]
+	lsls r1, r1, #4
+	ldr r2, _08027914  @ gUnknown_0202BCB0
+	movs r3, #0xc
+	ldrsh r0, [r2, r3]
+	subs r3, r1, r0
+	movs r0, #0x11
+	ldrsb r0, [r4, r0]
+	lsls r0, r0, #4
+	movs r5, #0xe
+	ldrsh r1, [r2, r5]
+	subs r2, r0, r1
+	adds r1, r3, #0
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	cmp r1, r0
+	bhi _080278A6
+	adds r0, r2, #0
+	adds r0, #0x10
+	cmp r0, #0xb0
+	bhi _080278A6
+	ldr r1, _08027918  @ 0x000001FF
+	adds r0, r3, r1
+	ands r0, r1
+	adds r1, r2, #0
+	adds r1, #0xfb
+	movs r2, #0xff
+	ands r1, r2
+	ldr r2, _0802791C  @ gUnknown_0859B968
+	movs r3, #0
+	bl CallARM_PushToSecondaryOAM
+_080278A6:
+	cmp r6, #0
+	bne _080278AC
+	b _080279FC
+_080278AC:
+	ldr r0, [r4, #0xc]
+	movs r1, #0x10
+	ands r0, r1
+	cmp r0, #0
+	beq _08027930
+	movs r1, #0x10
+	ldrsb r1, [r4, r1]
+	lsls r1, r1, #4
+	ldr r2, _08027914  @ gUnknown_0202BCB0
+	movs r3, #0xc
+	ldrsh r0, [r2, r3]
+	subs r3, r1, r0
+	movs r0, #0x11
+	ldrsb r0, [r4, r0]
+	lsls r0, r0, #4
+	movs r5, #0xe
+	ldrsh r1, [r2, r5]
+	subs r2, r0, r1
+	adds r1, r3, #0
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	cmp r1, r0
+	bls _080278DE
+	b _080279FC
+_080278DE:
+	adds r0, r2, #0
+	adds r0, #0x10
+	cmp r0, #0xb0
+	bls _080278E8
+	b _080279FC
+_080278E8:
+	ldr r1, _08027920  @ 0x00000209
+	adds r0, r3, r1
+	subs r1, #0xa
+	ands r0, r1
+	ldr r3, _08027924  @ 0x00000107
+	adds r1, r2, r3
+	movs r2, #0xff
+	ands r1, r2
+	ldr r2, _08027928  @ gUnknown_08590F44
+	ldrb r3, [r4, #0x1b]
+	lsrs r3, r3, #6
+	lsls r3, r3, #1
+	add r3, sp
+	ldrh r4, [r3]
+	movs r3, #0xf
+	ands r3, r4
+	lsls r3, r3, #0xc
+	ldr r4, _0802792C  @ 0x00000803
+	adds r3, r3, r4
+	bl CallARM_PushToSecondaryOAM
+	b _080279FC
+	.align 2, 0
+_08027914: .4byte gUnknown_0202BCB0
+_08027918: .4byte 0x000001FF
+_0802791C: .4byte gUnknown_0859B968
+_08027920: .4byte 0x00000209
+_08027924: .4byte 0x00000107
+_08027928: .4byte gUnknown_08590F44
+_0802792C: .4byte 0x00000803
+_08027930:
+	movs r1, #0xb
+	ldrsb r1, [r4, r1]
+	movs r0, #0xc0
+	ands r1, r0
+	ldr r2, [r4]
+	cmp r1, #0
+	beq _080279B0
+	ldr r0, [r4, #4]
+	ldr r1, [r2, #0x28]
+	ldr r0, [r0, #0x28]
+	orrs r1, r0
+	movs r0, #0x80
+	lsls r0, r0, #8
+	ands r1, r0
+	cmp r1, #0
+	beq _080279B0
+	movs r1, #0x10
+	ldrsb r1, [r4, r1]
+	lsls r1, r1, #4
+	ldr r2, _0802799C  @ gUnknown_0202BCB0
+	movs r5, #0xc
+	ldrsh r0, [r2, r5]
+	subs r3, r1, r0
+	movs r0, #0x11
+	ldrsb r0, [r4, r0]
+	lsls r0, r0, #4
+	movs r4, #0xe
+	ldrsh r1, [r2, r4]
+	subs r2, r0, r1
+	adds r1, r3, #0
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	cmp r1, r0
+	bhi _080279FC
+	adds r0, r2, #0
+	adds r0, #0x10
+	cmp r0, #0xb0
+	bhi _080279FC
+	ldr r5, _080279A0  @ 0x00000209
+	adds r0, r3, r5
+	ldr r1, _080279A4  @ 0x000001FF
+	ands r0, r1
+	ldr r3, _080279A8  @ 0x00000107
+	adds r1, r2, r3
+	movs r2, #0xff
+	ands r1, r2
+	ldr r2, _080279AC  @ gUnknown_08590F44
+	movs r3, #0x81
+	lsls r3, r3, #4
+	bl CallARM_PushToSecondaryOAM
+	b _080279FC
+	.align 2, 0
+_0802799C: .4byte gUnknown_0202BCB0
+_080279A0: .4byte 0x00000209
+_080279A4: .4byte 0x000001FF
+_080279A8: .4byte 0x00000107
+_080279AC: .4byte gUnknown_08590F44
+_080279B0:
+	ldrb r2, [r2, #4]
+	cmp r9, r2
+	bne _080279FC
+	movs r1, #0x10
+	ldrsb r1, [r4, r1]
+	lsls r1, r1, #4
+	ldr r2, _08027A18  @ gUnknown_0202BCB0
+	movs r5, #0xc
+	ldrsh r0, [r2, r5]
+	subs r3, r1, r0
+	movs r0, #0x11
+	ldrsb r0, [r4, r0]
+	lsls r0, r0, #4
+	movs r4, #0xe
+	ldrsh r1, [r2, r4]
+	subs r2, r0, r1
+	adds r1, r3, #0
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	cmp r1, r0
+	bhi _080279FC
+	adds r0, r2, #0
+	adds r0, #0x10
+	cmp r0, #0xb0
+	bhi _080279FC
+	ldr r5, _08027A1C  @ 0x00000209
+	adds r0, r3, r5
+	ldr r1, _08027A20  @ 0x000001FF
+	ands r0, r1
+	ldr r3, _08027A24  @ 0x00000107
+	adds r1, r2, r3
+	movs r2, #0xff
+	ands r1, r2
+	ldr r2, _08027A28  @ gUnknown_08590F44
+	ldr r3, _08027A2C  @ 0x00000811
+	bl CallARM_PushToSecondaryOAM
+_080279FC:
+	movs r4, #1
+	add r8, r4
+	mov r5, r8
+	cmp r5, #0xbf
+	bgt _08027A08
+	b _08027684
+_08027A08:
+	add sp, #0x14
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08027A18: .4byte gUnknown_0202BCB0
+_08027A1C: .4byte 0x00000209
+_08027A20: .4byte 0x000001FF
+_08027A24: .4byte 0x00000107
+_08027A28: .4byte gUnknown_08590F44
+_08027A2C: .4byte 0x00000811
+
+	THUMB_FUNC_START sub_8027A30
+sub_8027A30: @ 0x08027A30
+	ldr r1, _08027A38  @ gUnknown_0202BCB0
+	ldr r0, _08027A3C  @ 0x0000FFFF
+	strh r0, [r1, #0x18]
+	bx lr
+	.align 2, 0
+_08027A38: .4byte gUnknown_0202BCB0
+_08027A3C: .4byte 0x0000FFFF
+
+	THUMB_FUNC_START sub_8027A40
+sub_8027A40: @ 0x08027A40
+	ldr r1, _08027A48  @ gUnknown_0203A4D0
+	movs r0, #0
+	str r0, [r1]
+	bx lr
+	.align 2, 0
+_08027A48: .4byte gUnknown_0203A4D0
+
+	THUMB_FUNC_START sub_8027A4C
+sub_8027A4C: @ 0x08027A4C
+	push {r4, lr}
+	ldr r2, _08027AB4  @ gUnknown_0202BCB0
+	movs r1, #0x16
+	ldrsh r0, [r2, r1]
+	ldr r1, _08027AB8  @ gUnknown_0202E4D8
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r3, #0x14
+	ldrsh r1, [r2, r3]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	bl GetUnitStruct
+	adds r4, r0, #0
+	cmp r4, #0
+	beq _08027AC0
+	ldr r0, [r4, #0xc]
+	movs r1, #2
+	ands r0, r1
+	cmp r0, #0
+	bne _08027AC0
+	movs r0, #0xb
+	ldrsb r0, [r4, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, #0
+	bne _08027AC0
+	adds r0, r4, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #4
+	beq _08027AC0
+	cmp r1, #2
+	beq _08027AC0
+	ldr r1, _08027ABC  @ gUnknown_0203A4D0
+	ldr r0, [r1]
+	adds r0, #1
+	str r0, [r1]
+	cmp r0, #5
+	bne _08027AC0
+	adds r0, r4, #0
+	bl MakeMOVEUNITForMapUnit
+	adds r0, r4, #0
+	bl HideUnitSMS
+	b _08027AFA
+	.align 2, 0
+_08027AB4: .4byte gUnknown_0202BCB0
+_08027AB8: .4byte gUnknown_0202E4D8
+_08027ABC: .4byte gUnknown_0203A4D0
+_08027AC0:
+	ldr r2, _08027B00  @ gUnknown_0202BCB0
+	ldr r1, [r2, #0x18]
+	ldr r0, [r2, #0x14]
+	cmp r1, r0
+	beq _08027AFA
+	ldr r1, _08027B04  @ gUnknown_0203A4D0
+	movs r0, #0
+	str r0, [r1]
+	movs r1, #0x1a
+	ldrsh r0, [r2, r1]
+	ldr r1, _08027B08  @ gUnknown_0202E4D8
+	ldr r1, [r1]
+	lsls r0, r0, #2
+	adds r0, r0, r1
+	movs r3, #0x18
+	ldrsh r1, [r2, r3]
+	ldr r0, [r0]
+	adds r0, r0, r1
+	ldrb r0, [r0]
+	bl GetUnitStruct
+	adds r4, r0, #0
+	cmp r4, #0
+	beq _08027AFA
+	bl ClearMOVEUNITs
+	adds r0, r4, #0
+	bl ShowUnitSMS
+_08027AFA:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08027B00: .4byte gUnknown_0202BCB0
+_08027B04: .4byte gUnknown_0203A4D0
+_08027B08: .4byte gUnknown_0202E4D8
+
+	THUMB_FUNC_START sub_8027B0C
+sub_8027B0C: @ 0x08027B0C
+	push {lr}
+	ldr r2, _08027B54  @ gUnknown_0202E4D8
+	ldr r2, [r2]
+	lsls r1, r1, #2
+	adds r1, r1, r2
+	ldr r1, [r1]
+	adds r1, r1, r0
+	ldrb r0, [r1]
+	bl GetUnitStruct
+	adds r2, r0, #0
+	cmp r2, #0
+	beq _08027B58
+	ldr r0, [r2, #0xc]
+	movs r1, #2
+	ands r0, r1
+	cmp r0, #0
+	bne _08027B58
+	movs r0, #0xb
+	ldrsb r0, [r2, r0]
+	movs r1, #0xc0
+	ands r0, r1
+	cmp r0, #0
+	bne _08027B58
+	adds r0, r2, #0
+	adds r0, #0x30
+	ldrb r0, [r0]
+	movs r1, #0xf
+	ands r1, r0
+	cmp r1, #4
+	beq _08027B58
+	cmp r1, #2
+	beq _08027B58
+	movs r0, #1
+	b _08027B5A
+	.align 2, 0
+_08027B54: .4byte gUnknown_0202E4D8
+_08027B58:
+	movs r0, #0
+_08027B5A:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8027B60
+sub_8027B60: @ 0x08027B60
+	push {r4, r5, r6, r7, lr}
+	mov r7, r9
+	mov r6, r8
+	push {r6, r7}
+	sub sp, #4
+	mov r9, r0
+	mov r8, r1
+	adds r7, r2, #0
+	adds r4, r3, #0
+	adds r0, r4, #0
+	bl GetUnitSMSIndex
+	adds r5, r0, #0
+	bl SMS_RegisterUsage
+	adds r6, r0, #0
+	mov r1, r8
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	cmp r1, r0
+	bhi _08027C36
+	adds r0, r7, #0
+	adds r0, #0x20
+	cmp r0, #0xc0
+	bhi _08027C36
+	ldr r1, _08027BB0  @ gUnknown_088AF880
+	movs r0, #0x7f
+	ands r0, r5
+	lsls r0, r0, #3
+	adds r0, r0, r1
+	ldrh r0, [r0, #2]
+	cmp r0, #1
+	beq _08027BE4
+	cmp r0, #1
+	bgt _08027BB4
+	cmp r0, #0
+	beq _08027BBA
+	b _08027C36
+	.align 2, 0
+_08027BB0: .4byte gUnknown_088AF880
+_08027BB4:
+	cmp r0, #2
+	beq _08027C10
+	b _08027C36
+_08027BBA:
+	adds r0, r4, #0
+	bl GetUnitSpritePaletteIndexWrapper
+	movs r1, #0xf
+	ands r1, r0
+	lsls r1, r1, #0xc
+	movs r2, #0x88
+	lsls r2, r2, #4
+	adds r0, r6, r2
+	adds r1, r1, r0
+	ldr r3, _08027BE0  @ gUnknown_08590F4C
+	str r1, [sp]
+	mov r0, r9
+	mov r1, r8
+	adds r2, r7, #0
+	bl RegisterObjectAttributes_SafeMaybe
+	b _08027C36
+	.align 2, 0
+_08027BE0: .4byte gUnknown_08590F4C
+_08027BE4:
+	adds r0, r4, #0
+	bl GetUnitSpritePaletteIndexWrapper
+	movs r1, #0xf
+	ands r1, r0
+	lsls r1, r1, #0xc
+	movs r2, #0x88
+	lsls r2, r2, #4
+	adds r0, r6, r2
+	adds r1, r1, r0
+	adds r2, r7, #0
+	subs r2, #0x10
+	ldr r3, _08027C0C  @ gUnknown_08590F6C
+	str r1, [sp]
+	mov r0, r9
+	mov r1, r8
+	bl RegisterObjectAttributes_SafeMaybe
+	b _08027C36
+	.align 2, 0
+_08027C0C: .4byte gUnknown_08590F6C
+_08027C10:
+	adds r0, r4, #0
+	bl GetUnitSpritePaletteIndexWrapper
+	movs r4, #0xf
+	ands r4, r0
+	lsls r4, r4, #0xc
+	movs r1, #0x88
+	lsls r1, r1, #4
+	adds r0, r6, r1
+	adds r4, r4, r0
+	mov r1, r8
+	subs r1, #8
+	adds r2, r7, #0
+	subs r2, #0x10
+	ldr r3, _08027C44  @ gUnknown_08590F54
+	str r4, [sp]
+	mov r0, r9
+	bl RegisterObjectAttributes_SafeMaybe
+_08027C36:
+	add sp, #4
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08027C44: .4byte gUnknown_08590F54
+
+	THUMB_FUNC_START sub_8027C48
+sub_8027C48: @ 0x08027C48
+	push {r4, r5, r6, r7, lr}
+	mov r7, r9
+	mov r6, r8
+	push {r6, r7}
+	sub sp, #4
+	mov r9, r0
+	adds r6, r1, #0
+	adds r5, r2, #0
+	ldr r0, [sp, #0x20]
+	lsls r3, r3, #0x10
+	lsrs r7, r3, #0x10
+	bl GetClassStandingMapSpriteId
+	mov r8, r0
+	bl SMS_RegisterUsage
+	adds r4, r0, #0
+	adds r4, #0x80
+	adds r1, r6, #0
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	cmp r1, r0
+	bhi _08027CE8
+	adds r0, r5, #0
+	adds r0, #0x20
+	cmp r0, #0xc0
+	bhi _08027CE8
+	ldr r1, _08027C9C  @ gUnknown_088AF880
+	movs r0, #0x7f
+	mov r2, r8
+	ands r0, r2
+	lsls r0, r0, #3
+	adds r0, r0, r1
+	ldrh r0, [r0, #2]
+	cmp r0, #1
+	beq _08027CBC
+	cmp r0, #1
+	bgt _08027CA0
+	cmp r0, #0
+	beq _08027CA6
+	b _08027CE8
+	.align 2, 0
+_08027C9C: .4byte gUnknown_088AF880
+_08027CA0:
+	cmp r0, #2
+	beq _08027CD4
+	b _08027CE8
+_08027CA6:
+	ldr r3, _08027CB8  @ gUnknown_08590F4C
+	adds r0, r7, r4
+	str r0, [sp]
+	mov r0, r9
+	adds r1, r6, #0
+	adds r2, r5, #0
+	bl RegisterObjectAttributes_SafeMaybe
+	b _08027CE8
+	.align 2, 0
+_08027CB8: .4byte gUnknown_08590F4C
+_08027CBC:
+	adds r2, r5, #0
+	subs r2, #0x10
+	ldr r3, _08027CD0  @ gUnknown_08590F6C
+	adds r0, r7, r4
+	str r0, [sp]
+	mov r0, r9
+	adds r1, r6, #0
+	bl RegisterObjectAttributes_SafeMaybe
+	b _08027CE8
+	.align 2, 0
+_08027CD0: .4byte gUnknown_08590F6C
+_08027CD4:
+	adds r1, r6, #0
+	subs r1, #8
+	adds r2, r5, #0
+	subs r2, #0x10
+	ldr r3, _08027CF8  @ gUnknown_08590F54
+	adds r0, r7, r4
+	str r0, [sp]
+	mov r0, r9
+	bl RegisterObjectAttributes_SafeMaybe
+_08027CE8:
+	add sp, #4
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08027CF8: .4byte gUnknown_08590F54
+
+	THUMB_FUNC_START sub_8027CFC
+sub_8027CFC: @ 0x08027CFC
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	sub sp, #4
+	mov r8, r0
+	adds r5, r1, #0
+	adds r4, r2, #0
+	adds r0, r3, #0
+	bl GetClassStandingMapSpriteId
+	adds r6, r0, #0
+	bl SMS_RegisterUsage
+	adds r7, r0, #0
+	adds r7, #0x80
+	adds r1, r5, #0
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	cmp r1, r0
+	bhi _08027DA0
+	adds r0, r4, #0
+	adds r0, #0x20
+	cmp r0, #0xc0
+	bhi _08027DA0
+	ldr r1, _08027D48  @ gUnknown_088AF880
+	movs r0, #0x7f
+	ands r0, r6
+	lsls r0, r0, #3
+	adds r0, r0, r1
+	ldrh r0, [r0, #2]
+	cmp r0, #1
+	beq _08027D60
+	cmp r0, #1
+	bgt _08027D4C
+	cmp r0, #0
+	beq _08027D52
+	b _08027DA0
+	.align 2, 0
+_08027D48: .4byte gUnknown_088AF880
+_08027D4C:
+	cmp r0, #2
+	beq _08027D80
+	b _08027DA0
+_08027D52:
+	movs r0, #0x80
+	lsls r0, r0, #4
+	adds r2, r4, r0
+	ldr r3, _08027D5C  @ gUnknown_08590F4C
+	b _08027D70
+	.align 2, 0
+_08027D5C: .4byte gUnknown_08590F4C
+_08027D60:
+	adds r2, r4, #0
+	subs r2, #0x10
+	movs r0, #0xff
+	ands r2, r0
+	movs r0, #0x80
+	lsls r0, r0, #4
+	adds r2, r2, r0
+	ldr r3, _08027D7C  @ gUnknown_08590F6C
+_08027D70:
+	str r7, [sp]
+	mov r0, r8
+	adds r1, r5, #0
+	bl RegisterObjectAttributes
+	b _08027DA0
+	.align 2, 0
+_08027D7C: .4byte gUnknown_08590F6C
+_08027D80:
+	adds r1, r5, #0
+	subs r1, #8
+	ldr r0, _08027DAC  @ 0x000001FF
+	ands r1, r0
+	adds r2, r4, #0
+	subs r2, #0x10
+	movs r0, #0xff
+	ands r2, r0
+	movs r0, #0x80
+	lsls r0, r0, #4
+	adds r2, r2, r0
+	ldr r3, _08027DB0  @ gUnknown_08590F54
+	str r7, [sp]
+	mov r0, r8
+	bl RegisterObjectAttributes
+_08027DA0:
+	add sp, #4
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08027DAC: .4byte 0x000001FF
+_08027DB0: .4byte gUnknown_08590F54
+
+	THUMB_FUNC_START sub_8027DB4
+sub_8027DB4: @ 0x08027DB4
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	sub sp, #4
+	mov r8, r0
+	adds r6, r1, #0
+	adds r5, r2, #0
+	ldr r0, [sp, #0x1c]
+	ldr r4, [sp, #0x20]
+	lsls r3, r3, #0x10
+	lsrs r7, r3, #0x10
+	bl GetClassStandingMapSpriteId
+	adds r2, r0, #0
+	ldr r0, _08027E08  @ gUnknown_0859B66C
+	lsls r4, r4, #2
+	adds r4, r4, r0
+	ldr r0, [r4]
+	adds r4, r0, #1
+	adds r1, r6, #0
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	cmp r1, r0
+	bhi _08027E3C
+	adds r0, r5, #0
+	adds r0, #0x20
+	cmp r0, #0xc0
+	bhi _08027E3C
+	ldr r1, _08027E0C  @ gUnknown_088AF880
+	movs r0, #0x7f
+	ands r0, r2
+	lsls r0, r0, #3
+	adds r0, r0, r1
+	ldrh r0, [r0, #2]
+	cmp r0, #0
+	blt _08027E3C
+	cmp r0, #1
+	ble _08027E10
+	cmp r0, #2
+	beq _08027E28
+	b _08027E3C
+	.align 2, 0
+_08027E08: .4byte gUnknown_0859B66C
+_08027E0C: .4byte gUnknown_088AF880
+_08027E10:
+	adds r2, r5, #0
+	subs r2, #0x10
+	ldr r3, _08027E24  @ gUnknown_08590F6C
+	adds r0, r7, r4
+	str r0, [sp]
+	mov r0, r8
+	adds r1, r6, #0
+	bl RegisterObjectAttributes_SafeMaybe
+	b _08027E3C
+	.align 2, 0
+_08027E24: .4byte gUnknown_08590F6C
+_08027E28:
+	adds r1, r6, #0
+	subs r1, #8
+	adds r2, r5, #0
+	subs r2, #0x10
+	ldr r3, _08027E48  @ gUnknown_08590F54
+	adds r0, r7, r4
+	str r0, [sp]
+	mov r0, r8
+	bl RegisterObjectAttributes_SafeMaybe
+_08027E3C:
+	add sp, #4
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08027E48: .4byte gUnknown_08590F54
+
+	THUMB_FUNC_START sub_8027E4C
+sub_8027E4C: @ 0x08027E4C
+	push {r4, r5, r6, r7, lr}
+	mov r7, r9
+	mov r6, r8
+	push {r6, r7}
+	sub sp, #4
+	mov r9, r0
+	mov r8, r1
+	adds r6, r2, #0
+	adds r7, r3, #0
+	ldr r0, [sp, #0x20]
+	bl GetUnitSMSIndex
+	adds r4, r0, #0
+	bl SMS_RegisterUsage
+	adds r5, r0, #0
+	adds r5, #0x80
+	mov r1, r8
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	cmp r1, r0
+	bhi _08027F16
+	adds r0, r6, #0
+	adds r0, #0x20
+	cmp r0, #0xc0
+	bhi _08027F16
+	ldr r1, _08027E9C  @ gUnknown_088AF880
+	movs r0, #0x7f
+	ands r0, r4
+	lsls r0, r0, #3
+	adds r0, r0, r1
+	ldrh r0, [r0, #2]
+	cmp r0, #1
+	beq _08027ECC
+	cmp r0, #1
+	bgt _08027EA0
+	cmp r0, #0
+	beq _08027EA6
+	b _08027F16
+	.align 2, 0
+_08027E9C: .4byte gUnknown_088AF880
+_08027EA0:
+	cmp r0, #2
+	beq _08027EF4
+	b _08027F16
+_08027EA6:
+	ldr r0, [sp, #0x20]
+	bl GetUnitMapSpritePaletteIndex
+	movs r1, #0xf
+	ands r1, r0
+	lsls r1, r1, #0xc
+	adds r1, r7, r1
+	adds r1, r1, r5
+	ldr r3, _08027EC8  @ gUnknown_08590F4C
+	str r1, [sp]
+	mov r0, r9
+	mov r1, r8
+	adds r2, r6, #0
+	bl RegisterObjectAttributes_SafeMaybe
+	b _08027F16
+	.align 2, 0
+_08027EC8: .4byte gUnknown_08590F4C
+_08027ECC:
+	ldr r0, [sp, #0x20]
+	bl GetUnitMapSpritePaletteIndex
+	movs r1, #0xf
+	ands r1, r0
+	lsls r1, r1, #0xc
+	adds r1, r7, r1
+	adds r1, r1, r5
+	adds r2, r6, #0
+	subs r2, #0x10
+	ldr r3, _08027EF0  @ gUnknown_08590F6C
+	str r1, [sp]
+	mov r0, r9
+	mov r1, r8
+	bl RegisterObjectAttributes_SafeMaybe
+	b _08027F16
+	.align 2, 0
+_08027EF0: .4byte gUnknown_08590F6C
+_08027EF4:
+	ldr r0, [sp, #0x20]
+	bl GetUnitMapSpritePaletteIndex
+	movs r4, #0xf
+	ands r4, r0
+	lsls r4, r4, #0xc
+	adds r4, r7, r4
+	adds r4, r4, r5
+	mov r1, r8
+	subs r1, #8
+	adds r2, r6, #0
+	subs r2, #0x10
+	ldr r3, _08027F24  @ gUnknown_08590F54
+	str r4, [sp]
+	mov r0, r9
+	bl RegisterObjectAttributes_SafeMaybe
+_08027F16:
+	add sp, #4
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08027F24: .4byte gUnknown_08590F54
+
+	THUMB_FUNC_START SMS_DisplayOne
+SMS_DisplayOne: @ 0x08027F28
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	sub sp, #4
+	mov ip, r0
+	mov r8, r1
+	adds r5, r2, #0
+	adds r6, r3, #0
+	ldr r0, [sp, #0x20]
+	lsls r0, r0, #0x18
+	lsrs r7, r0, #0x18
+	adds r1, r5, #0
+	adds r1, #0x10
+	movs r0, #0x88
+	lsls r0, r0, #1
+	cmp r1, r0
+	bhi _08027FFE
+	adds r0, r6, #0
+	adds r0, #0x20
+	cmp r0, #0xe0
+	bhi _08027FFE
+	ldr r4, _08027F74  @ gUnknown_088AF880
+	mov r0, ip
+	bl GetClassStandingMapSpriteId
+	movs r1, #0x7f
+	ands r1, r0
+	lsls r1, r1, #3
+	adds r1, r1, r4
+	ldrh r0, [r1, #2]
+	cmp r0, #1
+	beq _08027FA8
+	cmp r0, #1
+	bgt _08027F78
+	cmp r0, #0
+	beq _08027F7E
+	b _08027FFE
+	.align 2, 0
+_08027F74: .4byte gUnknown_088AF880
+_08027F78:
+	cmp r0, #2
+	beq _08027FD8
+	b _08027FFE
+_08027F7E:
+	adds r1, r5, #0
+	subs r1, #8
+	ldr r0, _08027FA0  @ 0x000001FF
+	ands r1, r0
+	adds r2, r6, #0
+	subs r2, #0x10
+	movs r0, #0xff
+	ands r2, r0
+	cmp r7, #0
+	beq _08027F98
+	movs r0, #0x80
+	lsls r0, r0, #3
+	orrs r2, r0
+_08027F98:
+	ldr r3, _08027FA4  @ gUnknown_08590F4C
+	ldr r0, [sp, #0x1c]
+	adds r0, #0x40
+	b _08027FC6
+	.align 2, 0
+_08027FA0: .4byte 0x000001FF
+_08027FA4: .4byte gUnknown_08590F4C
+_08027FA8:
+	adds r1, r5, #0
+	subs r1, #8
+	ldr r0, _08027FD0  @ 0x000001FF
+	ands r1, r0
+	adds r2, r6, #0
+	subs r2, #0x20
+	movs r0, #0xff
+	ands r2, r0
+	cmp r7, #0
+	beq _08027FC2
+	movs r0, #0x80
+	lsls r0, r0, #3
+	orrs r2, r0
+_08027FC2:
+	ldr r3, _08027FD4  @ gUnknown_08590F6C
+	ldr r0, [sp, #0x1c]
+_08027FC6:
+	str r0, [sp]
+	mov r0, r8
+	bl RegisterObjectAttributes
+	b _08027FFE
+	.align 2, 0
+_08027FD0: .4byte 0x000001FF
+_08027FD4: .4byte gUnknown_08590F6C
+_08027FD8:
+	adds r1, r5, #0
+	subs r1, #0x10
+	ldr r0, _0802800C  @ 0x000001FF
+	ands r1, r0
+	adds r2, r6, #0
+	subs r2, #0x20
+	movs r0, #0xff
+	ands r2, r0
+	cmp r7, #0
+	beq _08027FF2
+	movs r0, #0x80
+	lsls r0, r0, #3
+	orrs r2, r0
+_08027FF2:
+	ldr r3, _08028010  @ gUnknown_08590F54
+	ldr r0, [sp, #0x1c]
+	str r0, [sp]
+	mov r0, r8
+	bl RegisterObjectAttributes
+_08027FFE:
+	add sp, #4
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802800C: .4byte 0x000001FF
+_08028010: .4byte gUnknown_08590F54
+
+	THUMB_FUNC_START sub_8028014
+sub_8028014: @ 0x08028014
+	push {r4, r5, r6, r7, lr}
+	mov r7, r9
+	mov r6, r8
+	push {r6, r7}
+	sub sp, #4
+	mov r9, r0
+	adds r7, r1, #0
+	adds r6, r2, #0
+	mov r8, r3
+	ldr r0, [sp, #0x20]
+	bl GetUnitSMSIndex
+	adds r5, r0, #0
+	bl SMS_RegisterUsage
+	adds r4, r0, #0
+	adds r4, #0x80
+	adds r1, r7, #0
+	adds r1, #0x10
+	movs r0, #0x80
+	lsls r0, r0, #1
+	cmp r1, r0
+	bhi _080280E8
+	adds r0, r6, #0
+	adds r0, #0x20
+	cmp r0, #0xc0
+	bhi _080280E8
+	ldr r1, _08028064  @ gUnknown_088AF880
+	movs r0, #0x7f
+	ands r0, r5
+	lsls r0, r0, #3
+	adds r0, r0, r1
+	ldrh r0, [r0, #2]
+	cmp r0, #1
+	beq _08028098
+	cmp r0, #1
+	bgt _08028068
+	cmp r0, #0
+	beq _0802806E
+	b _080280E8
+	.align 2, 0
+_08028064: .4byte gUnknown_088AF880
+_08028068:
+	cmp r0, #2
+	beq _080280C4
+	b _080280E8
+_0802806E:
+	ldr r3, _08028090  @ gUnknown_0859B976
+	add r4, r8
+	str r4, [sp]
+	mov r0, r9
+	adds r1, r7, #0
+	adds r2, r6, #0
+	bl RegisterObjectAttributes_SafeMaybe
+	ldr r3, _08028094  @ gUnknown_0859B98E
+	str r4, [sp]
+	mov r0, r9
+	adds r1, r7, #0
+	adds r2, r6, #0
+	bl RegisterObjectAttributes_SafeMaybe
+	b _080280E8
+	.align 2, 0
+_08028090: .4byte gUnknown_0859B976
+_08028094: .4byte gUnknown_0859B98E
+_08028098:
+	adds r5, r6, #0
+	subs r5, #0x10
+	ldr r3, _080280BC  @ gUnknown_0859B97E
+	add r4, r8
+	str r4, [sp]
+	mov r0, r9
+	adds r1, r7, #0
+	adds r2, r5, #0
+	bl RegisterObjectAttributes_SafeMaybe
+	ldr r3, _080280C0  @ gUnknown_0859B996
+	str r4, [sp]
+	mov r0, r9
+	adds r1, r7, #0
+	adds r2, r5, #0
+	bl RegisterObjectAttributes_SafeMaybe
+	b _080280E8
+	.align 2, 0
+_080280BC: .4byte gUnknown_0859B97E
+_080280C0: .4byte gUnknown_0859B996
+_080280C4:
+	adds r5, r7, #0
+	subs r5, #8
+	subs r6, #0x10
+	ldr r3, _080280F8  @ gUnknown_0859B986
+	add r4, r8
+	str r4, [sp]
+	mov r0, r9
+	adds r1, r5, #0
+	adds r2, r6, #0
+	bl RegisterObjectAttributes_SafeMaybe
+	ldr r3, _080280FC  @ gUnknown_0859B99E
+	str r4, [sp]
+	mov r0, r9
+	adds r1, r5, #0
+	adds r2, r6, #0
+	bl RegisterObjectAttributes_SafeMaybe
+_080280E8:
+	add sp, #4
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080280F8: .4byte gUnknown_0859B986
+_080280FC: .4byte gUnknown_0859B99E
+
+	THUMB_FUNC_START sub_8028100
+sub_8028100: @ 0x08028100
+	ldr r1, _08028108  @ gUnknown_0203A018
+	movs r0, #0
+	str r0, [r1]
+	bx lr
+	.align 2, 0
+_08028108: .4byte gUnknown_0203A018
+
+	THUMB_FUNC_START HideUnitSMS
+HideUnitSMS: @ 0x0802810C
+	push {r4, lr}
+	adds r4, r0, #0
+	cmp r4, #0
+	bne _08028118
+	bl SMS_UpdateFromGameData
+_08028118:
+	ldr r2, [r4, #0x3c]
+	cmp r2, #0
+	beq _0802812A
+	ldrb r1, [r2, #0xb]
+	movs r3, #0x80
+	negs r3, r3
+	adds r0, r3, #0
+	orrs r0, r1
+	strb r0, [r2, #0xb]
+_0802812A:
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START ShowUnitSMS
+ShowUnitSMS: @ 0x08028130
+	push {lr}
+	ldr r2, [r0, #0x3c]
+	cmp r2, #0
+	beq _08028140
+	ldrb r1, [r2, #0xb]
+	movs r0, #0x7f
+	ands r0, r1
+	strb r0, [r2, #0xb]
+_08028140:
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START GetUnitStandingSpriteDataFlagThing
+GetUnitStandingSpriteDataFlagThing: @ 0x08028144
+	push {lr}
+	ldr r0, [r0, #0x3c]
+	cmp r0, #0
+	beq _0802815A
+	ldrb r1, [r0, #0xb]
+	movs r0, #0x80
+	negs r0, r0
+	ands r0, r1
+	lsls r0, r0, #0x18
+	lsrs r0, r0, #0x18
+	b _0802815C
+_0802815A:
+	movs r0, #0x80
+_0802815C:
+	pop {r1}
+	bx r1
+
+	THUMB_FUNC_START sub_8028160
+sub_8028160: @ 0x08028160
+	push {r4, r5, r6, r7, lr}
+	mov r7, r9
+	mov r6, r8
+	push {r6, r7}
+	mov r8, r0
+	adds r5, r1, #0
+	mov r9, r2
+	ldr r0, _080281C4  @ gUnknown_0859B73C
+	lsls r3, r3, #1
+	adds r3, r3, r0
+	ldrh r6, [r3]
+	movs r3, #0
+	cmp r3, r9
+	bge _080281B8
+	movs r0, #7
+	ands r0, r6
+	lsls r0, r0, #2
+	movs r1, #0xf
+	mov ip, r1
+	mov r7, ip
+	lsls r7, r0
+	mov ip, r7
+_0802818C:
+	adds r4, r3, #1
+	cmp r5, #0
+	ble _080281B2
+	mov r0, ip
+	mvns r2, r0
+	asrs r1, r6, #3
+	lsls r1, r1, #2
+	lsls r0, r3, #0xa
+	adds r3, r5, #0
+	adds r0, r0, r1
+	mov r7, r8
+	adds r1, r7, r0
+_080281A4:
+	ldr r0, [r1]
+	ands r0, r2
+	str r0, [r1]
+	adds r1, #0x20
+	subs r3, #1
+	cmp r3, #0
+	bne _080281A4
+_080281B2:
+	adds r3, r4, #0
+	cmp r3, r9
+	blt _0802818C
+_080281B8:
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080281C4: .4byte gUnknown_0859B73C
+
+.align 2, 0

--- a/asm/chapterintrofx.s
+++ b/asm/chapterintrofx.s
@@ -1,0 +1,2484 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ The screen with the chapter name and all
+
+	THUMB_FUNC_START sub_801FD90
+sub_801FD90: @ 0x0801FD90
+	push {lr}
+	bl GetGameClock
+	adds r2, r0, #0
+	lsrs r2, r2, #1
+	movs r0, #0xff
+	ands r2, r0
+	movs r0, #2
+	adds r1, r2, #0
+	bl BG_SetPosition
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_801FDAC
+sub_801FDAC: @ 0x0801FDAC
+	ldr r1, [r0, #0x14]
+	adds r1, #0x50
+	movs r2, #0
+	strh r2, [r1]
+	adds r0, #0x50
+	strh r2, [r0]
+	bx lr
+
+	THUMB_FUNC_START sub_801FDBC
+sub_801FDBC: @ 0x0801FDBC
+	push {r4, lr}
+	adds r4, r0, #0
+	ldr r0, _0801FE10  @ gKeyStatusPtr
+	ldr r0, [r0]
+	ldrh r1, [r0, #8]
+	movs r0, #0xb
+	ands r0, r1
+	cmp r0, #0
+	beq _0801FDE2
+	ldr r0, [r4, #0x14]
+	adds r1, r0, #0
+	adds r1, #0x52
+	ldrh r0, [r1]
+	cmp r0, #0
+	beq _0801FDDE
+	adds r1, r4, #0
+	adds r1, #0x50
+_0801FDDE:
+	movs r0, #1
+	strh r0, [r1]
+_0801FDE2:
+	adds r0, r4, #0
+	adds r0, #0x50
+	movs r1, #0
+	ldrsh r0, [r0, r1]
+	cmp r0, #0
+	beq _0801FE0A
+	ldr r2, [r4, #0x14]
+	adds r1, r2, #0
+	adds r1, #0x50
+	movs r3, #0
+	ldrsh r0, [r1, r3]
+	cmp r0, #0
+	beq _0801FE0A
+	adds r1, r0, #0
+	adds r0, r2, #0
+	bl Proc_GotoLabel
+	adds r0, r4, #0
+	bl Proc_Delete
+_0801FE0A:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801FE10: .4byte gKeyStatusPtr
+
+	THUMB_FUNC_START sub_801FE14
+sub_801FE14: @ 0x0801FE14
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #0x10
+	movs r0, #0x82
+	lsls r0, r0, #7
+	mov r9, r0
+	ldr r1, _0801FEE0  @ 0x00004110
+	mov r8, r1
+	movs r6, #0
+	ldr r7, _0801FEE4  @ gBG3TilemapBuffer
+	mov sl, r7
+_0801FE30:
+	movs r0, #0
+	str r0, [sp]
+	lsls r5, r6, #5
+	adds r2, r6, #0
+	adds r2, #0x10
+	adds r0, r6, #0
+	adds r0, #8
+	adds r4, r6, #0
+	adds r4, #0x18
+	adds r1, r6, #1
+	str r1, [sp, #4]
+	adds r5, #0x10
+	lsls r3, r2, #5
+	adds r3, #0x10
+	lsls r1, r0, #5
+	adds r1, #0x10
+	lsls r0, r0, #6
+	add r0, sl
+	mov ip, r0
+	lsls r2, r2, #6
+	add r2, sl
+	str r2, [sp, #0xc]
+	lsls r0, r6, #6
+	mov r6, sl
+	adds r2, r0, r6
+	lsls r0, r4, #5
+	adds r0, #0x10
+	str r0, [sp, #8]
+	lsls r4, r4, #6
+	add r4, sl
+	lsls r1, r1, #1
+	add r1, sl
+	lsls r3, r3, #1
+	add r3, sl
+	lsls r5, r5, #1
+	add r5, sl
+_0801FE78:
+	mov r7, r9
+	strh r7, [r2]
+	mov r0, r9
+	strh r0, [r5]
+	ldr r6, [sp, #0xc]
+	strh r0, [r6]
+	strh r0, [r3]
+	mov r0, r8
+	mov r7, ip
+	strh r0, [r7]
+	strh r0, [r1]
+	strh r0, [r4]
+	ldr r6, [sp, #8]
+	ldr r7, [sp]
+	adds r0, r6, r7
+	lsls r0, r0, #1
+	add r0, sl
+	mov r6, r8
+	strh r6, [r0]
+	movs r7, #1
+	add r9, r7
+	movs r0, #1
+	add r8, r0
+	movs r6, #2
+	add ip, r6
+	ldr r7, [sp, #0xc]
+	adds r7, #2
+	str r7, [sp, #0xc]
+	adds r2, #2
+	adds r4, #2
+	adds r1, #2
+	adds r3, #2
+	adds r5, #2
+	ldr r0, [sp]
+	adds r0, #1
+	str r0, [sp]
+	cmp r0, #0xf
+	ble _0801FE78
+	movs r1, #0x10
+	add r9, r1
+	add r8, r1
+	ldr r6, [sp, #4]
+	cmp r6, #7
+	ble _0801FE30
+	add sp, #0x10
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801FEE0: .4byte 0x00004110
+_0801FEE4: .4byte gBG3TilemapBuffer
+
+	THUMB_FUNC_START sub_801FEE8
+sub_801FEE8: @ 0x0801FEE8
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #0x14
+	movs r0, #0x82
+	lsls r0, r0, #7
+	mov r8, r0
+	ldr r1, _0801FFC8  @ 0x00004110
+	str r1, [sp, #0xc]
+	movs r2, #0
+	ldr r6, _0801FFCC  @ gBG2TilemapBuffer
+_0801FF02:
+	movs r5, #0
+	adds r0, r2, #0
+	adds r0, #0x10
+	adds r3, r2, #0
+	adds r3, #8
+	adds r4, r2, #0
+	adds r4, #0x18
+	adds r7, r2, #1
+	str r7, [sp, #8]
+	lsls r2, r2, #5
+	str r2, [sp]
+	adds r2, #0x1f
+	lsls r0, r0, #5
+	mov sl, r0
+	mov r1, sl
+	adds r1, #0x1f
+	lsls r3, r3, #5
+	mov r9, r3
+	mov r0, r9
+	adds r0, #0x1f
+	lsls r4, r4, #5
+	mov ip, r4
+	mov r3, ip
+	adds r3, #0x1f
+	str r3, [sp, #4]
+	lsls r0, r0, #1
+	adds r4, r0, r6
+	lsls r1, r1, #1
+	adds r3, r1, r6
+	lsls r2, r2, #1
+	adds r2, r2, r6
+_0801FF40:
+	ldr r0, [sp]
+	adds r0, #0xf
+	subs r0, r0, r5
+	lsls r0, r0, #1
+	adds r0, r0, r6
+	movs r1, #0x80
+	lsls r1, r1, #3
+	add r1, r8
+	strh r1, [r0]
+	strh r1, [r2]
+	mov r0, sl
+	adds r0, #0xf
+	subs r0, r0, r5
+	lsls r0, r0, #1
+	adds r0, r0, r6
+	strh r1, [r0]
+	strh r1, [r3]
+	mov r0, r9
+	adds r0, #0xf
+	subs r0, r0, r5
+	lsls r0, r0, #1
+	adds r0, r0, r6
+	str r0, [sp, #0x10]
+	ldr r7, [sp, #0xc]
+	movs r0, #0x80
+	lsls r0, r0, #3
+	adds r1, r7, r0
+	ldr r7, [sp, #0x10]
+	strh r1, [r7]
+	strh r1, [r4]
+	mov r0, ip
+	adds r0, #0xf
+	subs r0, r0, r5
+	lsls r0, r0, #1
+	adds r0, r0, r6
+	strh r1, [r0]
+	ldr r7, [sp, #4]
+	subs r0, r7, r5
+	lsls r0, r0, #1
+	adds r0, r0, r6
+	strh r1, [r0]
+	movs r0, #1
+	add r8, r0
+	ldr r1, [sp, #0xc]
+	adds r1, #1
+	str r1, [sp, #0xc]
+	subs r4, #2
+	subs r3, #2
+	subs r2, #2
+	adds r5, #1
+	cmp r5, #0xf
+	ble _0801FF40
+	movs r3, #0x10
+	add r8, r3
+	adds r1, #0x10
+	str r1, [sp, #0xc]
+	ldr r2, [sp, #8]
+	cmp r2, #7
+	ble _0801FF02
+	add sp, #0x14
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0801FFC8: .4byte 0x00004110
+_0801FFCC: .4byte gBG2TilemapBuffer
+
+	THUMB_FUNC_START sub_801FFD0
+sub_801FFD0: @ 0x0801FFD0
+	adds r0, #0x4c
+	movs r1, #0
+	strh r1, [r0]
+	bx lr
+
+	THUMB_FUNC_START sub_801FFD8
+sub_801FFD8: @ 0x0801FFD8
+	push {r4, lr}
+	adds r4, r0, #0
+	adds r4, #0x4c
+	ldrh r0, [r4]
+	adds r0, #1
+	strh r0, [r4]
+	movs r0, #0
+	ldrsh r1, [r4, r0]
+	lsrs r0, r1, #0x1f
+	adds r1, r1, r0
+	lsls r1, r1, #0xf
+	lsrs r1, r1, #0x10
+	movs r0, #1
+	movs r2, #0
+	bl BG_SetPosition
+	ldr r2, _0802000C  @ 0x0400001C
+	movs r1, #0
+	ldrsh r0, [r4, r1]
+	lsrs r1, r0, #0x1f
+	adds r0, r0, r1
+	asrs r0, r0, #1
+	strh r0, [r2]
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802000C: .4byte 0x0400001C
+
+	THUMB_FUNC_START sub_8020010
+sub_8020010: @ 0x08020010
+	push {r4, r5, r6, r7, lr}
+	adds r7, r0, #0
+	adds r5, r1, #0
+	adds r6, r2, #0
+	ldr r4, _08020084  @ gBG1TilemapBuffer
+	cmp r5, #0
+	bne _08020022
+	movs r5, #0xc0
+	lsls r5, r5, #0x13
+_08020022:
+	ldr r0, _08020088  @ gUnknown_08B1754C
+	lsls r1, r6, #5
+	movs r2, #0x40
+	bl CopyToPaletteBuffer
+	ldr r0, _0802008C  @ gUnknown_08B12DB4
+	adds r1, r5, #0
+	bl CopyDataWithPossibleUncomp
+	movs r1, #0xf
+	adds r0, r6, #0
+	ands r0, r1
+	lsls r2, r0, #0xc
+	adds r0, r6, #1
+	ands r0, r1
+	lsls r1, r0, #0xc
+	movs r3, #0
+_08020044:
+	adds r0, r3, r2
+	strh r0, [r4]
+	adds r4, #2
+	adds r3, #1
+	cmp r3, #0xdf
+	ble _08020044
+	ldr r5, _08020090  @ 0x0000019F
+	ldr r6, _08020094  @ gUnknown_0859B108
+	cmp r3, r5
+	bgt _08020064
+_08020058:
+	adds r0, r3, r1
+	strh r0, [r4]
+	adds r4, #2
+	adds r3, #1
+	cmp r3, r5
+	ble _08020058
+_08020064:
+	ldr r1, _08020098  @ 0x0000027F
+	cmp r3, r1
+	bgt _08020076
+_0802006A:
+	adds r0, r3, r2
+	strh r0, [r4]
+	adds r4, #2
+	adds r3, #1
+	cmp r3, r1
+	ble _0802006A
+_08020076:
+	adds r0, r6, #0
+	adds r1, r7, #0
+	bl Proc_Create
+	pop {r4, r5, r6, r7}
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08020084: .4byte gBG1TilemapBuffer
+_08020088: .4byte gUnknown_08B1754C
+_0802008C: .4byte gUnknown_08B12DB4
+_08020090: .4byte 0x0000019F
+_08020094: .4byte gUnknown_0859B108
+_08020098: .4byte 0x0000027F
+
+	THUMB_FUNC_START sub_802009C
+sub_802009C: @ 0x0802009C
+	push {r4, lr}
+	ldr r4, _080200EC  @ gLCDControlBuffer
+	ldrb r1, [r4]
+	movs r0, #8
+	negs r0, r0
+	ands r0, r1
+	strb r0, [r4]
+	movs r1, #0x80
+	lsls r1, r1, #8
+	movs r0, #2
+	bl SetBackgroundTileDataOffset
+	ldrb r2, [r4, #0xc]
+	movs r1, #4
+	negs r1, r1
+	adds r0, r1, #0
+	ands r0, r2
+	strb r0, [r4, #0xc]
+	ldrb r2, [r4, #0x10]
+	adds r0, r1, #0
+	ands r0, r2
+	movs r2, #2
+	orrs r0, r2
+	strb r0, [r4, #0x10]
+	ldrb r0, [r4, #0x14]
+	ands r1, r0
+	movs r0, #1
+	orrs r1, r0
+	strb r1, [r4, #0x14]
+	ldrb r0, [r4, #0x18]
+	movs r1, #3
+	orrs r0, r1
+	strb r0, [r4, #0x18]
+	ldrb r1, [r4, #0x15]
+	movs r0, #0x3f
+	ands r0, r1
+	strb r0, [r4, #0x15]
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080200EC: .4byte gLCDControlBuffer
+
+	THUMB_FUNC_START sub_80200F0
+sub_80200F0: @ 0x080200F0
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	mov sl, r0
+	movs r0, #0
+	bl SetupBackgrounds
+	ldr r7, _0802028C  @ gLCDControlBuffer
+	ldrb r1, [r7]
+	movs r0, #8
+	negs r0, r0
+	ands r0, r1
+	movs r1, #1
+	mov r9, r1
+	mov r2, r9
+	orrs r0, r2
+	strb r0, [r7]
+	ldrb r2, [r7, #0xc]
+	movs r1, #4
+	negs r1, r1
+	adds r0, r1, #0
+	ands r0, r2
+	strb r0, [r7, #0xc]
+	ldrb r2, [r7, #0x10]
+	adds r0, r1, #0
+	ands r0, r2
+	movs r4, #2
+	mov r8, r4
+	mov r2, r8
+	orrs r0, r2
+	strb r0, [r7, #0x10]
+	ldrb r2, [r7, #0x14]
+	adds r0, r1, #0
+	ands r0, r2
+	mov r4, r9
+	orrs r0, r4
+	strb r0, [r7, #0x14]
+	ldrb r0, [r7, #0x18]
+	ands r1, r0
+	mov r0, r8
+	orrs r1, r0
+	strb r1, [r7, #0x18]
+	ldrb r1, [r7, #1]
+	movs r0, #2
+	negs r0, r0
+	ands r0, r1
+	movs r1, #3
+	negs r1, r1
+	ands r0, r1
+	subs r1, #2
+	ands r0, r1
+	subs r1, #4
+	ands r0, r1
+	movs r6, #0x10
+	orrs r0, r6
+	strb r0, [r7, #1]
+	movs r0, #0
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	movs r0, #1
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	movs r0, #2
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	ldr r0, _08020290  @ gBG0TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	ldr r0, _08020294  @ gBG1TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	ldr r0, _08020298  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r1, #0x80
+	lsls r1, r1, #8
+	movs r0, #2
+	bl SetBackgroundTileDataOffset
+	ldrb r0, [r7, #1]
+	movs r5, #0x20
+	orrs r0, r5
+	movs r1, #0x41
+	negs r1, r1
+	ands r0, r1
+	movs r1, #0x7f
+	ands r0, r1
+	strb r0, [r7, #1]
+	ldr r2, _0802029C  @ gUnknown_030030B4
+	ldrb r1, [r2]
+	orrs r1, r4
+	mov r4, r8
+	orrs r1, r4
+	movs r3, #4
+	orrs r1, r3
+	movs r2, #8
+	orrs r1, r2
+	orrs r1, r6
+	movs r0, #0x36
+	adds r0, r0, r7
+	mov ip, r0
+	ldrb r0, [r0]
+	mov r4, r9
+	orrs r0, r4
+	mov r4, r8
+	orrs r0, r4
+	orrs r0, r3
+	orrs r0, r2
+	orrs r0, r6
+	orrs r1, r5
+	ldr r2, _0802029C  @ gUnknown_030030B4
+	strb r1, [r2]
+	orrs r0, r5
+	mov r4, ip
+	strb r0, [r4]
+	adds r0, r7, #0
+	adds r0, #0x2d
+	movs r4, #0
+	strb r4, [r0]
+	adds r0, #4
+	strb r4, [r0]
+	subs r0, #5
+	strb r4, [r0]
+	adds r0, #4
+	strb r4, [r0]
+	movs r0, #0
+	movs r1, #0
+	movs r2, #0
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	bl sub_8001710
+	movs r3, #1
+	negs r3, r3
+	movs r0, #0
+	movs r1, #2
+	movs r2, #0x40
+	bl sub_80017B4
+	bl sub_80D74B0
+	bl EnablePaletteSync
+	ldrb r1, [r7, #0x15]
+	movs r0, #0x3f
+	ands r0, r1
+	movs r1, #0x40
+	orrs r0, r1
+	orrs r0, r5
+	strb r0, [r7, #0x15]
+	ldr r0, _080202A0  @ gUnknown_08B17B64
+	ldr r1, _080202A4  @ 0x06008000
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _080202A8  @ gUnknown_08B18ED4
+	movs r1, #0
+	movs r2, #0x60
+	bl CopyToPaletteBuffer
+	ldr r1, _080202AC  @ gUnknown_08B18D68
+	ldr r0, _08020298  @ gBG2TilemapBuffer
+	movs r2, #0
+	movs r3, #5
+	bl sub_800154C
+	ldr r0, _080202B0  @ gUnknown_08B19874
+	ldr r1, _080202B4  @ 0x06014000
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _080202B8  @ gUnknown_08B19DEC
+	movs r1, #0x90
+	lsls r1, r1, #2
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	mov r0, sl
+	movs r1, #0
+	movs r2, #0xe
+	bl sub_8020010
+	movs r0, #6
+	bl BG_EnableSyncByMask
+	movs r0, #0x52
+	add sl, r0
+	mov r1, sl
+	strh r4, [r1]
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802028C: .4byte gLCDControlBuffer
+_08020290: .4byte gBG0TilemapBuffer
+_08020294: .4byte gBG1TilemapBuffer
+_08020298: .4byte gBG2TilemapBuffer
+_0802029C: .4byte gUnknown_030030B4
+_080202A0: .4byte gUnknown_08B17B64
+_080202A4: .4byte 0x06008000
+_080202A8: .4byte gUnknown_08B18ED4
+_080202AC: .4byte gUnknown_08B18D68
+_080202B0: .4byte gUnknown_08B19874
+_080202B4: .4byte 0x06014000
+_080202B8: .4byte gUnknown_08B19DEC
+
+	THUMB_FUNC_START sub_80202BC
+sub_80202BC: @ 0x080202BC
+	push {lr}
+	adds r2, r0, #0
+	adds r0, #0x4c
+	movs r1, #0
+	strh r1, [r0]
+	adds r0, #2
+	strh r1, [r0]
+	adds r0, #0x16
+	strh r1, [r0]
+	adds r0, #2
+	strh r1, [r0]
+	adds r1, r2, #0
+	adds r1, #0x68
+	movs r0, #3
+	strh r0, [r1]
+	ldr r0, _080202F0  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _080202EC
+	ldr r0, _080202F4  @ 0x00000316
+	bl m4aSongNumStart
+_080202EC:
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080202F0: .4byte gUnknown_0202BCF0
+_080202F4: .4byte 0x00000316
+
+	THUMB_FUNC_START sub_80202F8
+sub_80202F8: @ 0x080202F8
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #0x10
+	adds r7, r0, #0
+	adds r0, #0x4c
+	str r0, [sp, #4]
+	movs r1, #0
+	ldrsh r0, [r0, r1]
+	ldr r2, _08020490  @ gUnknown_0859B120
+	adds r1, r0, r2
+	ldrb r1, [r1]
+	adds r0, #1
+	adds r0, r0, r2
+	ldrb r2, [r0]
+	adds r3, r7, #0
+	adds r3, #0x4e
+	str r3, [sp, #8]
+	movs r4, #0
+	ldrsh r3, [r3, r4]
+	adds r5, r7, #0
+	adds r5, #0x68
+	str r5, [sp, #0xc]
+	movs r4, #0
+	ldrsh r0, [r5, r4]
+	str r0, [sp]
+	movs r0, #0
+	bl sub_8012DCC
+	str r0, [r7, #0x2c]
+	ldr r2, _08020494  @ gUnknown_0859B132
+	ldr r5, [sp, #4]
+	movs r1, #0
+	ldrsh r0, [r5, r1]
+	adds r1, r0, r2
+	ldrb r1, [r1]
+	adds r0, #1
+	adds r0, r0, r2
+	ldrb r2, [r0]
+	ldr r4, [sp, #8]
+	movs r5, #0
+	ldrsh r3, [r4, r5]
+	ldr r4, [sp, #0xc]
+	movs r5, #0
+	ldrsh r0, [r4, r5]
+	str r0, [sp]
+	movs r0, #0
+	bl sub_8012DCC
+	str r0, [r7, #0x30]
+	movs r0, #0x64
+	adds r0, r0, r7
+	mov sl, r0
+	movs r1, #0
+	ldrsh r0, [r0, r1]
+	cmp r0, #0x64
+	bgt _080203EE
+	movs r1, #0xa0
+	lsls r1, r1, #1
+	mov r2, sl
+	movs r4, #0
+	ldrsh r3, [r2, r4]
+	movs r0, #0x64
+	str r0, [sp]
+	movs r0, #4
+	movs r2, #0x40
+	bl sub_8012DCC
+	mov r8, r0
+	ldr r4, _08020498  @ gSinLookup
+	movs r5, #0x80
+	adds r5, r5, r4
+	mov r9, r5
+	movs r1, #0
+	ldrsh r0, [r5, r1]
+	lsls r0, r0, #4
+	mov r1, r8
+	bl Div
+	adds r6, r0, #0
+	lsls r6, r6, #0x10
+	asrs r6, r6, #0x10
+	movs r2, #0
+	ldrsh r0, [r4, r2]
+	negs r0, r0
+	lsls r0, r0, #4
+	mov r1, r8
+	bl Div
+	adds r5, r0, #0
+	lsls r5, r5, #0x10
+	asrs r5, r5, #0x10
+	movs r3, #0
+	ldrsh r0, [r4, r3]
+	lsls r0, r0, #4
+	mov r1, r8
+	bl Div
+	adds r4, r0, #0
+	lsls r4, r4, #0x10
+	asrs r4, r4, #0x10
+	mov r1, r9
+	movs r2, #0
+	ldrsh r0, [r1, r2]
+	lsls r0, r0, #4
+	mov r1, r8
+	bl Div
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x10
+	str r0, [sp]
+	movs r0, #0
+	adds r1, r6, #0
+	adds r2, r5, #0
+	adds r3, r4, #0
+	bl WriteOAMRotScaleData
+	mov r3, sl
+	ldrh r0, [r3]
+	adds r0, #1
+	strh r0, [r3]
+_080203EE:
+	ldr r0, [r7, #0x2c]
+	subs r0, #0x10
+	ldr r4, _0802049C  @ 0x000001FF
+	ands r0, r4
+	ldr r1, [r7, #0x30]
+	subs r1, #0x10
+	ands r1, r4
+	movs r5, #0x80
+	lsls r5, r5, #1
+	orrs r1, r5
+	ldr r6, _080204A0  @ gUnknown_08590F54
+	ldr r3, _080204A4  @ 0x00002210
+	adds r2, r6, #0
+	bl CallARM_PushToSecondaryOAM
+	ldr r1, [r7, #0x2c]
+	movs r0, #0xe0
+	subs r0, r0, r1
+	ands r0, r4
+	ldr r2, [r7, #0x30]
+	movs r1, #0x90
+	subs r1, r1, r2
+	ands r1, r4
+	orrs r1, r5
+	ldr r3, _080204A8  @ 0x00002214
+	adds r2, r6, #0
+	bl CallARM_PushToSecondaryOAM
+	ldr r4, [sp, #8]
+	ldrh r0, [r4]
+	adds r0, #1
+	strh r0, [r4]
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x10
+	ldr r5, [sp, #0xc]
+	movs r2, #0
+	ldrsh r1, [r5, r2]
+	cmp r0, r1
+	blt _08020480
+	movs r0, #0
+	strh r0, [r4]
+	ldr r3, [sp, #4]
+	ldrh r0, [r3]
+	adds r0, #1
+	strh r0, [r3]
+	adds r4, r7, #0
+	adds r4, #0x66
+	movs r5, #0
+	ldrsh r3, [r4, r5]
+	movs r0, #0x12
+	str r0, [sp]
+	movs r0, #0
+	movs r1, #3
+	movs r2, #8
+	bl sub_8012DCC
+	ldr r1, [sp, #0xc]
+	strh r0, [r1]
+	ldrh r0, [r4]
+	adds r0, #1
+	strh r0, [r4]
+	ldr r2, [sp, #4]
+	movs r3, #0
+	ldrsh r0, [r2, r3]
+	adds r0, #1
+	ldr r4, _08020490  @ gUnknown_0859B120
+	adds r0, r0, r4
+	ldrb r0, [r0]
+	cmp r0, #0
+	bne _08020480
+	adds r0, r7, #0
+	bl Proc_ClearNativeCallback
+_08020480:
+	add sp, #0x10
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08020490: .4byte gUnknown_0859B120
+_08020494: .4byte gUnknown_0859B132
+_08020498: .4byte gSinLookup
+_0802049C: .4byte 0x000001FF
+_080204A0: .4byte gUnknown_08590F54
+_080204A4: .4byte 0x00002210
+_080204A8: .4byte 0x00002214
+
+	THUMB_FUNC_START sub_80204AC
+sub_80204AC: @ 0x080204AC
+	adds r3, r0, #0
+	ldr r2, _080204E0  @ gLCDControlBuffer
+	ldrb r0, [r2, #1]
+	movs r1, #1
+	orrs r0, r1
+	movs r1, #2
+	orrs r0, r1
+	movs r1, #4
+	orrs r0, r1
+	movs r1, #9
+	negs r1, r1
+	ands r0, r1
+	movs r1, #0x10
+	orrs r0, r1
+	strb r0, [r2, #1]
+	adds r0, r3, #0
+	adds r0, #0x4c
+	movs r1, #0
+	strh r1, [r0]
+	adds r0, #0x18
+	strh r1, [r0]
+	adds r0, #2
+	strh r1, [r0]
+	adds r0, #2
+	strh r1, [r0]
+	bx lr
+	.align 2, 0
+_080204E0: .4byte gLCDControlBuffer
+
+	THUMB_FUNC_START sub_80204E4
+sub_80204E4: @ 0x080204E4
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #4
+	adds r4, r0, #0
+	adds r6, r1, #0
+	mov r8, r3
+	adds r4, #0x4c
+	movs r0, #0
+	ldrsh r3, [r4, r0]
+	movs r5, #0x46
+	str r5, [sp]
+	movs r0, #5
+	movs r1, #0x78
+	bl sub_8012DCC
+	adds r7, r0, #0
+	movs r2, #0
+	ldrsh r3, [r4, r2]
+	str r5, [sp]
+	movs r0, #5
+	movs r1, #0x50
+	mov r2, r8
+	bl sub_8012DCC
+	mov sl, r0
+	adds r0, r7, #0
+	subs r0, #8
+	ldr r4, _0802056C  @ 0x000001FF
+	ands r0, r4
+	lsls r6, r6, #9
+	orrs r0, r6
+	mov r1, sl
+	subs r1, #8
+	ands r1, r4
+	adds r5, #0xba
+	orrs r1, r5
+	ldr r2, _08020570  @ gUnknown_08590F4C
+	mov r8, r2
+	ldr r2, _08020574  @ 0x00002218
+	mov r9, r2
+	mov r2, r8
+	mov r3, r9
+	bl CallARM_PushToSecondaryOAM
+	movs r0, #0xe8
+	subs r0, r0, r7
+	ands r0, r4
+	orrs r0, r6
+	movs r1, #0x98
+	mov r2, sl
+	subs r1, r1, r2
+	ands r1, r4
+	orrs r1, r5
+	mov r2, r8
+	mov r3, r9
+	bl CallARM_PushToSecondaryOAM
+	add sp, #4
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802056C: .4byte 0x000001FF
+_08020570: .4byte gUnknown_08590F4C
+_08020574: .4byte 0x00002218
+
+	THUMB_FUNC_START sub_8020578
+sub_8020578: @ 0x08020578
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #4
+	mov sl, r0
+	movs r0, #0x64
+	add r0, sl
+	mov r9, r0
+	movs r1, #0
+	ldrsh r0, [r0, r1]
+	cmp r0, #0x46
+	bgt _08020614
+	movs r1, #0xa0
+	lsls r1, r1, #1
+	mov r2, r9
+	movs r0, #0
+	ldrsh r3, [r2, r0]
+	movs r0, #0x46
+	str r0, [sp]
+	movs r0, #4
+	movs r2, #0x10
+	bl sub_8012DCC
+	adds r7, r0, #0
+	ldr r4, _08020774  @ gSinLookup
+	movs r1, #0x80
+	adds r1, r1, r4
+	mov r8, r1
+	movs r2, #0
+	ldrsh r0, [r1, r2]
+	lsls r0, r0, #4
+	adds r1, r7, #0
+	bl Div
+	adds r6, r0, #0
+	lsls r6, r6, #0x10
+	asrs r6, r6, #0x10
+	movs r1, #0
+	ldrsh r0, [r4, r1]
+	negs r0, r0
+	lsls r0, r0, #4
+	adds r1, r7, #0
+	bl Div
+	adds r5, r0, #0
+	lsls r5, r5, #0x10
+	asrs r5, r5, #0x10
+	movs r2, #0
+	ldrsh r0, [r4, r2]
+	lsls r0, r0, #4
+	adds r1, r7, #0
+	bl Div
+	adds r4, r0, #0
+	lsls r4, r4, #0x10
+	asrs r4, r4, #0x10
+	mov r1, r8
+	movs r2, #0
+	ldrsh r0, [r1, r2]
+	lsls r0, r0, #4
+	adds r1, r7, #0
+	bl Div
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x10
+	str r0, [sp]
+	movs r0, #1
+	adds r1, r6, #0
+	adds r2, r5, #0
+	adds r3, r4, #0
+	bl WriteOAMRotScaleData
+	mov r1, r9
+	ldrh r0, [r1]
+	adds r0, #1
+	strh r0, [r1]
+_08020614:
+	mov r0, sl
+	movs r1, #1
+	movs r2, #0xd7
+	movs r3, #0x11
+	bl sub_80204E4
+	movs r2, #0x66
+	add r2, sl
+	mov r9, r2
+	movs r1, #0
+	ldrsh r0, [r2, r1]
+	cmp r0, #0x46
+	bgt _080206AA
+	movs r1, #0xa0
+	lsls r1, r1, #1
+	adds r3, r0, #0
+	movs r0, #0x46
+	str r0, [sp]
+	movs r0, #4
+	movs r2, #0x10
+	bl sub_8012DCC
+	adds r7, r0, #0
+	ldr r4, _08020774  @ gSinLookup
+	movs r1, #0x80
+	adds r1, r1, r4
+	mov r8, r1
+	movs r2, #0
+	ldrsh r0, [r1, r2]
+	lsls r0, r0, #4
+	adds r1, r7, #0
+	bl Div
+	adds r6, r0, #0
+	lsls r6, r6, #0x10
+	asrs r6, r6, #0x10
+	movs r1, #0
+	ldrsh r0, [r4, r1]
+	negs r0, r0
+	lsls r0, r0, #4
+	adds r1, r7, #0
+	bl Div
+	adds r5, r0, #0
+	lsls r5, r5, #0x10
+	asrs r5, r5, #0x10
+	movs r2, #0
+	ldrsh r0, [r4, r2]
+	lsls r0, r0, #4
+	adds r1, r7, #0
+	bl Div
+	adds r4, r0, #0
+	lsls r4, r4, #0x10
+	asrs r4, r4, #0x10
+	mov r1, r8
+	movs r2, #0
+	ldrsh r0, [r1, r2]
+	lsls r0, r0, #4
+	adds r1, r7, #0
+	bl Div
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x10
+	str r0, [sp]
+	movs r0, #2
+	adds r1, r6, #0
+	adds r2, r5, #0
+	adds r3, r4, #0
+	bl WriteOAMRotScaleData
+	mov r1, r9
+	ldrh r0, [r1]
+	adds r0, #1
+	strh r0, [r1]
+_080206AA:
+	mov r0, sl
+	movs r1, #2
+	movs r2, #0xc0
+	movs r3, #0x20
+	bl sub_80204E4
+	movs r2, #0x68
+	add r2, sl
+	mov r9, r2
+	movs r1, #0
+	ldrsh r0, [r2, r1]
+	cmp r0, #0x46
+	bgt _08020740
+	movs r1, #0xa0
+	lsls r1, r1, #1
+	adds r3, r0, #0
+	movs r0, #0x46
+	str r0, [sp]
+	movs r0, #4
+	movs r2, #0x10
+	bl sub_8012DCC
+	adds r7, r0, #0
+	ldr r4, _08020774  @ gSinLookup
+	movs r1, #0x80
+	adds r1, r1, r4
+	mov r8, r1
+	movs r2, #0
+	ldrsh r0, [r1, r2]
+	lsls r0, r0, #4
+	adds r1, r7, #0
+	bl Div
+	adds r6, r0, #0
+	lsls r6, r6, #0x10
+	asrs r6, r6, #0x10
+	movs r1, #0
+	ldrsh r0, [r4, r1]
+	negs r0, r0
+	lsls r0, r0, #4
+	adds r1, r7, #0
+	bl Div
+	adds r5, r0, #0
+	lsls r5, r5, #0x10
+	asrs r5, r5, #0x10
+	movs r2, #0
+	ldrsh r0, [r4, r2]
+	lsls r0, r0, #4
+	adds r1, r7, #0
+	bl Div
+	adds r4, r0, #0
+	lsls r4, r4, #0x10
+	asrs r4, r4, #0x10
+	mov r1, r8
+	movs r2, #0
+	ldrsh r0, [r1, r2]
+	lsls r0, r0, #4
+	adds r1, r7, #0
+	bl Div
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x10
+	str r0, [sp]
+	movs r0, #3
+	adds r1, r6, #0
+	adds r2, r5, #0
+	adds r3, r4, #0
+	bl WriteOAMRotScaleData
+	mov r1, r9
+	ldrh r0, [r1]
+	adds r0, #1
+	strh r0, [r1]
+_08020740:
+	mov r0, sl
+	movs r1, #3
+	movs r2, #0xa9
+	movs r3, #0x2f
+	bl sub_80204E4
+	mov r1, sl
+	adds r1, #0x4c
+	ldrh r0, [r1]
+	adds r0, #1
+	strh r0, [r1]
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x10
+	cmp r0, #0x45
+	ble _08020764
+	mov r0, sl
+	bl Proc_ClearNativeCallback
+_08020764:
+	add sp, #4
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08020774: .4byte gSinLookup
+
+	THUMB_FUNC_START sub_8020778
+sub_8020778: @ 0x08020778
+	push {r4, r5, lr}
+	ldr r4, _080207BC  @ gBG0TilemapBuffer
+	movs r1, #0x94
+	lsls r1, r1, #5
+	adds r0, r4, #0
+	bl BG_Fill
+	movs r0, #8
+	movs r1, #5
+	bl sub_80895B4
+	ldr r0, _080207C0  @ gUnknown_0202BCF0
+	bl sub_808979C
+	adds r5, r0, #0
+	movs r0, #0xa0
+	lsls r0, r0, #2
+	adds r1, r5, #0
+	bl sub_808966C
+	ldr r0, _080207C4  @ 0x00000246
+	adds r4, r4, r0
+	adds r0, r4, #0
+	movs r1, #5
+	adds r2, r5, #0
+	bl sub_80896FC
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080207BC: .4byte gBG0TilemapBuffer
+_080207C0: .4byte gUnknown_0202BCF0
+_080207C4: .4byte 0x00000246
+
+	THUMB_FUNC_START sub_80207C8
+sub_80207C8: @ 0x080207C8
+	push {r4, r5, lr}
+	ldr r4, _080207F0  @ gUnknown_0859B144
+	movs r5, #0x88
+	lsls r5, r5, #6
+	movs r0, #0
+	movs r1, #0x40
+	adds r2, r4, #0
+	adds r3, r5, #0
+	bl CallARM_PushToSecondaryOAM
+	movs r0, #0
+	movs r1, #0x40
+	adds r2, r4, #0
+	adds r3, r5, #0
+	bl CallARM_PushToSecondaryOAM
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080207F0: .4byte gUnknown_0859B144
+
+	THUMB_FUNC_START sub_80207F4
+sub_80207F4: @ 0x080207F4
+	adds r2, r0, #0
+	adds r0, #0x4c
+	movs r1, #0
+	strh r1, [r0]
+	adds r0, #2
+	strh r1, [r0]
+	adds r0, #0x18
+	strh r1, [r0]
+	bx lr
+
+	THUMB_FUNC_START sub_8020808
+sub_8020808: @ 0x08020808
+	push {r4, r5, r6, r7, lr}
+	sub sp, #8
+	adds r7, r0, #0
+	adds r0, #0x66
+	movs r1, #0
+	ldrsh r0, [r0, r1]
+	cmp r0, #0
+	bne _0802082E
+	adds r4, r7, #0
+	adds r4, #0x4e
+	ldrb r2, [r4]
+	movs r0, #1
+	movs r1, #0x10
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	ldrh r0, [r4]
+	adds r0, #1
+	b _0802084A
+_0802082E:
+	adds r4, r7, #0
+	adds r4, #0x4e
+	ldrh r1, [r4]
+	lsls r1, r1, #0x10
+	asrs r1, r1, #0x11
+	lsls r1, r1, #0x18
+	lsrs r1, r1, #0x18
+	movs r0, #1
+	movs r2, #0x10
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	ldrh r0, [r4]
+	subs r0, #1
+_0802084A:
+	strh r0, [r4]
+	adds r5, r4, #0
+	adds r4, r7, #0
+	adds r4, #0x4c
+	movs r1, #0
+	ldrsh r0, [r4, r1]
+	adds r6, r7, #0
+	adds r6, #0x66
+	cmp r0, #0xff
+	bgt _080208A4
+	movs r0, #0xc0
+	lsls r0, r0, #1
+	str r0, [sp]
+	str r0, [sp, #4]
+	movs r0, #2
+	movs r1, #0
+	movs r2, #0
+	movs r3, #0
+	bl sub_80ADDFC
+	ldrh r2, [r4]
+	adds r2, #0xf0
+	lsls r2, r2, #0x10
+	asrs r2, r2, #0x10
+	movs r0, #2
+	adds r1, r2, #0
+	bl sub_80ADE90
+	movs r0, #0x4c
+	str r0, [sp]
+	movs r0, #2
+	movs r1, #0x70
+	movs r2, #0x58
+	movs r3, #0x4c
+	bl sub_80ADEE0
+	bl FlushLCDControl
+	movs r1, #0
+	ldrsh r0, [r6, r1]
+	cmp r0, #0
+	beq _080208AC
+	ldrh r0, [r4]
+	adds r0, #4
+	strh r0, [r4]
+_080208A4:
+	movs r1, #0
+	ldrsh r0, [r6, r1]
+	cmp r0, #0
+	bne _080208CC
+_080208AC:
+	movs r1, #0
+	ldrsh r0, [r5, r1]
+	cmp r0, #0xf
+	ble _080208EC
+	movs r0, #0x20
+	strh r0, [r5]
+	movs r0, #1
+	movs r1, #0x10
+	movs r2, #0x10
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	ldrh r0, [r6]
+	adds r0, #1
+	strh r0, [r6]
+	b _080208EC
+_080208CC:
+	movs r1, #0
+	ldrsh r0, [r5, r1]
+	cmp r0, #0
+	bgt _080208EC
+	movs r0, #1
+	movs r1, #0
+	movs r2, #0x10
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	ldr r0, _080208F4  @ gUnknown_0859B180
+	bl Proc_DeleteAllWithScript
+	adds r0, r7, #0
+	bl Proc_ClearNativeCallback
+_080208EC:
+	add sp, #8
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080208F4: .4byte gUnknown_0859B180
+
+	THUMB_FUNC_START sub_80208F8
+sub_80208F8: @ 0x080208F8
+	push {r4, lr}
+	sub sp, #4
+	ldr r2, _08020940  @ gLCDControlBuffer
+	ldrb r1, [r2, #1]
+	movs r0, #2
+	negs r0, r0
+	ands r0, r1
+	movs r1, #2
+	orrs r0, r1
+	movs r1, #4
+	orrs r0, r1
+	movs r1, #9
+	negs r1, r1
+	ands r0, r1
+	movs r1, #0x10
+	orrs r0, r1
+	strb r0, [r2, #1]
+	movs r4, #0
+	str r4, [sp]
+	movs r0, #0
+	movs r1, #0
+	movs r2, #1
+	movs r3, #0
+	bl sub_8001ED0
+	str r4, [sp]
+	movs r0, #0
+	movs r1, #1
+	movs r2, #0
+	movs r3, #0
+	bl sub_8001F0C
+	add sp, #4
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08020940: .4byte gLCDControlBuffer
+
+	THUMB_FUNC_START sub_8020944
+sub_8020944: @ 0x08020944
+	push {r4, lr}
+	sub sp, #4
+	ldr r3, _080209BC  @ gLCDControlBuffer
+	ldrb r1, [r3, #1]
+	movs r2, #1
+	orrs r1, r2
+	movs r2, #2
+	orrs r1, r2
+	movs r2, #4
+	orrs r1, r2
+	movs r2, #9
+	negs r2, r2
+	ands r1, r2
+	movs r2, #0x10
+	orrs r1, r2
+	strb r1, [r3, #1]
+	adds r0, #0x4c
+	movs r4, #0
+	strh r4, [r0]
+	str r4, [sp]
+	movs r0, #0
+	movs r1, #0
+	movs r2, #1
+	movs r3, #0
+	bl sub_8001ED0
+	str r4, [sp]
+	movs r0, #0
+	movs r1, #1
+	movs r2, #0
+	movs r3, #0
+	bl sub_8001F0C
+	ldr r0, _080209C0  @ gUnknown_08B18F34
+	ldr r1, _080209C4  @ 0x06008000
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _080209C8  @ gUnknown_08B19854
+	movs r1, #0x80
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	ldr r0, _080209CC  @ gUnknown_08B196D8
+	ldr r4, _080209D0  @ gUnknown_02020188
+	adds r1, r4, #0
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _080209D4  @ gBG2TilemapBuffer
+	movs r2, #0x80
+	lsls r2, r2, #7
+	adds r1, r4, #0
+	bl CallARM_FillTileRect
+	movs r0, #4
+	bl BG_EnableSyncByMask
+	add sp, #4
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080209BC: .4byte gLCDControlBuffer
+_080209C0: .4byte gUnknown_08B18F34
+_080209C4: .4byte 0x06008000
+_080209C8: .4byte gUnknown_08B19854
+_080209CC: .4byte gUnknown_08B196D8
+_080209D0: .4byte gUnknown_02020188
+_080209D4: .4byte gBG2TilemapBuffer
+
+	THUMB_FUNC_START sub_80209D8
+sub_80209D8: @ 0x080209D8
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	adds r4, r5, #0
+	adds r4, #0x4c
+	ldrb r1, [r4]
+	movs r0, #1
+	movs r2, #0x10
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	adds r0, r5, #0
+	adds r0, #0x50
+	movs r1, #0
+	ldrsh r0, [r0, r1]
+	cmp r0, #3
+	beq _08020A04
+	bl GetGameClock
+	movs r1, #3
+	ands r1, r0
+	cmp r1, #0
+	bne _08020A38
+_08020A04:
+	adds r0, r5, #0
+	adds r0, #0x52
+	ldrh r0, [r0]
+	cmp r0, #0
+	beq _08020A14
+	ldrh r0, [r4]
+	adds r0, #4
+	b _08020A18
+_08020A14:
+	ldrh r0, [r4]
+	adds r0, #1
+_08020A18:
+	strh r0, [r4]
+	adds r0, r5, #0
+	adds r0, #0x4c
+	movs r1, #0
+	ldrsh r0, [r0, r1]
+	cmp r0, #5
+	ble _08020A38
+	movs r0, #1
+	movs r1, #6
+	movs r2, #0x10
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	adds r0, r5, #0
+	bl Proc_ClearNativeCallback
+_08020A38:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_8020A40
+sub_8020A40: @ 0x08020A40
+	push {r4, r5, lr}
+	adds r0, #0x4c
+	movs r1, #0x1e
+	strh r1, [r0]
+	bl sub_8001710
+	ldr r4, _08020A88  @ gUnknown_02022928
+	movs r5, #1
+	negs r5, r5
+	adds r0, r4, #0
+	movs r1, #4
+	movs r2, #2
+	adds r3, r5, #0
+	bl sub_800172C
+	movs r1, #0xa0
+	lsls r1, r1, #1
+	adds r0, r4, r1
+	movs r1, #0xe
+	movs r2, #2
+	adds r3, r5, #0
+	bl sub_800172C
+	movs r0, #0xe0
+	lsls r0, r0, #1
+	adds r4, r4, r0
+	adds r0, r4, #0
+	movs r1, #0x12
+	movs r2, #1
+	adds r3, r5, #0
+	bl sub_800172C
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08020A88: .4byte gUnknown_02022928
+
+	THUMB_FUNC_START sub_8020A8C
+sub_8020A8C: @ 0x08020A8C
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	bl GetGameClock
+	adds r4, r0, #0
+	movs r0, #3
+	ands r4, r0
+	cmp r4, #0
+	bne _08020AE8
+	bl sub_80D74B0
+	bl EnablePaletteSync
+	adds r1, r5, #0
+	adds r1, #0x4c
+	ldrh r0, [r1]
+	subs r0, #1
+	strh r0, [r1]
+	lsls r0, r0, #0x10
+	cmp r0, #0
+	bge _08020AE8
+	ldr r2, _08020AF0  @ gLCDControlBuffer
+	ldrb r0, [r2, #1]
+	movs r1, #1
+	orrs r0, r1
+	movs r1, #3
+	negs r1, r1
+	ands r0, r1
+	subs r1, #2
+	ands r0, r1
+	subs r1, #4
+	ands r0, r1
+	movs r1, #0x10
+	orrs r0, r1
+	strb r0, [r2, #1]
+	movs r0, #2
+	movs r1, #0
+	bl SetBackgroundTileDataOffset
+	ldr r0, _08020AF4  @ gPaletteBuffer
+	strh r4, [r0]
+	bl EnablePaletteSync
+	adds r0, r5, #0
+	bl Proc_ClearNativeCallback
+_08020AE8:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08020AF0: .4byte gLCDControlBuffer
+_08020AF4: .4byte gPaletteBuffer
+
+	THUMB_FUNC_START sub_8020AF8
+sub_8020AF8: @ 0x08020AF8
+	push {lr}
+	movs r0, #0
+	bl SetupBackgrounds
+	bl sub_80156D4
+	ldr r0, _08020B1C  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0x15]
+	bl SetupOAMSpliceForWeather
+	bl SMS_UpdateFromGameData
+	bl SMS_FlushIndirect
+	bl Font_LoadForUI
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08020B1C: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START sub_8020B20
+sub_8020B20: @ 0x08020B20
+	ldr r1, _08020B2C  @ gUnknown_0202BCB0
+	movs r0, #0xa0
+	lsls r0, r0, #2
+	strh r0, [r1, #0xe]
+	bx lr
+	.align 2, 0
+_08020B2C: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_8020B30
+sub_8020B30: @ 0x08020B30
+	push {r4, r5, lr}
+	sub sp, #8
+	ldr r2, _08020C10  @ gLCDControlBuffer
+	ldrb r0, [r2, #1]
+	movs r1, #1
+	orrs r0, r1
+	movs r1, #2
+	orrs r0, r1
+	movs r1, #4
+	orrs r0, r1
+	movs r1, #8
+	orrs r0, r1
+	movs r1, #0x10
+	orrs r0, r1
+	strb r0, [r2, #1]
+	movs r0, #1
+	movs r1, #0x10
+	movs r2, #0
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	movs r4, #0
+	str r4, [sp]
+	movs r0, #0
+	movs r1, #1
+	movs r2, #0
+	movs r3, #0
+	bl sub_8001ED0
+	movs r0, #1
+	str r0, [sp]
+	movs r0, #0
+	movs r1, #0
+	movs r2, #0
+	movs r3, #1
+	bl sub_8001F0C
+	movs r0, #1
+	bl sub_8001F64
+	str r4, [sp, #4]
+	movs r1, #0xc0
+	lsls r1, r1, #0x13
+	ldr r2, _08020C14  @ 0x01000008
+	add r0, sp, #4
+	bl CpuFastSet
+	ldr r0, _08020C18  @ gBG0TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	ldr r0, _08020C1C  @ gBG1TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	ldr r0, _08020C20  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #7
+	bl BG_EnableSyncByMask
+	bl sub_8030C24
+	ldr r4, _08020C24  @ gUnknown_0202BCF0
+	movs r0, #0xe
+	ldrsb r0, [r4, r0]
+	bl LoadChapterMapGfx
+	bl SetupMapSpritesPalettes
+	bl LoadObjUIGfx
+	movs r0, #0xe
+	ldrsb r0, [r4, r0]
+	bl GetROMChapterStruct
+	ldrb r0, [r0, #0x10]
+	lsls r0, r0, #4
+	bl sub_8015A40
+	lsls r0, r0, #0x10
+	lsrs r0, r0, #0x10
+	adds r0, #0xf
+	movs r1, #0xf8
+	lsls r1, r1, #1
+	ands r0, r1
+	ldr r5, _08020C28  @ gUnknown_0202BCB0
+	strh r0, [r5, #0xc]
+	movs r0, #0xe
+	ldrsb r0, [r4, r0]
+	bl GetROMChapterStruct
+	ldrb r0, [r0, #0x11]
+	lsls r0, r0, #4
+	bl sub_8015A6C
+	lsls r0, r0, #0x10
+	lsrs r0, r0, #0x10
+	adds r0, #0xf
+	movs r1, #0xfc
+	lsls r1, r1, #2
+	ands r0, r1
+	strh r0, [r5, #0xe]
+	bl RefreshFogAndUnitMaps
+	bl UpdateGameTilesGraphics
+	add sp, #8
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08020C10: .4byte gLCDControlBuffer
+_08020C14: .4byte 0x01000008
+_08020C18: .4byte gBG0TilemapBuffer
+_08020C1C: .4byte gBG1TilemapBuffer
+_08020C20: .4byte gBG2TilemapBuffer
+_08020C24: .4byte gUnknown_0202BCF0
+_08020C28: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_8020C2C
+sub_8020C2C: @ 0x08020C2C
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	bl sub_8001710
+	ldr r5, _08020C9C  @ gUnknown_02022968
+	adds r0, r5, #0
+	movs r1, #6
+	movs r2, #0xa
+	movs r3, #1
+	bl sub_800172C
+	movs r1, #0xa0
+	lsls r1, r1, #2
+	adds r0, r5, r1
+	movs r1, #0x1a
+	movs r2, #6
+	movs r3, #1
+	bl sub_800172C
+	movs r1, #0xa0
+	lsls r1, r1, #1
+	adds r0, r5, r1
+	movs r1, #0x10
+	movs r2, #2
+	movs r3, #1
+	bl sub_800172C
+	movs r1, #0x88
+	lsls r1, r1, #2
+	adds r0, r5, r1
+	movs r1, #0x17
+	movs r2, #1
+	movs r3, #1
+	bl sub_800172C
+	bl sub_80D74B0
+	bl EnablePaletteSync
+	adds r4, #0x4c
+	movs r0, #0x1e
+	strh r0, [r4]
+	ldr r0, _08020CA0  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xe]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	bl GetROMChapterStruct
+	ldrb r0, [r0, #0x12]
+	cmp r0, #5
+	bne _08020C96
+	bl sub_8030758
+_08020C96:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08020C9C: .4byte gUnknown_02022968
+_08020CA0: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START sub_8020CA4
+sub_8020CA4: @ 0x08020CA4
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	bl GetGameClock
+	adds r4, r0, #0
+	movs r0, #1
+	ands r4, r0
+	cmp r4, #0
+	beq _08020CB8
+	b _08020DAE
+_08020CB8:
+	bl sub_80D74B0
+	ldr r5, _08020D30  @ gUnknown_0202BCF0
+	movs r0, #0xe
+	ldrsb r0, [r5, r0]
+	bl GetROMChapterStruct
+	ldrb r0, [r0, #0x12]
+	cmp r0, #5
+	bne _08020CD0
+	bl sub_8030758
+_08020CD0:
+	bl GetChapterThing
+	cmp r0, #2
+	beq _08020CE8
+	movs r0, #0xe
+	ldrsb r0, [r5, r0]
+	bl GetROMChapterStruct
+	adds r0, #0x87
+	ldrb r0, [r0]
+	cmp r0, #0
+	beq _08020D3C
+_08020CE8:
+	movs r0, #0xe
+	ldrsb r0, [r5, r0]
+	bl GetROMChapterStruct
+	ldrh r1, [r0, #0x28]
+	ldr r0, _08020D34  @ 0x0000FFFF
+	cmp r1, r0
+	beq _08020D08
+	movs r0, #0xe
+	ldrsb r0, [r5, r0]
+	bl GetROMChapterStruct
+	ldrh r0, [r0, #0x28]
+	movs r1, #0
+	bl Sound_PlaySong80024D4
+_08020D08:
+	adds r3, r6, #0
+	adds r3, #0x4c
+	strh r4, [r3]
+	ldr r2, _08020D38  @ gLCDControlBuffer
+	ldrb r0, [r2, #1]
+	movs r1, #1
+	orrs r0, r1
+	movs r1, #2
+	orrs r0, r1
+	movs r1, #4
+	orrs r0, r1
+	movs r1, #9
+	negs r1, r1
+	ands r0, r1
+	subs r1, #8
+	ands r0, r1
+	strb r0, [r2, #1]
+	adds r4, r3, #0
+	b _08020D6C
+	.align 2, 0
+_08020D30: .4byte gUnknown_0202BCF0
+_08020D34: .4byte 0x0000FFFF
+_08020D38: .4byte gLCDControlBuffer
+_08020D3C:
+	bl EnablePaletteSync
+	adds r0, r6, #0
+	adds r0, #0x4c
+	movs r1, #0
+	ldrsh r2, [r0, r1]
+	adds r1, r2, #7
+	adds r4, r0, #0
+	cmp r1, #0
+	bge _08020D52
+	adds r1, #7
+_08020D52:
+	asrs r0, r1, #3
+	adds r1, r0, #0
+	adds r1, #0xc
+	lsls r1, r1, #0x18
+	lsrs r1, r1, #0x18
+	movs r2, #4
+	subs r2, r2, r0
+	lsls r2, r2, #0x18
+	lsrs r2, r2, #0x18
+	movs r0, #1
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+_08020D6C:
+	ldrh r0, [r4]
+	subs r0, #1
+	strh r0, [r4]
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x10
+	cmp r0, #0x18
+	bne _08020D9C
+	ldr r5, _08020DB4  @ gUnknown_0202BCF0
+	movs r0, #0xe
+	ldrsb r0, [r5, r0]
+	bl GetROMChapterStruct
+	ldrh r1, [r0, #0x28]
+	ldr r0, _08020DB8  @ 0x0000FFFF
+	cmp r1, r0
+	beq _08020D9C
+	movs r0, #0xe
+	ldrsb r0, [r5, r0]
+	bl GetROMChapterStruct
+	ldrh r0, [r0, #0x28]
+	movs r1, #0
+	bl Sound_PlaySong80024D4
+_08020D9C:
+	movs r1, #0
+	ldrsh r0, [r4, r1]
+	cmp r0, #0
+	bge _08020DAE
+	bl sub_8030C40
+	adds r0, r6, #0
+	bl Proc_ClearNativeCallback
+_08020DAE:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08020DB4: .4byte gUnknown_0202BCF0
+_08020DB8: .4byte 0x0000FFFF
+
+	THUMB_FUNC_START sub_8020DBC
+sub_8020DBC: @ 0x08020DBC
+	adds r0, #0x4c
+	movs r1, #0
+	strh r1, [r0]
+	ldr r2, _08020DE4  @ gLCDControlBuffer
+	adds r2, #0x36
+	ldrb r0, [r2]
+	movs r1, #1
+	orrs r0, r1
+	movs r1, #2
+	orrs r0, r1
+	movs r1, #4
+	orrs r0, r1
+	movs r1, #8
+	orrs r0, r1
+	movs r1, #0x11
+	negs r1, r1
+	ands r0, r1
+	strb r0, [r2]
+	bx lr
+	.align 2, 0
+_08020DE4: .4byte gLCDControlBuffer
+
+	THUMB_FUNC_START sub_8020DE8
+sub_8020DE8: @ 0x08020DE8
+	push {r4, r5, r6, lr}
+	sub sp, #4
+	adds r5, r0, #0
+	adds r4, r5, #0
+	adds r4, #0x4c
+	movs r0, #0
+	ldrsh r3, [r4, r0]
+	movs r0, #0x28
+	str r0, [sp]
+	movs r0, #5
+	movs r1, #0
+	movs r2, #0x78
+	bl sub_8012DCC
+	ldr r3, _08020E44  @ gLCDControlBuffer
+	movs r1, #0x78
+	subs r1, r1, r0
+	movs r2, #0x2d
+	adds r2, r2, r3
+	mov ip, r2
+	movs r2, #0
+	mov r6, ip
+	strb r1, [r6]
+	adds r1, r3, #0
+	adds r1, #0x31
+	strb r2, [r1]
+	adds r0, #0x78
+	subs r1, #5
+	strb r0, [r1]
+	adds r1, #4
+	movs r0, #0xa0
+	strb r0, [r1]
+	ldrh r0, [r4]
+	adds r0, #1
+	strh r0, [r4]
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x10
+	cmp r0, #0x28
+	ble _08020E3C
+	adds r0, r5, #0
+	bl Proc_ClearNativeCallback
+_08020E3C:
+	add sp, #4
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08020E44: .4byte gLCDControlBuffer
+
+	THUMB_FUNC_START sub_8020E48
+sub_8020E48: @ 0x08020E48
+	push {r4, r5, r6, lr}
+	adds r5, r0, #0
+	movs r0, #4
+	bl Sound_FadeOut800231C
+	bl sub_8001710
+	ldr r6, _08020EA8  @ gPaletteBuffer
+	movs r4, #2
+	negs r4, r4
+	adds r0, r6, #0
+	movs r1, #0
+	movs r2, #3
+	adds r3, r4, #0
+	bl sub_800172C
+	adds r0, r6, #0
+	adds r0, #0x80
+	movs r1, #4
+	movs r2, #2
+	adds r3, r4, #0
+	bl sub_800172C
+	movs r1, #0xe0
+	lsls r1, r1, #1
+	adds r0, r6, r1
+	movs r1, #0xe
+	movs r2, #2
+	adds r3, r4, #0
+	bl sub_800172C
+	movs r1, #0x90
+	lsls r1, r1, #2
+	adds r0, r6, r1
+	movs r1, #0x12
+	movs r2, #1
+	adds r3, r4, #0
+	bl sub_800172C
+	adds r5, #0x4c
+	movs r0, #0xf
+	strh r0, [r5]
+	movs r0, #1
+	bl SoundStuff_80023E0
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08020EA8: .4byte gPaletteBuffer
+
+	THUMB_FUNC_START sub_8020EAC
+sub_8020EAC: @ 0x08020EAC
+	push {r4, lr}
+	adds r4, r0, #0
+	bl sub_80D74B0
+	bl EnablePaletteSync
+	adds r1, r4, #0
+	adds r1, #0x4c
+	ldrh r0, [r1]
+	subs r0, #1
+	strh r0, [r1]
+	lsls r0, r0, #0x10
+	cmp r0, #0
+	bge _08020EF4
+	ldr r2, _08020EFC  @ gLCDControlBuffer
+	ldrb r1, [r2, #1]
+	movs r0, #2
+	negs r0, r0
+	ands r0, r1
+	movs r1, #3
+	negs r1, r1
+	ands r0, r1
+	subs r1, #2
+	ands r0, r1
+	subs r1, #4
+	ands r0, r1
+	subs r1, #8
+	ands r0, r1
+	strb r0, [r2, #1]
+	movs r0, #2
+	movs r1, #0
+	bl SetBackgroundTileDataOffset
+	adds r0, r4, #0
+	bl Proc_ClearNativeCallback
+_08020EF4:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08020EFC: .4byte gLCDControlBuffer
+
+	THUMB_FUNC_START sub_8020F00
+sub_8020F00: @ 0x08020F00
+	push {r4, r5, lr}
+	sub sp, #4
+	adds r4, r0, #0
+	ldr r2, _08020FCC  @ gLCDControlBuffer
+	ldrb r1, [r2]
+	movs r0, #8
+	negs r0, r0
+	ands r0, r1
+	strb r0, [r2]
+	movs r0, #0
+	str r0, [sp]
+	movs r1, #0xc0
+	lsls r1, r1, #0x13
+	ldr r2, _08020FD0  @ 0x01000008
+	mov r0, sp
+	bl CpuFastSet
+	ldr r0, _08020FD4  @ gBG0TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	ldr r0, _08020FD8  @ gBG1TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	ldr r0, _08020FDC  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #7
+	bl BG_EnableSyncByMask
+	ldr r0, _08020FE0  @ gUnknown_0859B0E0
+	bl Proc_DeleteAllWithScript
+	ldr r0, _08020FE4  @ gUnknown_0859B108
+	bl Proc_DeleteAllWithScript
+	ldr r0, _08020FE8  @ gUnknown_0859B160
+	bl Proc_DeleteAllWithScript
+	bl sub_8001710
+	ldr r5, _08020FEC  @ gUnknown_02022968
+	adds r0, r5, #0
+	movs r1, #6
+	movs r2, #0xa
+	movs r3, #2
+	bl sub_800172C
+	movs r1, #0xa0
+	lsls r1, r1, #2
+	adds r0, r5, r1
+	movs r1, #0x1a
+	movs r2, #6
+	movs r3, #2
+	bl sub_800172C
+	movs r1, #0xa0
+	lsls r1, r1, #1
+	adds r0, r5, r1
+	movs r1, #0x10
+	movs r2, #2
+	movs r3, #2
+	bl sub_800172C
+	movs r1, #0x88
+	lsls r1, r1, #2
+	adds r0, r5, r1
+	movs r1, #0x17
+	movs r2, #1
+	movs r3, #2
+	bl sub_800172C
+	bl sub_80D74B0
+	bl EnablePaletteSync
+	adds r4, #0x4c
+	movs r0, #0xe
+	strh r0, [r4]
+	ldr r4, _08020FF0  @ gUnknown_0202BCF0
+	movs r0, #0xe
+	ldrsb r0, [r4, r0]
+	bl GetROMChapterStruct
+	ldrh r1, [r0, #0x28]
+	ldr r0, _08020FF4  @ 0x0000FFFF
+	cmp r1, r0
+	beq _08020FC4
+	movs r0, #0xe
+	ldrsb r0, [r4, r0]
+	bl GetROMChapterStruct
+	ldrh r0, [r0, #0x28]
+	movs r1, #0
+	bl Sound_PlaySong80024D4
+_08020FC4:
+	add sp, #4
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08020FCC: .4byte gLCDControlBuffer
+_08020FD0: .4byte 0x01000008
+_08020FD4: .4byte gBG0TilemapBuffer
+_08020FD8: .4byte gBG1TilemapBuffer
+_08020FDC: .4byte gBG2TilemapBuffer
+_08020FE0: .4byte gUnknown_0859B0E0
+_08020FE4: .4byte gUnknown_0859B108
+_08020FE8: .4byte gUnknown_0859B160
+_08020FEC: .4byte gUnknown_02022968
+_08020FF0: .4byte gUnknown_0202BCF0
+_08020FF4: .4byte 0x0000FFFF
+
+	THUMB_FUNC_START sub_8020FF8
+sub_8020FF8: @ 0x08020FF8
+	push {r4, r5, lr}
+	adds r4, r0, #0
+	bl sub_80D74B0
+	ldr r5, _08021054  @ gUnknown_0202BCF0
+	movs r0, #0xe
+	ldrsb r0, [r5, r0]
+	bl GetROMChapterStruct
+	ldrb r0, [r0, #0x12]
+	cmp r0, #5
+	bne _08021014
+	bl sub_8030758
+_08021014:
+	bl GetChapterThing
+	cmp r0, #2
+	beq _0802102C
+	movs r0, #0xe
+	ldrsb r0, [r5, r0]
+	bl GetROMChapterStruct
+	adds r0, #0x87
+	ldrb r0, [r0]
+	cmp r0, #0
+	beq _0802105C
+_0802102C:
+	adds r3, r4, #0
+	adds r3, #0x4c
+	movs r0, #0
+	strh r0, [r3]
+	ldr r2, _08021058  @ gLCDControlBuffer
+	ldrb r0, [r2, #1]
+	movs r1, #1
+	orrs r0, r1
+	movs r1, #2
+	orrs r0, r1
+	movs r1, #4
+	orrs r0, r1
+	movs r1, #9
+	negs r1, r1
+	ands r0, r1
+	subs r1, #8
+	ands r0, r1
+	strb r0, [r2, #1]
+	b _08021064
+	.align 2, 0
+_08021054: .4byte gUnknown_0202BCF0
+_08021058: .4byte gLCDControlBuffer
+_0802105C:
+	bl EnablePaletteSync
+	adds r3, r4, #0
+	adds r3, #0x4c
+_08021064:
+	ldrh r0, [r3]
+	subs r0, #1
+	strh r0, [r3]
+	lsls r0, r0, #0x10
+	cmp r0, #0
+	bge _0802107A
+	bl sub_8030C40
+	adds r0, r4, #0
+	bl Proc_ClearNativeCallback
+_0802107A:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_8021080
+sub_8021080: @ 0x08021080
+	adds r1, #0x50
+	strh r0, [r1]
+	bx lr
+
+	THUMB_FUNC_START sub_8021088
+sub_8021088: @ 0x08021088
+	adds r1, #0x4c
+	strh r0, [r1]
+	bx lr
+
+	THUMB_FUNC_START sub_8021090
+sub_8021090: @ 0x08021090
+	push {lr}
+	adds r3, r0, #0
+	adds r0, #0x52
+	ldrh r0, [r0]
+	cmp r0, #0
+	beq _080210A4
+	adds r0, r3, #0
+	bl Proc_ClearNativeCallback
+	b _080210BA
+_080210A4:
+	adds r0, r3, #0
+	adds r0, #0x4c
+	ldrh r1, [r0]
+	subs r2, r1, #1
+	strh r2, [r0]
+	lsls r1, r1, #0x10
+	cmp r1, #0
+	bge _080210BA
+	adds r0, r3, #0
+	bl Proc_ClearNativeCallback
+_080210BA:
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_80210C0
+sub_80210C0: @ 0x080210C0
+	adds r0, #0x52
+	movs r1, #2
+	strh r1, [r0]
+	bx lr
+
+	THUMB_FUNC_START sub_80210C8
+sub_80210C8: @ 0x080210C8
+	push {r4, r5, r6, lr}
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6}
+	ldr r4, _0802117C  @ gLCDControlBuffer
+	ldrb r1, [r4, #0xc]
+	movs r5, #4
+	negs r5, r5
+	adds r0, r5, #0
+	ands r0, r1
+	strb r0, [r4, #0xc]
+	ldrb r1, [r4, #0x10]
+	adds r0, r5, #0
+	ands r0, r1
+	movs r1, #1
+	mov r9, r1
+	mov r1, r9
+	orrs r0, r1
+	strb r0, [r4, #0x10]
+	ldrb r1, [r4, #0x14]
+	adds r0, r5, #0
+	ands r0, r1
+	movs r1, #2
+	mov r8, r1
+	mov r1, r8
+	orrs r0, r1
+	strb r0, [r4, #0x14]
+	ldrb r0, [r4, #0x18]
+	movs r6, #3
+	orrs r0, r6
+	strb r0, [r4, #0x18]
+	ldrb r1, [r4, #1]
+	movs r0, #0x21
+	negs r0, r0
+	ands r0, r1
+	movs r1, #0x41
+	negs r1, r1
+	ands r0, r1
+	movs r1, #0x7f
+	ands r0, r1
+	strb r0, [r4, #1]
+	ldr r0, _08021180  @ gBG0TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	ldrb r1, [r4, #0xc]
+	adds r0, r5, #0
+	ands r0, r1
+	strb r0, [r4, #0xc]
+	ldrb r1, [r4, #0x10]
+	adds r0, r5, #0
+	ands r0, r1
+	mov r1, r9
+	orrs r0, r1
+	strb r0, [r4, #0x10]
+	ldrb r0, [r4, #0x14]
+	ands r5, r0
+	mov r0, r8
+	orrs r5, r0
+	strb r5, [r4, #0x14]
+	ldrb r0, [r4, #0x18]
+	orrs r0, r6
+	strb r0, [r4, #0x18]
+	bl GetChapterThing
+	cmp r0, #2
+	beq _08021168
+	ldr r0, _08021184  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xe]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	bl GetROMChapterStruct
+	adds r0, #0x87
+	ldrb r0, [r0]
+	cmp r0, #0
+	beq _08021170
+_08021168:
+	bl sub_80311A8
+	bl sub_80141B0
+_08021170:
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802117C: .4byte gLCDControlBuffer
+_08021180: .4byte gBG0TilemapBuffer
+_08021184: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START sub_8021188
+sub_8021188: @ 0x08021188
+	push {r4, lr}
+	adds r4, r0, #0
+	bl GetGameClock
+	movs r1, #1
+	ands r1, r0
+	cmp r1, #0
+	bne _080211BC
+	bl sub_80D74B0
+	ldr r0, _080211C4  @ gUnknown_0202BCF0
+	ldrb r0, [r0, #0xe]
+	lsls r0, r0, #0x18
+	asrs r0, r0, #0x18
+	bl GetROMChapterStruct
+	ldrb r0, [r0, #0x12]
+	cmp r0, #5
+	bne _080211B2
+	bl sub_8030758
+_080211B2:
+	bl sub_8030C40
+	adds r0, r4, #0
+	bl Proc_ClearNativeCallback
+_080211BC:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080211C4: .4byte gUnknown_0202BCF0
+
+.align 2, 0 @ align with 0

--- a/asm/chapterintrofx_title.s
+++ b/asm/chapterintrofx_title.s
@@ -1,0 +1,255 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ Proc Displaying Chapter Title in the middle of the screen
+
+	THUMB_FUNC_START sub_802237C
+sub_802237C: @ 0x0802237C
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #4
+	str r0, [sp]
+	ldr r1, _080223A4  @ gUnknown_0202BCF0
+	movs r0, #0xe
+	ldrsb r0, [r1, r0]
+	cmp r0, #0x16
+	beq _08022398
+	cmp r0, #0x23
+	bne _080223AC
+_08022398:
+	ldr r1, _080223A8  @ 0x000003E7
+	ldr r0, [sp]
+	bl Proc_GotoLabel
+	b _080224BE
+	.align 2, 0
+_080223A4: .4byte gUnknown_0202BCF0
+_080223A8: .4byte 0x000003E7
+_080223AC:
+	bl SetupBackgroundForWeatherMaybe
+	movs r0, #0
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	movs r0, #1
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	movs r0, #2
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	movs r0, #3
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	ldr r2, _080224D0  @ gBG0TilemapBuffer
+	mov r8, r2
+	mov r0, r8
+	movs r1, #0
+	bl BG_Fill
+	ldr r0, _080224D4  @ gBG1TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	ldr r0, _080224D8  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	ldr r0, _080224DC  @ gBG3TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	ldr r7, _080224E0  @ gLCDControlBuffer
+	ldrb r0, [r7, #1]
+	movs r5, #0x20
+	orrs r0, r5
+	movs r1, #0x41
+	negs r1, r1
+	ands r0, r1
+	movs r1, #0x7f
+	ands r0, r1
+	strb r0, [r7, #1]
+	movs r0, #0x34
+	adds r0, r0, r7
+	mov r9, r0
+	ldrb r1, [r0]
+	movs r2, #1
+	orrs r1, r2
+	movs r0, #2
+	orrs r1, r0
+	movs r6, #4
+	orrs r1, r6
+	movs r4, #8
+	orrs r1, r4
+	movs r3, #0x10
+	orrs r1, r3
+	movs r0, #0x36
+	adds r0, r0, r7
+	mov ip, r0
+	ldrb r2, [r0]
+	movs r0, #2
+	negs r0, r0
+	ands r0, r2
+	movs r2, #3
+	negs r2, r2
+	mov sl, r2
+	ands r0, r2
+	orrs r0, r6
+	orrs r0, r4
+	orrs r0, r3
+	orrs r1, r5
+	mov r2, r9
+	strb r1, [r2]
+	orrs r0, r5
+	mov r1, ip
+	strb r0, [r1]
+	adds r0, r7, #0
+	adds r0, #0x2d
+	movs r5, #0
+	strb r5, [r0]
+	adds r1, r7, #0
+	adds r1, #0x31
+	movs r0, #0x40
+	strb r0, [r1]
+	subs r1, #5
+	movs r0, #0xf0
+	strb r0, [r1]
+	adds r1, #4
+	movs r0, #0x60
+	strb r0, [r1]
+	movs r0, #8
+	movs r1, #1
+	bl sub_80895B4
+	movs r4, #0x80
+	lsls r4, r4, #1
+	ldr r0, _080224E4  @ gUnknown_0202BCF0
+	bl sub_808979C
+	adds r1, r0, #0
+	adds r0, r4, #0
+	bl sub_8089624
+	ldr r2, _080224E8  @ 0x00000246
+	add r8, r2
+	mov r0, r8
+	movs r1, #1
+	bl sub_80896D8
+	bl EnablePaletteSync
+	movs r0, #0xf
+	bl BG_EnableSyncByMask
+	ldrb r0, [r7, #1]
+	movs r1, #1
+	orrs r0, r1
+	mov r2, sl
+	ands r0, r2
+	subs r1, #6
+	ands r0, r1
+	subs r1, #4
+	ands r0, r1
+	subs r1, #8
+	ands r0, r1
+	strb r0, [r7, #1]
+	ldr r0, [sp]
+	adds r0, #0x52
+	strh r5, [r0]
+_080224BE:
+	add sp, #4
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080224D0: .4byte gBG0TilemapBuffer
+_080224D4: .4byte gBG1TilemapBuffer
+_080224D8: .4byte gBG2TilemapBuffer
+_080224DC: .4byte gBG3TilemapBuffer
+_080224E0: .4byte gLCDControlBuffer
+_080224E4: .4byte gUnknown_0202BCF0
+_080224E8: .4byte 0x00000246
+
+	THUMB_FUNC_START sub_80224EC
+sub_80224EC: @ 0x080224EC
+	push {lr}
+	ldr r0, _08022520  @ gBG0TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	ldr r2, _08022524  @ gLCDControlBuffer
+	ldrb r1, [r2, #1]
+	movs r0, #2
+	negs r0, r0
+	ands r0, r1
+	movs r1, #3
+	negs r1, r1
+	ands r0, r1
+	movs r1, #4
+	orrs r0, r1
+	movs r1, #8
+	orrs r0, r1
+	movs r1, #0x10
+	orrs r0, r1
+	strb r0, [r2, #1]
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08022520: .4byte gBG0TilemapBuffer
+_08022524: .4byte gLCDControlBuffer
+
+	THUMB_FUNC_START sub_8022528
+sub_8022528: @ 0x08022528
+	push {r4, r5, lr}
+	movs r0, #0
+	bl SetupBackgrounds
+	ldr r0, _080225A0  @ gBG2TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #4
+	bl BG_EnableSyncByMask
+	bl sub_8030C24
+	ldr r4, _080225A4  @ gUnknown_0202BCF0
+	movs r0, #0xe
+	ldrsb r0, [r4, r0]
+	bl LoadChapterMapGfx
+	bl SetupMapSpritesPalettes
+	bl LoadObjUIGfx
+	movs r0, #0xe
+	ldrsb r0, [r4, r0]
+	bl GetROMChapterStruct
+	ldrb r0, [r0, #0x10]
+	lsls r0, r0, #4
+	bl sub_8015A40
+	lsls r0, r0, #0x10
+	lsrs r0, r0, #0x10
+	adds r0, #0xf
+	movs r1, #0xf8
+	lsls r1, r1, #1
+	ands r0, r1
+	ldr r5, _080225A8  @ gUnknown_0202BCB0
+	strh r0, [r5, #0xc]
+	movs r0, #0xe
+	ldrsb r0, [r4, r0]
+	bl GetROMChapterStruct
+	ldrb r0, [r0, #0x11]
+	lsls r0, r0, #4
+	bl sub_8015A6C
+	lsls r0, r0, #0x10
+	lsrs r0, r0, #0x10
+	adds r0, #0xf
+	movs r1, #0xfc
+	lsls r1, r1, #2
+	ands r0, r1
+	strh r0, [r5, #0xe]
+	bl RefreshFogAndUnitMaps
+	bl UpdateGameTilesGraphics
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080225A0: .4byte gBG2TilemapBuffer
+_080225A4: .4byte gUnknown_0202BCF0
+_080225A8: .4byte gUnknown_0202BCB0
+
+.align 2, 0

--- a/asm/danceringfx.s
+++ b/asm/danceringfx.s
@@ -1,0 +1,207 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	THUMB_FUNC_START sub_80219F8
+sub_80219F8: @ 0x080219F8
+	push {r4, r5, r6, lr}
+	sub sp, #4
+	adds r6, r0, #0
+	ldr r0, _08021A7C  @ gUnknown_085A6C80
+	ldr r1, _08021A80  @ 0x06002000
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _08021A84  @ gUnknown_085A7CA0
+	movs r1, #0x40
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	ldr r0, _08021A88  @ gUnknown_085A7A64
+	ldr r4, _08021A8C  @ gUnknown_02003D2C
+	adds r1, r4, #0
+	bl CopyDataWithPossibleUncomp
+	movs r0, #0x84
+	lsls r0, r0, #6
+	adds r1, r0, #0
+	movs r5, #0x90
+	lsls r5, r5, #2
+_08021A24:
+	ldrh r2, [r4]
+	adds r0, r1, r2
+	strh r0, [r4]
+	adds r4, #2
+	subs r5, #1
+	cmp r5, #0
+	bne _08021A24
+	ldr r0, _08021A90  @ gBG0TilemapBuffer
+	movs r1, #0x80
+	lsls r1, r1, #1
+	bl BG_Fill
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	movs r0, #1
+	movs r1, #0x10
+	movs r2, #0x10
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	str r5, [sp]
+	movs r0, #1
+	movs r1, #0
+	movs r2, #0
+	movs r3, #0
+	bl sub_8001ED0
+	movs r0, #1
+	str r0, [sp]
+	movs r0, #0
+	movs r1, #1
+	movs r2, #1
+	movs r3, #1
+	bl sub_8001F0C
+	adds r0, r6, #0
+	adds r0, #0x4c
+	strh r5, [r0]
+	add sp, #4
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021A7C: .4byte gUnknown_085A6C80
+_08021A80: .4byte 0x06002000
+_08021A84: .4byte gUnknown_085A7CA0
+_08021A88: .4byte gUnknown_085A7A64
+_08021A8C: .4byte gUnknown_02003D2C
+_08021A90: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_8021A94
+sub_8021A94: @ 0x08021A94
+	push {r4, lr}
+	sub sp, #0x38
+	adds r4, r0, #0
+	ldr r1, _08021ACC  @ gUnknown_080D7BCC
+	mov r0, sp
+	movs r2, #0x38
+	bl memcpy
+	adds r1, r4, #0
+	adds r1, #0x4c
+	ldrh r0, [r1]
+	adds r0, #1
+	strh r0, [r1]
+	movs r2, #0
+	ldrsh r0, [r1, r2]
+	lsrs r1, r0, #0x1f
+	adds r0, r0, r1
+	asrs r0, r0, #1
+	lsls r0, r0, #2
+	add r0, sp
+	ldrb r1, [r0]
+	ldrb r0, [r0, #1]
+	cmp r1, #0xff
+	bne _08021AD0
+	adds r0, r4, #0
+	bl Proc_ClearNativeCallback
+	b _08021AEA
+	.align 2, 0
+_08021ACC: .4byte gUnknown_080D7BCC
+_08021AD0:
+	lsls r0, r0, #5
+	adds r0, r0, r1
+	lsls r0, r0, #1
+	ldr r1, _08021AF4  @ gUnknown_02003D2C
+	adds r0, r0, r1
+	ldr r1, _08021AF8  @ gBG0TilemapBuffer
+	movs r2, #6
+	movs r3, #6
+	bl TileMap_CopyRect
+	movs r0, #1
+	bl BG_EnableSyncByMask
+_08021AEA:
+	add sp, #0x38
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021AF4: .4byte gUnknown_02003D2C
+_08021AF8: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_8021AFC
+sub_8021AFC: @ 0x08021AFC
+	adds r0, #0x4c
+	movs r1, #0x10
+	strh r1, [r0]
+	bx lr
+
+	THUMB_FUNC_START sub_8021B04
+sub_8021B04: @ 0x08021B04
+	push {r4, r5, lr}
+	adds r5, r0, #0
+	adds r4, r5, #0
+	adds r4, #0x4c
+	ldrb r1, [r4]
+	movs r0, #1
+	movs r2, #0x10
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	ldrh r0, [r4]
+	subs r0, #1
+	strh r0, [r4]
+	lsls r0, r0, #0x10
+	cmp r0, #0
+	bge _08021B2A
+	adds r0, r5, #0
+	bl Proc_ClearNativeCallback
+_08021B2A:
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_8021B30
+sub_8021B30: @ 0x08021B30
+	push {r4, r5, r6, lr}
+	adds r6, r0, #0
+	ldr r0, _08021B8C  @ gUnknown_0203A4D4
+	ldrh r1, [r0]
+	movs r0, #0x80
+	lsls r0, r0, #2
+	ands r0, r1
+	cmp r0, #0
+	beq _08021B86
+	ldr r0, _08021B90  @ gUnknown_0203A958
+	ldrb r0, [r0, #0xd]
+	bl GetUnitStruct
+	movs r4, #0x10
+	ldrsb r4, [r0, r4]
+	movs r5, #0x11
+	ldrsb r5, [r0, r5]
+	ldr r0, _08021B94  @ gUnknown_0859B410
+	adds r1, r6, #0
+	bl Proc_CreateBlockingChild
+	lsls r0, r4, #4
+	ldr r2, _08021B98  @ gUnknown_0202BCB0
+	movs r3, #0xc
+	ldrsh r1, [r2, r3]
+	subs r0, r0, r1
+	adds r4, r0, #0
+	subs r4, #0x10
+	lsls r0, r5, #4
+	movs r3, #0xe
+	ldrsh r1, [r2, r3]
+	subs r0, r0, r1
+	adds r5, r0, #0
+	subs r5, #0x10
+	negs r1, r4
+	lsls r1, r1, #0x10
+	lsrs r1, r1, #0x10
+	negs r2, r5
+	lsls r2, r2, #0x10
+	lsrs r2, r2, #0x10
+	movs r0, #0
+	bl BG_SetPosition
+_08021B86:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021B8C: .4byte gUnknown_0203A4D4
+_08021B90: .4byte gUnknown_0203A958
+_08021B94: .4byte gUnknown_0859B410
+_08021B98: .4byte gUnknown_0202BCB0
+
+.align 2, 0 @ align with 0

--- a/asm/danceringfx.s
+++ b/asm/danceringfx.s
@@ -2,6 +2,8 @@
 
 	.SYNTAX UNIFIED
 
+	@ Some sparkle effect that's apparenly calling on dance
+
 	THUMB_FUNC_START sub_80219F8
 sub_80219F8: @ 0x080219F8
 	push {r4, r5, r6, lr}

--- a/asm/emitstarfx.s
+++ b/asm/emitstarfx.s
@@ -1,0 +1,418 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ Some effect proc emitting little white stars. Seems unused
+
+	THUMB_FUNC_START sub_8021FB8
+sub_8021FB8: @ 0x08021FB8
+	push {r4, lr}
+	adds r4, r0, #0
+	movs r0, #0
+	str r0, [r4, #0x34]
+	str r0, [r4, #0x38]
+	str r0, [r4, #0x3c]
+	bl AdvanceGetLCGRNValue
+	ldr r1, _08021FE8  @ 0x000003FF
+	ands r1, r0
+	ldr r0, [r4, #0x14]
+	adds r0, #0x64
+	movs r2, #0
+	ldrsh r0, [r0, r2]
+	lsls r0, r0, #4
+	movs r2, #0xc0
+	lsls r2, r2, #4
+	adds r0, r0, r2
+	adds r1, r1, r0
+	negs r1, r1
+	str r1, [r4, #0x40]
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021FE8: .4byte 0x000003FF
+
+	THUMB_FUNC_START sub_8021FEC
+sub_8021FEC: @ 0x08021FEC
+	push {r4, lr}
+	sub sp, #4
+	adds r4, r0, #0
+	ldr r0, [r4, #0x14]
+	adds r0, #0x66
+	movs r1, #0
+	ldrsh r0, [r0, r1]
+	cmp r0, #0
+	beq _0802200A
+	bl GetGameClock
+	movs r1, #3
+	ands r1, r0
+	cmp r1, #0
+	bne _08022026
+_0802200A:
+	ldr r2, [r4, #0x34]
+	ldr r0, [r4, #0x3c]
+	adds r2, r2, r0
+	str r2, [r4, #0x34]
+	ldr r1, [r4, #0x38]
+	ldr r0, [r4, #0x40]
+	adds r1, r1, r0
+	str r1, [r4, #0x38]
+	ldr r0, [r4, #0x2c]
+	adds r0, r0, r2
+	str r0, [r4, #0x2c]
+	ldr r0, [r4, #0x30]
+	adds r0, r0, r1
+	str r0, [r4, #0x30]
+_08022026:
+	ldr r2, [r4, #0x30]
+	cmp r2, #0
+	bge _0802203E
+	adds r0, r4, #0
+	bl Proc_ClearNativeCallback
+	ldr r1, [r4, #0x14]
+	adds r1, #0x4c
+	ldrh r0, [r1]
+	subs r0, #1
+	strh r0, [r1]
+	b _08022052
+_0802203E:
+	movs r0, #0x2e
+	ldrsh r1, [r4, r0]
+	asrs r2, r2, #0x10
+	ldr r3, _0802205C  @ gUnknown_08590F44
+	movs r0, #0xa0
+	lsls r0, r0, #4
+	str r0, [sp]
+	movs r0, #0xa
+	bl RegisterObjectAttributes_SafeMaybe
+_08022052:
+	add sp, #4
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802205C: .4byte gUnknown_08590F44
+
+	THUMB_FUNC_START sub_8022060
+sub_8022060: @ 0x08022060
+	push {r4, r5, r6, lr}
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6}
+	sub sp, #4
+	adds r5, r0, #0
+	mov r8, r1
+	mov r9, r3
+	ldr r6, [sp, #0x1c]
+	ldr r1, [r5]
+	movs r4, #0x80
+	lsls r4, r4, #1
+	str r4, [sp]
+	movs r0, #0
+	adds r3, r6, #0
+	bl sub_8012DCC
+	str r0, [r5]
+	mov r0, r8
+	ldr r1, [r0]
+	str r4, [sp]
+	movs r0, #0
+	mov r2, r9
+	adds r3, r6, #0
+	bl sub_8012DCC
+	mov r1, r8
+	str r0, [r1]
+	add sp, #4
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_80220A8
+sub_80220A8: @ 0x080220A8
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	sub sp, #4
+	adds r6, r0, #0
+	bl GetGameClock
+	movs r1, #3
+	ands r1, r0
+	cmp r1, #0
+	bne _080220C4
+	b _080221EE
+_080220C4:
+	movs r0, #0
+	mov r9, r0
+	adds r0, r6, #0
+	adds r0, #0x4c
+	movs r2, #0
+	ldrsh r1, [r0, r2]
+	mov r8, r0
+	cmp r1, #0x28
+	ble _080220D8
+	b _080221EE
+_080220D8:
+	movs r3, #0x64
+	adds r3, r3, r6
+	mov sl, r3
+	mov r7, sl
+_080220E0:
+	ldr r0, _080221A4  @ gUnknown_0859B510
+	adds r1, r6, #0
+	bl Proc_Create
+	adds r5, r0, #0
+	bl AdvanceGetLCGRNValue
+	ldr r1, [r6, #0x34]
+	lsls r1, r1, #0x10
+	ldr r4, _080221A8  @ 0x0000FFFF
+	ands r0, r4
+	lsls r0, r0, #4
+	adds r1, r1, r0
+	str r1, [r5, #0x2c]
+	bl AdvanceGetLCGRNValue
+	ldr r1, [r6, #0x38]
+	adds r1, #8
+	lsls r1, r1, #0x10
+	ands r0, r4
+	lsls r0, r0, #3
+	adds r1, r1, r0
+	str r1, [r5, #0x30]
+	adds r4, r5, #0
+	adds r4, #0x2c
+	adds r1, r5, #0
+	adds r1, #0x30
+	ldr r2, [r6, #0x3c]
+	ldr r3, [r6, #0x40]
+	movs r5, #0
+	ldrsh r0, [r7, r5]
+	movs r5, #0x80
+	lsls r5, r5, #1
+	cmp r0, r5
+	ble _0802212A
+	movs r0, #0x80
+	lsls r0, r0, #1
+_0802212A:
+	str r0, [sp]
+	adds r0, r4, #0
+	bl sub_8022060
+	mov r1, r8
+	ldrh r0, [r1]
+	adds r1, r0, #1
+	mov r2, r8
+	strh r1, [r2]
+	movs r3, #1
+	add r9, r3
+	mov r4, r9
+	cmp r4, #0
+	bgt _0802214E
+	lsls r0, r1, #0x10
+	asrs r0, r0, #0x10
+	cmp r0, #0x28
+	ble _080220E0
+_0802214E:
+	lsls r0, r1, #0x10
+	asrs r0, r0, #0x10
+	cmp r0, #0x28
+	bgt _080221EE
+	ldr r0, _080221A4  @ gUnknown_0859B510
+	adds r1, r6, #0
+	bl Proc_Create
+	adds r5, r0, #0
+	bl AdvanceGetLCGRNValue
+	ldr r1, [r6, #0x34]
+	subs r1, #8
+	lsls r1, r1, #0x10
+	ldr r4, _080221A8  @ 0x0000FFFF
+	ands r0, r4
+	lsls r0, r0, #5
+	adds r1, r1, r0
+	str r1, [r5, #0x2c]
+	bl AdvanceGetLCGRNValue
+	ldr r1, [r6, #0x38]
+	adds r1, #8
+	lsls r1, r1, #0x10
+	ands r0, r4
+	lsls r0, r0, #3
+	adds r1, r1, r0
+	str r1, [r5, #0x30]
+	adds r7, r5, #0
+	adds r7, #0x2c
+	adds r1, r5, #0
+	adds r1, #0x30
+	ldr r2, [r6, #0x3c]
+	ldr r3, [r6, #0x40]
+	mov r5, sl
+	movs r4, #0
+	ldrsh r0, [r5, r4]
+	movs r4, #0x80
+	lsls r4, r4, #1
+	cmp r0, r4
+	bgt _080221AC
+	str r0, [sp]
+	b _080221AE
+	.align 2, 0
+_080221A4: .4byte gUnknown_0859B510
+_080221A8: .4byte 0x0000FFFF
+_080221AC:
+	str r4, [sp]
+_080221AE:
+	adds r0, r7, #0
+	bl sub_8022060
+	mov r5, r8
+	ldrh r0, [r5]
+	adds r0, #1
+	strh r0, [r5]
+	mov r1, sl
+	ldrh r2, [r1]
+	movs r3, #0
+	ldrsh r0, [r1, r3]
+	cmp r0, #0
+	blt _080221CE
+	adds r0, r2, #0
+	adds r0, #8
+	strh r0, [r1]
+_080221CE:
+	mov r4, sl
+	movs r5, #0
+	ldrsh r1, [r4, r5]
+	movs r0, #0xa0
+	lsls r0, r0, #1
+	cmp r1, r0
+	ble _080221EE
+	adds r0, r6, #0
+	bl Proc_ClearNativeCallback
+	movs r0, #0
+	strh r0, [r4]
+	adds r1, r6, #0
+	adds r1, #0x66
+	movs r0, #1
+	strh r0, [r1]
+_080221EE:
+	add sp, #4
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_8022200
+sub_8022200: @ 0x08022200
+	push {r4, r5, lr}
+	sub sp, #4
+	adds r5, r0, #0
+	adds r5, #0x64
+	movs r0, #0
+	ldrsh r1, [r5, r0]
+	movs r0, #0x10
+	subs r0, r0, r1
+	cmp r0, #0
+	bge _08022216
+	movs r0, #0
+_08022216:
+	lsls r3, r0, #0x18
+	lsrs r3, r3, #0x18
+	movs r0, #2
+	movs r1, #0
+	movs r2, #0
+	bl SetSpecialColorEffectsParameters
+	movs r4, #1
+	str r4, [sp]
+	movs r0, #1
+	movs r1, #1
+	movs r2, #1
+	movs r3, #1
+	bl sub_8001ED0
+	str r4, [sp]
+	movs r0, #1
+	movs r1, #1
+	movs r2, #1
+	movs r3, #1
+	bl sub_8001F0C
+	ldrh r0, [r5]
+	adds r0, #1
+	strh r0, [r5]
+	add sp, #4
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_8022250
+sub_8022250: @ 0x08022250
+	push {r4, r5, r6, lr}
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6}
+	adds r6, r0, #0
+	mov r8, r1
+	mov r9, r2
+	adds r4, r3, #0
+	ldr r5, [sp, #0x18]
+	ldr r0, _080222A8  @ gUnknown_0859B540
+	ldr r1, _080222AC  @ 0x06014000
+	movs r2, #0x20
+	bl RegisterTileGraphics
+	ldr r0, _080222B0  @ gUnknown_0859B528
+	adds r1, r6, #0
+	bl Proc_Create
+	adds r3, r0, #0
+	mov r0, r8
+	str r0, [r3, #0x34]
+	mov r0, r9
+	str r0, [r3, #0x38]
+	lsls r4, r4, #0x10
+	str r4, [r3, #0x3c]
+	lsls r5, r5, #0x10
+	str r5, [r3, #0x40]
+	adds r0, r3, #0
+	adds r0, #0x4c
+	movs r2, #0
+	strh r2, [r0]
+	adds r1, r3, #0
+	adds r1, #0x64
+	ldr r0, _080222B4  @ 0x0000FFFF
+	strh r0, [r1]
+	adds r0, r3, #0
+	adds r0, #0x66
+	strh r2, [r0]
+	pop {r3, r4}
+	mov r8, r3
+	mov r9, r4
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080222A8: .4byte gUnknown_0859B540
+_080222AC: .4byte 0x06014000
+_080222B0: .4byte gUnknown_0859B528
+_080222B4: .4byte 0x0000FFFF
+
+	THUMB_FUNC_START sub_80222B8
+sub_80222B8: @ 0x080222B8
+	push {lr}
+	ldr r0, _080222CC  @ gUnknown_0859B528
+	bl Proc_Find
+	adds r0, #0x64
+	movs r1, #0
+	strh r1, [r0]
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080222CC: .4byte gUnknown_0859B528
+
+	THUMB_FUNC_START sub_80222D0
+sub_80222D0: @ 0x080222D0
+	push {lr}
+	ldr r0, _080222DC  @ gUnknown_0859B528
+	bl Proc_DeleteAllWithScript
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080222DC: .4byte gUnknown_0859B528
+
+.align 2, 0

--- a/asm/eventwarpfx.s
+++ b/asm/eventwarpfx.s
@@ -1,0 +1,312 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ map effect for when using the warp event codes
+	@ *not* the effect used by the warp/rescue staves
+
+	THUMB_FUNC_START sub_8021B9C
+sub_8021B9C: @ 0x08021B9C
+	push {r4, r5, r6, lr}
+	sub sp, #4
+	adds r6, r0, #0
+	ldr r0, _08021C48  @ gUnknown_085A5A60
+	ldr r1, _08021C4C  @ 0x06002000
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _08021C50  @ gUnknown_085A61A8
+	movs r1, #0xa0
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	ldr r0, _08021C54  @ gUnknown_085A61C8
+	ldr r4, _08021C58  @ gUnknown_02003D2C
+	adds r1, r4, #0
+	bl CopyDataWithPossibleUncomp
+	movs r0, #0xa2
+	lsls r0, r0, #7
+	adds r1, r0, #0
+	movs r5, #0xd8
+	lsls r5, r5, #2
+_08021BC8:
+	ldrh r2, [r4]
+	adds r0, r1, r2
+	strh r0, [r4]
+	adds r4, #2
+	subs r5, #1
+	cmp r5, #0
+	bne _08021BC8
+	ldr r0, _08021C5C  @ gBG0TilemapBuffer
+	movs r1, #0x80
+	lsls r1, r1, #1
+	bl BG_Fill
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	ldr r0, _08021C60  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _08021BF8
+	movs r0, #0xb4
+	bl m4aSongNumStart
+_08021BF8:
+	movs r0, #1
+	movs r1, #0xa
+	movs r2, #0xc
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	str r5, [sp]
+	movs r0, #1
+	movs r1, #0
+	movs r2, #0
+	movs r3, #0
+	bl sub_8001ED0
+	movs r0, #1
+	str r0, [sp]
+	movs r0, #0
+	movs r1, #1
+	movs r2, #1
+	movs r3, #1
+	bl sub_8001F0C
+	ldr r2, _08021C64  @ gLCDControlBuffer
+	ldrb r1, [r2, #1]
+	movs r0, #0x21
+	negs r0, r0
+	ands r0, r1
+	movs r1, #0x41
+	negs r1, r1
+	ands r0, r1
+	movs r1, #0x7f
+	ands r0, r1
+	strb r0, [r2, #1]
+	adds r0, r6, #0
+	adds r0, #0x4c
+	strh r5, [r0]
+	add sp, #4
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021C48: .4byte gUnknown_085A5A60
+_08021C4C: .4byte 0x06002000
+_08021C50: .4byte gUnknown_085A61A8
+_08021C54: .4byte gUnknown_085A61C8
+_08021C58: .4byte gUnknown_02003D2C
+_08021C5C: .4byte gBG0TilemapBuffer
+_08021C60: .4byte gUnknown_0202BCF0
+_08021C64: .4byte gLCDControlBuffer
+
+	THUMB_FUNC_START sub_8021C68
+sub_8021C68: @ 0x08021C68
+	push {r4, r5, r6, lr}
+	adds r3, r0, #0
+	adds r0, #0x64
+	movs r1, #0
+	ldrsh r0, [r0, r1]
+	ldr r4, _08021CC4  @ gUnknown_0859B48C
+	cmp r0, #0
+	bne _08021C7A
+	ldr r4, _08021CC8  @ gUnknown_0859B448
+_08021C7A:
+	adds r0, r3, #0
+	adds r0, #0x66
+	movs r1, #0
+	ldrsh r0, [r0, r1]
+	adds r2, r3, #0
+	adds r2, #0x4c
+	cmp r0, #0
+	beq _08021C9E
+	ldr r0, _08021CCC  @ gKeyStatusPtr
+	ldr r0, [r0]
+	ldrh r1, [r0, #4]
+	movs r0, #1
+	ands r0, r1
+	cmp r0, #0
+	beq _08021C9E
+	ldrh r0, [r2]
+	adds r0, #1
+	strh r0, [r2]
+_08021C9E:
+	ldrh r0, [r2]
+	adds r6, r0, #1
+	strh r6, [r2]
+	movs r1, #0
+	ldrsh r0, [r2, r1]
+	lsrs r1, r0, #0x1f
+	adds r0, r0, r1
+	asrs r0, r0, #1
+	lsls r0, r0, #2
+	adds r0, r0, r4
+	ldrb r4, [r0]
+	ldrb r5, [r0, #1]
+	cmp r4, #0xff
+	bne _08021CD0
+	adds r0, r3, #0
+	bl Proc_ClearNativeCallback
+	b _08021CF6
+	.align 2, 0
+_08021CC4: .4byte gUnknown_0859B48C
+_08021CC8: .4byte gUnknown_0859B448
+_08021CCC: .4byte gKeyStatusPtr
+_08021CD0:
+	lsls r0, r6, #0x10
+	asrs r0, r0, #0x10
+	cmp r0, #8
+	bne _08021CDC
+	bl SMS_UpdateFromGameData
+_08021CDC:
+	lsls r0, r5, #5
+	adds r0, r0, r4
+	lsls r0, r0, #1
+	ldr r1, _08021CFC  @ gUnknown_02003D2C
+	adds r0, r0, r1
+	ldr r1, _08021D00  @ gBG0TilemapBuffer
+	movs r2, #4
+	movs r3, #7
+	bl TileMap_CopyRect
+	movs r0, #1
+	bl BG_EnableSyncByMask
+_08021CF6:
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021CFC: .4byte gUnknown_02003D2C
+_08021D00: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_8021D04
+sub_8021D04: @ 0x08021D04
+	push {lr}
+	ldr r0, _08021D2C  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _08021D18
+	movs r0, #0xb5
+	bl m4aSongNumStart
+_08021D18:
+	ldr r0, _08021D30  @ gBG0TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021D2C: .4byte gUnknown_0202BCF0
+_08021D30: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_8021D34
+sub_8021D34: @ 0x08021D34
+	push {r4, r5, r6, r7, lr}
+	mov r7, r8
+	push {r7}
+	adds r6, r0, #0
+	adds r7, r1, #0
+	mov r8, r2
+	adds r4, r3, #0
+	ldr r5, [sp, #0x18]
+	lsls r4, r4, #0x18
+	lsrs r4, r4, #0x18
+	lsls r5, r5, #0x18
+	lsrs r5, r5, #0x18
+	ldr r0, _08021D9C  @ gUnknown_0859B4D0
+	adds r1, r6, #0
+	bl Proc_Create
+	lsls r4, r4, #0x18
+	asrs r4, r4, #0x18
+	adds r1, r0, #0
+	adds r1, #0x64
+	strh r4, [r1]
+	lsls r5, r5, #0x18
+	asrs r5, r5, #0x18
+	adds r0, #0x66
+	strh r5, [r0]
+	lsls r0, r7, #4
+	ldr r2, _08021DA0  @ gUnknown_0202BCB0
+	movs r3, #0xc
+	ldrsh r1, [r2, r3]
+	subs r0, r0, r1
+	adds r7, r0, #0
+	subs r7, #8
+	mov r1, r8
+	lsls r0, r1, #4
+	movs r3, #0xe
+	ldrsh r1, [r2, r3]
+	subs r0, r0, r1
+	subs r0, #0x20
+	negs r1, r7
+	lsls r1, r1, #0x10
+	lsrs r1, r1, #0x10
+	negs r2, r0
+	lsls r2, r2, #0x10
+	lsrs r2, r2, #0x10
+	movs r0, #0
+	bl BG_SetPosition
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021D9C: .4byte gUnknown_0859B4D0
+_08021DA0: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_8021DA4
+sub_8021DA4: @ 0x08021DA4
+	push {r4, r5, r6, lr}
+	mov r6, r8
+	push {r6}
+	sub sp, #4
+	mov r8, r0
+	adds r5, r1, #0
+	adds r6, r2, #0
+	lsls r4, r3, #0x18
+	lsrs r4, r4, #0x18
+	ldr r0, _08021DF4  @ gUnknown_0859B4D0
+	mov r1, r8
+	bl Proc_Create
+	adds r3, r0, #0
+	lsls r4, r4, #0x18
+	asrs r4, r4, #0x18
+	adds r0, #0x64
+	strh r4, [r0]
+	negs r5, r5
+	lsls r5, r5, #0x10
+	lsrs r5, r5, #0x10
+	negs r6, r6
+	lsls r6, r6, #0x10
+	lsrs r6, r6, #0x10
+	movs r0, #0
+	adds r1, r5, #0
+	adds r2, r6, #0
+	str r3, [sp]
+	bl BG_SetPosition
+	ldr r3, [sp]
+	adds r3, #0x66
+	movs r0, #1
+	strh r0, [r3]
+	add sp, #4
+	pop {r3}
+	mov r8, r3
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021DF4: .4byte gUnknown_0859B4D0
+
+	THUMB_FUNC_START sub_8021DF8
+sub_8021DF8: @ 0x08021DF8
+	push {lr}
+	ldr r0, _08021E0C  @ gUnknown_0859B4D0
+	bl Proc_Find
+	cmp r0, #0
+	beq _08021E06
+	movs r0, #1
+_08021E06:
+	pop {r1}
+	bx r1
+	.align 2, 0
+_08021E0C: .4byte gUnknown_0859B4D0
+
+.align 2, 0 @ align with 0

--- a/asm/gameoverbgfx.s
+++ b/asm/gameoverbgfx.s
@@ -1,0 +1,428 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ Background effect for the game over screen
+
+	THUMB_FUNC_START sub_80211C8
+sub_80211C8: @ 0x080211C8
+	adds r2, r0, #0
+	movs r0, #0x2e
+	str r0, [r2, #0x34]
+	subs r0, #0x88
+	str r0, [r2, #0x38]
+	adds r0, #0x4a
+	str r0, [r2, #0x3c]
+	subs r0, #0x25
+	str r0, [r2, #0x40]
+	adds r1, r2, #0
+	adds r1, #0x64
+	ldr r0, _080211F8  @ 0x000004D2
+	strh r0, [r1]
+	adds r1, #2
+	ldr r0, _080211FC  @ 0x0000162E
+	strh r0, [r1]
+	adds r1, #2
+	ldr r0, _08021200  @ 0x000018CA
+	strh r0, [r1]
+	adds r1, #2
+	ldr r0, _08021204  @ 0x00002158
+	strh r0, [r1]
+	bx lr
+	.align 2, 0
+_080211F8: .4byte 0x000004D2
+_080211FC: .4byte 0x0000162E
+_08021200: .4byte 0x000018CA
+_08021204: .4byte 0x00002158
+
+	THUMB_FUNC_START sub_8021208
+sub_8021208: @ 0x08021208
+	push {r4, r5, lr}
+	adds r3, r0, #0
+	adds r2, r3, #0
+	adds r2, #0x64
+	ldr r1, [r3, #0x34]
+	ldrh r0, [r2]
+	adds r0, r0, r1
+	strh r0, [r2]
+	movs r0, #0x66
+	adds r0, r0, r3
+	mov ip, r0
+	ldr r1, [r3, #0x38]
+	ldrh r0, [r0]
+	adds r0, r0, r1
+	mov r1, ip
+	strh r0, [r1]
+	adds r4, r3, #0
+	adds r4, #0x68
+	ldr r1, [r3, #0x3c]
+	ldrh r0, [r4]
+	adds r0, r0, r1
+	strh r0, [r4]
+	adds r5, r3, #0
+	adds r5, #0x6a
+	ldr r1, [r3, #0x40]
+	ldrh r0, [r5]
+	adds r0, r0, r1
+	strh r0, [r5]
+	movs r3, #0
+	ldrsh r1, [r2, r3]
+	negs r1, r1
+	lsls r1, r1, #8
+	lsrs r1, r1, #0x10
+	mov r0, ip
+	movs r3, #0
+	ldrsh r2, [r0, r3]
+	negs r2, r2
+	lsls r2, r2, #8
+	lsrs r2, r2, #0x10
+	movs r0, #2
+	bl BG_SetPosition
+	movs r0, #0
+	ldrsh r1, [r4, r0]
+	negs r1, r1
+	lsls r1, r1, #8
+	lsrs r1, r1, #0x10
+	movs r3, #0
+	ldrsh r2, [r5, r3]
+	negs r2, r2
+	lsls r2, r2, #8
+	lsrs r2, r2, #0x10
+	movs r0, #3
+	bl BG_SetPosition
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_802127C
+sub_802127C: @ 0x0802127C
+	push {lr}
+	ldr r0, _080212B8  @ 0x04000006
+	ldrh r0, [r0]
+	adds r0, #1
+	lsls r0, r0, #0x10
+	lsrs r1, r0, #0x10
+	cmp r1, #0xa0
+	bls _0802128E
+	movs r1, #0
+_0802128E:
+	cmp r1, #0x50
+	bls _0802129A
+	movs r0, #0xa0
+	subs r0, r0, r1
+	lsls r0, r0, #0x10
+	lsrs r1, r0, #0x10
+_0802129A:
+	adds r0, r1, #0
+	movs r1, #3
+	bl __udivsi3
+	lsls r0, r0, #0x10
+	lsrs r1, r0, #0x10
+	cmp r1, #0x10
+	bls _080212AC
+	movs r1, #0x10
+_080212AC:
+	ldr r0, _080212BC  @ 0x04000052
+	strb r1, [r0]
+	adds r0, #1
+	strb r1, [r0]
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080212B8: .4byte 0x04000006
+_080212BC: .4byte 0x04000052
+
+	THUMB_FUNC_START sub_80212C0
+sub_80212C0: @ 0x080212C0
+	push {r4, r5, lr}
+	sub sp, #4
+	adds r5, r0, #0
+	bl BlockGameGraphicsLogic
+	movs r0, #0x3e
+	movs r1, #0
+	bl Sound_PlaySong80024D4
+	ldr r3, _080213C8  @ gLCDControlBuffer
+	ldrb r2, [r3, #0xc]
+	movs r1, #4
+	negs r1, r1
+	adds r0, r1, #0
+	ands r0, r2
+	strb r0, [r3, #0xc]
+	ldrb r2, [r3, #0x10]
+	adds r0, r1, #0
+	ands r0, r2
+	movs r2, #1
+	orrs r0, r2
+	strb r0, [r3, #0x10]
+	ldrb r0, [r3, #0x14]
+	ands r1, r0
+	movs r0, #2
+	orrs r1, r0
+	strb r1, [r3, #0x14]
+	ldrb r0, [r3, #0x18]
+	movs r1, #3
+	orrs r0, r1
+	strb r0, [r3, #0x18]
+	movs r0, #2
+	movs r1, #0
+	bl SetBackgroundTileDataOffset
+	movs r0, #3
+	movs r1, #0
+	bl SetBackgroundTileDataOffset
+	ldr r0, _080213CC  @ gUnknown_08A0AB0C
+	ldr r1, _080213D0  @ 0x06001000
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _080213D4  @ gUnknown_08A0AE64
+	movs r1, #0x80
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	ldr r0, _080213D8  @ gUnknown_08A07DD8
+	ldr r1, _080213DC  @ 0x06002000
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _080213E0  @ gUnknown_08A0AE44
+	movs r1, #0
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	movs r0, #0
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	bl ClearBG0BG1
+	ldr r0, _080213E4  @ gUnknown_02022EF6
+	ldr r1, _080213E8  @ gUnknown_08A0AE84
+	movs r2, #0x80
+	bl CallARM_FillTileRect
+	bl sub_801FEE8
+	bl sub_801FE14
+	movs r0, #0xc
+	bl BG_EnableSyncByMask
+	ldr r0, _080213EC  @ sub_802127C
+	bl SetPrimaryHBlankHandler
+	movs r0, #1
+	movs r1, #0xe
+	movs r2, #0xe
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	movs r4, #0
+	str r4, [sp]
+	movs r0, #0
+	movs r1, #0
+	movs r2, #1
+	movs r3, #0
+	bl sub_8001ED0
+	str r4, [sp]
+	movs r0, #0
+	movs r1, #0
+	movs r2, #0
+	movs r3, #1
+	bl sub_8001F0C
+	bl sub_8001710
+	ldr r4, _080213F0  @ gPaletteBuffer
+	adds r0, r4, #0
+	movs r1, #0
+	movs r2, #1
+	movs r3, #1
+	bl sub_800172C
+	adds r4, #0x80
+	adds r0, r4, #0
+	movs r1, #4
+	movs r2, #1
+	movs r3, #1
+	bl sub_800172C
+	adds r5, #0x4c
+	movs r0, #0x15
+	strh r0, [r5]
+	movs r4, #9
+_080213B0:
+	bl sub_80D74B0
+	subs r4, #1
+	cmp r4, #0
+	bge _080213B0
+	bl EnablePaletteSync
+	add sp, #4
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080213C8: .4byte gLCDControlBuffer
+_080213CC: .4byte gUnknown_08A0AB0C
+_080213D0: .4byte 0x06001000
+_080213D4: .4byte gUnknown_08A0AE64
+_080213D8: .4byte gUnknown_08A07DD8
+_080213DC: .4byte 0x06002000
+_080213E0: .4byte gUnknown_08A0AE44
+_080213E4: .4byte gUnknown_02022EF6
+_080213E8: .4byte gUnknown_08A0AE84
+_080213EC: .4byte sub_802127C
+_080213F0: .4byte gPaletteBuffer
+
+	THUMB_FUNC_START sub_80213F4
+sub_80213F4: @ 0x080213F4
+	push {r4, lr}
+	adds r4, r0, #0
+	bl GetGameClock
+	movs r1, #7
+	ands r1, r0
+	cmp r1, #0
+	bne _08021422
+	bl sub_80D74B0
+	bl EnablePaletteSync
+	adds r1, r4, #0
+	adds r1, #0x4c
+	ldrh r0, [r1]
+	subs r0, #1
+	strh r0, [r1]
+	lsls r0, r0, #0x10
+	cmp r0, #0
+	bge _08021422
+	adds r0, r4, #0
+	bl Proc_ClearNativeCallback
+_08021422:
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_8021428
+sub_8021428: @ 0x08021428
+	adds r0, #0x4e
+	ldr r1, _08021430  @ 0x000005DC
+	strh r1, [r0]
+	bx lr
+	.align 2, 0
+_08021430: .4byte 0x000005DC
+
+	THUMB_FUNC_START sub_8021434
+sub_8021434: @ 0x08021434
+	push {r4, lr}
+	adds r4, r0, #0
+	adds r1, r4, #0
+	adds r1, #0x4e
+	ldrh r0, [r1]
+	subs r0, #1
+	strh r0, [r1]
+	lsls r0, r0, #0x10
+	cmp r0, #0
+	bge _08021450
+	adds r0, r4, #0
+	movs r1, #0x63
+	bl Proc_GotoLabel
+_08021450:
+	ldr r0, _0802146C  @ gKeyStatusPtr
+	ldr r0, [r0]
+	ldrh r1, [r0, #8]
+	movs r0, #0xb
+	ands r0, r1
+	cmp r0, #0
+	beq _08021466
+	adds r0, r4, #0
+	movs r1, #0x63
+	bl Proc_GotoLabel
+_08021466:
+	pop {r4}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802146C: .4byte gKeyStatusPtr
+
+	THUMB_FUNC_START sub_8021470
+sub_8021470: @ 0x08021470
+	push {r4, r5, lr}
+	bl sub_8001710
+	ldr r4, _080214A4  @ gPaletteBuffer
+	movs r5, #1
+	negs r5, r5
+	adds r0, r4, #0
+	movs r1, #0
+	movs r2, #1
+	adds r3, r5, #0
+	bl sub_800172C
+	adds r4, #0x80
+	adds r0, r4, #0
+	movs r1, #4
+	movs r2, #1
+	adds r3, r5, #0
+	bl sub_800172C
+	movs r0, #4
+	bl Sound_FadeOut800231C
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080214A4: .4byte gPaletteBuffer
+
+	THUMB_FUNC_START sub_80214A8
+sub_80214A8: @ 0x080214A8
+	push {r4, lr}
+	adds r4, r0, #0
+	bl sub_80D74B0
+	bl EnablePaletteSync
+	adds r1, r4, #0
+	adds r1, #0x4c
+	ldrh r0, [r1]
+	adds r0, #1
+	strh r0, [r1]
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x10
+	cmp r0, #0x20
+	bne _080214CC
+	adds r0, r4, #0
+	bl Proc_ClearNativeCallback
+_080214CC:
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_80214D4
+sub_80214D4: @ 0x080214D4
+	push {lr}
+	movs r0, #0
+	bl SetPrimaryHBlankHandler
+	movs r0, #0
+	bl SetSecondaryHBlankHandler
+	ldr r2, _08021510  @ gLCDControlBuffer
+	ldrb r1, [r2, #1]
+	movs r0, #2
+	negs r0, r0
+	ands r0, r1
+	movs r1, #3
+	negs r1, r1
+	ands r0, r1
+	subs r1, #2
+	ands r0, r1
+	subs r1, #4
+	ands r0, r1
+	subs r1, #8
+	ands r0, r1
+	strb r0, [r2, #1]
+	ldr r1, _08021514  @ gPaletteBuffer
+	movs r0, #0
+	strh r0, [r1]
+	bl EnablePaletteSync
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021510: .4byte gLCDControlBuffer
+_08021514: .4byte gPaletteBuffer
+
+	THUMB_FUNC_START sub_8021518
+sub_8021518: @ 0x08021518
+	push {lr}
+	adds r1, r0, #0
+	cmp r1, #0
+	beq _0802152C
+	ldr r0, _08021528  @ gUnknown_0859B358
+	bl Proc_CreateBlockingChild
+	b _08021534
+	.align 2, 0
+_08021528: .4byte gUnknown_0859B358
+_0802152C:
+	ldr r0, _08021538  @ gUnknown_0859B358
+	movs r1, #3
+	bl Proc_Create
+_08021534:
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021538: .4byte gUnknown_0859B358
+
+.align 2, 0 @ align with 0

--- a/asm/lightrunefx.s
+++ b/asm/lightrunefx.s
@@ -1,0 +1,568 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ The effect that plays when putting down a light rune
+
+	THUMB_FUNC_START sub_802153C
+sub_802153C: @ 0x0802153C
+	push {r4, r5, r6, lr}
+	sub sp, #4
+	adds r6, r0, #0
+	ldr r0, _080215D4  @ gUnknown_085A403C
+	ldr r1, _080215D8  @ 0x06002000
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _080215DC  @ gUnknown_085A5760
+	movs r1, #0x40
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	ldr r0, _080215E0  @ gUnknown_085A5780
+	ldr r4, _080215E4  @ gUnknown_02003D2C
+	adds r1, r4, #0
+	bl CopyDataWithPossibleUncomp
+	movs r0, #0x84
+	lsls r0, r0, #6
+	adds r1, r0, #0
+	movs r5, #0xd8
+	lsls r5, r5, #2
+_08021568:
+	ldrh r2, [r4]
+	adds r0, r1, r2
+	strh r0, [r4]
+	adds r4, #2
+	subs r5, #1
+	cmp r5, #0
+	bne _08021568
+	ldr r0, _080215E8  @ gBG0TilemapBuffer
+	movs r1, #0x80
+	lsls r1, r1, #1
+	bl BG_Fill
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	ldr r0, _080215EC  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _0802159A
+	movs r0, #0xb6
+	lsls r0, r0, #2
+	bl m4aSongNumStart
+_0802159A:
+	movs r0, #1
+	movs r1, #0x10
+	movs r2, #0x10
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	str r5, [sp]
+	movs r0, #1
+	movs r1, #0
+	movs r2, #0
+	movs r3, #0
+	bl sub_8001ED0
+	movs r0, #1
+	str r0, [sp]
+	movs r0, #0
+	movs r1, #1
+	movs r2, #1
+	movs r3, #1
+	bl sub_8001F0C
+	adds r0, r6, #0
+	adds r0, #0x4c
+	strh r5, [r0]
+	add sp, #4
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080215D4: .4byte gUnknown_085A403C
+_080215D8: .4byte 0x06002000
+_080215DC: .4byte gUnknown_085A5760
+_080215E0: .4byte gUnknown_085A5780
+_080215E4: .4byte gUnknown_02003D2C
+_080215E8: .4byte gBG0TilemapBuffer
+_080215EC: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START sub_80215F0
+sub_80215F0: @ 0x080215F0
+	push {r4, r5, r6, lr}
+	sub sp, #0x34
+	adds r6, r0, #0
+	ldr r1, _0802162C  @ gUnknown_080D7B30
+	mov r0, sp
+	movs r2, #0x34
+	bl memcpy
+	adds r1, r6, #0
+	adds r1, #0x4c
+	ldrh r0, [r1]
+	adds r0, #1
+	strh r0, [r1]
+	movs r2, #0
+	ldrsh r0, [r1, r2]
+	movs r1, #3
+	bl __divsi3
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0xe
+	add r0, sp
+	ldrb r4, [r0]
+	ldrb r5, [r0, #1]
+	cmp r4, #0xff
+	bne _08021630
+	adds r0, r6, #0
+	bl Proc_ClearNativeCallback
+	b _08021656
+	.align 2, 0
+_0802162C: .4byte gUnknown_080D7B30
+_08021630:
+	cmp r4, #0x18
+	bne _0802163C
+	cmp r5, #9
+	bne _0802163C
+	bl SMS_UpdateFromGameData
+_0802163C:
+	lsls r0, r5, #5
+	adds r0, r0, r4
+	lsls r0, r0, #1
+	ldr r1, _08021660  @ gUnknown_02003D2C
+	adds r0, r0, r1
+	ldr r1, _08021664  @ gBG0TilemapBuffer
+	movs r2, #8
+	movs r3, #9
+	bl TileMap_CopyRect
+	movs r0, #1
+	bl BG_EnableSyncByMask
+_08021656:
+	add sp, #0x34
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021660: .4byte gUnknown_02003D2C
+_08021664: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_8021668
+sub_8021668: @ 0x08021668
+	push {lr}
+	bl SetDefaultColorEffects
+	ldr r0, _08021680  @ gBG0TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021680: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_8021684
+sub_8021684: @ 0x08021684
+	push {r4, r5, lr}
+	adds r3, r0, #0
+	adds r4, r1, #0
+	adds r5, r2, #0
+	ldr r0, _080216C8  @ gUnknown_0859B3B0
+	adds r1, r3, #0
+	bl Proc_CreateBlockingChild
+	lsls r0, r4, #4
+	ldr r2, _080216CC  @ gUnknown_0202BCB0
+	movs r3, #0xc
+	ldrsh r1, [r2, r3]
+	subs r0, r0, r1
+	adds r4, r0, #0
+	subs r4, #0x18
+	lsls r0, r5, #4
+	movs r3, #0xe
+	ldrsh r1, [r2, r3]
+	subs r0, r0, r1
+	adds r5, r0, #0
+	subs r5, #0x28
+	negs r1, r4
+	lsls r1, r1, #0x10
+	lsrs r1, r1, #0x10
+	negs r2, r5
+	lsls r2, r2, #0x10
+	lsrs r2, r2, #0x10
+	movs r0, #0
+	bl BG_SetPosition
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080216C8: .4byte gUnknown_0859B3B0
+_080216CC: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_80216D0
+sub_80216D0: @ 0x080216D0
+	push {r4, r5, r6, lr}
+	sub sp, #4
+	adds r6, r0, #0
+	ldr r0, _08021768  @ gUnknown_085A403C
+	ldr r1, _0802176C  @ 0x06002000
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _08021770  @ gUnknown_085A5760
+	movs r1, #0x40
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	ldr r0, _08021774  @ gUnknown_085A5780
+	ldr r4, _08021778  @ gUnknown_02003D2C
+	adds r1, r4, #0
+	bl CopyDataWithPossibleUncomp
+	movs r0, #0x84
+	lsls r0, r0, #6
+	adds r1, r0, #0
+	movs r5, #0xd8
+	lsls r5, r5, #2
+_080216FC:
+	ldrh r2, [r4]
+	adds r0, r1, r2
+	strh r0, [r4]
+	adds r4, #2
+	subs r5, #1
+	cmp r5, #0
+	bne _080216FC
+	ldr r0, _0802177C  @ gBG0TilemapBuffer
+	movs r1, #0x80
+	lsls r1, r1, #1
+	bl BG_Fill
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	ldr r0, _08021780  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _0802172E
+	movs r0, #0xb6
+	lsls r0, r0, #2
+	bl m4aSongNumStart
+_0802172E:
+	movs r0, #1
+	movs r1, #0x10
+	movs r2, #0x10
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	str r5, [sp]
+	movs r0, #1
+	movs r1, #0
+	movs r2, #0
+	movs r3, #0
+	bl sub_8001ED0
+	movs r0, #1
+	str r0, [sp]
+	movs r0, #0
+	movs r1, #1
+	movs r2, #1
+	movs r3, #1
+	bl sub_8001F0C
+	adds r0, r6, #0
+	adds r0, #0x4c
+	strh r5, [r0]
+	add sp, #4
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021768: .4byte gUnknown_085A403C
+_0802176C: .4byte 0x06002000
+_08021770: .4byte gUnknown_085A5760
+_08021774: .4byte gUnknown_085A5780
+_08021778: .4byte gUnknown_02003D2C
+_0802177C: .4byte gBG0TilemapBuffer
+_08021780: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START sub_8021784
+sub_8021784: @ 0x08021784
+	push {r4, r5, r6, lr}
+	sub sp, #0x34
+	adds r6, r0, #0
+	ldr r1, _080217C0  @ gUnknown_080D7B64
+	mov r0, sp
+	movs r2, #0x34
+	bl memcpy
+	adds r1, r6, #0
+	adds r1, #0x4c
+	ldrh r0, [r1]
+	adds r0, #1
+	strh r0, [r1]
+	movs r2, #0
+	ldrsh r0, [r1, r2]
+	movs r1, #3
+	bl __divsi3
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0xe
+	add r0, sp
+	ldrb r4, [r0]
+	ldrb r5, [r0, #1]
+	cmp r4, #0xff
+	bne _080217C4
+	adds r0, r6, #0
+	bl Proc_ClearNativeCallback
+	b _080217EA
+	.align 2, 0
+_080217C0: .4byte gUnknown_080D7B64
+_080217C4:
+	cmp r4, #0x18
+	bne _080217D0
+	cmp r5, #9
+	bne _080217D0
+	bl SMS_UpdateFromGameData
+_080217D0:
+	lsls r0, r5, #5
+	adds r0, r0, r4
+	lsls r0, r0, #1
+	ldr r1, _080217F4  @ gUnknown_02003D2C
+	adds r0, r0, r1
+	ldr r1, _080217F8  @ gBG0TilemapBuffer
+	movs r2, #8
+	movs r3, #9
+	bl TileMap_CopyRect
+	movs r0, #1
+	bl BG_EnableSyncByMask
+_080217EA:
+	add sp, #0x34
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080217F4: .4byte gUnknown_02003D2C
+_080217F8: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_80217FC
+sub_80217FC: @ 0x080217FC
+	push {lr}
+	bl SetDefaultColorEffects
+	ldr r0, _08021814  @ gBG0TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021814: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_8021818
+sub_8021818: @ 0x08021818
+	push {r4, r5, lr}
+	adds r3, r0, #0
+	adds r4, r1, #0
+	adds r5, r2, #0
+	ldr r0, _0802185C  @ gUnknown_0859B3D0
+	adds r1, r3, #0
+	bl Proc_CreateBlockingChild
+	lsls r0, r4, #4
+	ldr r2, _08021860  @ gUnknown_0202BCB0
+	movs r3, #0xc
+	ldrsh r1, [r2, r3]
+	subs r0, r0, r1
+	adds r4, r0, #0
+	subs r4, #0x18
+	lsls r0, r5, #4
+	movs r3, #0xe
+	ldrsh r1, [r2, r3]
+	subs r0, r0, r1
+	adds r5, r0, #0
+	subs r5, #0x28
+	negs r1, r4
+	lsls r1, r1, #0x10
+	lsrs r1, r1, #0x10
+	negs r2, r5
+	lsls r2, r2, #0x10
+	lsrs r2, r2, #0x10
+	movs r0, #0
+	bl BG_SetPosition
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_0802185C: .4byte gUnknown_0859B3D0
+_08021860: .4byte gUnknown_0202BCB0
+
+	THUMB_FUNC_START sub_8021864
+sub_8021864: @ 0x08021864
+	push {r4, r5, r6, lr}
+	sub sp, #4
+	adds r6, r0, #0
+	ldr r0, _080218FC  @ gUnknown_085A403C
+	ldr r1, _08021900  @ 0x06002000
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _08021904  @ gUnknown_085A5760
+	movs r1, #0x40
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	ldr r0, _08021908  @ gUnknown_085A5780
+	ldr r4, _0802190C  @ gUnknown_02003D2C
+	adds r1, r4, #0
+	bl CopyDataWithPossibleUncomp
+	movs r0, #0x84
+	lsls r0, r0, #6
+	adds r1, r0, #0
+	movs r5, #0xd8
+	lsls r5, r5, #2
+_08021890:
+	ldrh r2, [r4]
+	adds r0, r1, r2
+	strh r0, [r4]
+	adds r4, #2
+	subs r5, #1
+	cmp r5, #0
+	bne _08021890
+	ldr r0, _08021910  @ gBG0TilemapBuffer
+	movs r1, #0x80
+	lsls r1, r1, #1
+	bl BG_Fill
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	ldr r0, _08021914  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _080218C2
+	movs r0, #0xb6
+	lsls r0, r0, #2
+	bl m4aSongNumStart
+_080218C2:
+	movs r0, #1
+	movs r1, #0x10
+	movs r2, #0x10
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	str r5, [sp]
+	movs r0, #1
+	movs r1, #0
+	movs r2, #0
+	movs r3, #0
+	bl sub_8001ED0
+	movs r0, #1
+	str r0, [sp]
+	movs r0, #0
+	movs r1, #1
+	movs r2, #1
+	movs r3, #1
+	bl sub_8001F0C
+	adds r0, r6, #0
+	adds r0, #0x4c
+	strh r5, [r0]
+	add sp, #4
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080218FC: .4byte gUnknown_085A403C
+_08021900: .4byte 0x06002000
+_08021904: .4byte gUnknown_085A5760
+_08021908: .4byte gUnknown_085A5780
+_0802190C: .4byte gUnknown_02003D2C
+_08021910: .4byte gBG0TilemapBuffer
+_08021914: .4byte gUnknown_0202BCF0
+
+	THUMB_FUNC_START sub_8021918
+sub_8021918: @ 0x08021918
+	push {r4, r5, r6, lr}
+	sub sp, #0x34
+	adds r6, r0, #0
+	ldr r1, _08021954  @ gUnknown_080D7B98
+	mov r0, sp
+	movs r2, #0x34
+	bl memcpy
+	adds r1, r6, #0
+	adds r1, #0x4c
+	ldrh r0, [r1]
+	adds r0, #1
+	strh r0, [r1]
+	movs r2, #0
+	ldrsh r0, [r1, r2]
+	movs r1, #3
+	bl __divsi3
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0xe
+	add r0, sp
+	ldrb r4, [r0]
+	ldrb r5, [r0, #1]
+	cmp r4, #0xff
+	bne _08021958
+	adds r0, r6, #0
+	bl Proc_ClearNativeCallback
+	b _0802197E
+	.align 2, 0
+_08021954: .4byte gUnknown_080D7B98
+_08021958:
+	cmp r4, #0x18
+	bne _08021964
+	cmp r5, #9
+	bne _08021964
+	bl SMS_UpdateFromGameData
+_08021964:
+	lsls r0, r5, #5
+	adds r0, r0, r4
+	lsls r0, r0, #1
+	ldr r1, _08021988  @ gUnknown_02003D2C
+	adds r0, r0, r1
+	ldr r1, _0802198C  @ gBG0TilemapBuffer
+	movs r2, #8
+	movs r3, #9
+	bl TileMap_CopyRect
+	movs r0, #1
+	bl BG_EnableSyncByMask
+_0802197E:
+	add sp, #0x34
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021988: .4byte gUnknown_02003D2C
+_0802198C: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_8021990
+sub_8021990: @ 0x08021990
+	push {lr}
+	bl SetDefaultColorEffects
+	ldr r0, _080219A8  @ gBG0TilemapBuffer
+	movs r1, #0
+	bl BG_Fill
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080219A8: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_80219AC
+sub_80219AC: @ 0x080219AC
+	push {r4, r5, lr}
+	adds r3, r0, #0
+	adds r4, r1, #0
+	adds r5, r2, #0
+	ldr r0, _080219F0  @ gUnknown_0859B3F0
+	adds r1, r3, #0
+	bl Proc_CreateBlockingChild
+	lsls r0, r4, #4
+	ldr r2, _080219F4  @ gUnknown_0202BCB0
+	movs r3, #0xc
+	ldrsh r1, [r2, r3]
+	subs r0, r0, r1
+	adds r4, r0, #0
+	subs r4, #0x18
+	lsls r0, r5, #4
+	movs r3, #0xe
+	ldrsh r1, [r2, r3]
+	subs r0, r0, r1
+	adds r5, r0, #0
+	subs r5, #0x28
+	negs r1, r4
+	lsls r1, r1, #0x10
+	lsrs r1, r1, #0x10
+	negs r2, r5
+	lsls r2, r2, #0x10
+	lsrs r2, r2, #0x10
+	movs r0, #0
+	bl BG_SetPosition
+	pop {r4, r5}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080219F0: .4byte gUnknown_0859B3F0
+_080219F4: .4byte gUnknown_0202BCB0
+
+.align 2, 0 @ align with 0

--- a/asm/minefx.s
+++ b/asm/minefx.s
@@ -1,0 +1,79 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ Map effect happening when a mine is being set
+
+	THUMB_FUNC_START sub_80222E0
+sub_80222E0: @ 0x080222E0
+	push {lr}
+	ldr r0, _080222F8  @ gUnknown_0202BCF0
+	adds r0, #0x41
+	ldrb r0, [r0]
+	lsls r0, r0, #0x1e
+	cmp r0, #0
+	blt _080222F4
+	ldr r0, _080222FC  @ 0x000002F9
+	bl m4aSongNumStart
+_080222F4:
+	pop {r0}
+	bx r0
+	.align 2, 0
+_080222F8: .4byte gUnknown_0202BCF0
+_080222FC: .4byte 0x000002F9
+
+	THUMB_FUNC_START sub_8022300
+sub_8022300: @ 0x08022300
+	push {r4, r5, r6, lr}
+	sub sp, #8
+	adds r4, r0, #0
+	adds r5, r1, #0
+	adds r6, r2, #0
+	lsls r0, r5, #4
+	ldr r2, _08022364  @ gUnknown_0202BCB0
+	movs r3, #0xc
+	ldrsh r1, [r2, r3]
+	subs r0, r0, r1
+	adds r5, r0, #0
+	adds r5, #8
+	lsls r0, r6, #4
+	movs r3, #0xe
+	ldrsh r1, [r2, r3]
+	subs r0, r0, r1
+	adds r6, r0, #4
+	adds r0, r4, #0
+	movs r1, #0x20
+	bl NewBlockingTimer
+	ldr r0, _08022368  @ gUnknown_085A7CC0
+	ldr r1, _0802236C  @ 0x06013000
+	bl CopyDataWithPossibleUncomp
+	ldr r0, _08022370  @ gUnknown_085A7EC8
+	movs r1, #0xa8
+	lsls r1, r1, #2
+	movs r2, #0x20
+	bl CopyToPaletteBuffer
+	ldr r0, _08022374  @ gUnknown_085A7E34
+	movs r3, #0xa3
+	lsls r3, r3, #7
+	movs r1, #0
+	str r1, [sp]
+	str r1, [sp, #4]
+	adds r1, r5, #0
+	adds r2, r6, #0
+	bl APProc_Create
+	ldr r0, _08022378  @ gUnknown_0859B560
+	adds r1, r4, #0
+	bl Proc_Create
+	add sp, #8
+	pop {r4, r5, r6}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08022364: .4byte gUnknown_0202BCB0
+_08022368: .4byte gUnknown_085A7CC0
+_0802236C: .4byte 0x06013000
+_08022370: .4byte gUnknown_085A7EC8
+_08022374: .4byte gUnknown_085A7E34
+_08022378: .4byte gUnknown_0859B560
+
+.align 2, 0

--- a/asm/whitecircularfadefx.s
+++ b/asm/whitecircularfadefx.s
@@ -1,0 +1,218 @@
+	.INCLUDE "macro.inc"
+
+	.SYNTAX UNIFIED
+
+	@ Some white circular fade effect proc. Seems unused
+
+	THUMB_FUNC_START sub_8021E10
+sub_8021E10: @ 0x08021E10
+	push {r4, r5, r6, r7, lr}
+	mov r7, sl
+	mov r6, r9
+	mov r5, r8
+	push {r5, r6, r7}
+	adds r7, r0, #0
+	adds r2, r7, #0
+	adds r2, #0x4c
+	movs r0, #0
+	ldrsh r1, [r2, r0]
+	lsls r0, r1, #2
+	adds r0, r0, r1
+	movs r1, #0x40
+	subs r1, r1, r0
+	mov r9, r1
+	movs r0, #0
+	mov sl, r2
+_08021E32:
+	movs r6, #0
+	lsls r5, r0, #3
+	adds r1, r0, #1
+	mov r8, r1
+	lsls r0, r0, #6
+	ldr r2, _08021EC8  @ gBG0TilemapBuffer
+	adds r4, r0, r2
+_08021E40:
+	lsls r2, r6, #3
+	ldr r1, [r7, #0x2c]
+	subs r0, r1, r2
+	cmp r0, #0
+	bge _08021E4C
+	subs r0, r2, r1
+_08021E4C:
+	ldr r2, [r7, #0x30]
+	subs r1, r2, r5
+	cmp r1, #0
+	bge _08021E56
+	subs r1, r5, r2
+_08021E56:
+	adds r2, r0, #0
+	muls r2, r0, r2
+	adds r0, r2, #0
+	adds r2, r1, #0
+	muls r2, r1, r2
+	adds r1, r2, #0
+	adds r0, r0, r1
+	bl Sqrt
+	lsls r0, r0, #0x10
+	lsrs r0, r0, #0x10
+	add r0, r9
+	cmp r0, #0
+	bge _08021E74
+	adds r0, #3
+_08021E74:
+	asrs r1, r0, #2
+	movs r0, #0xf
+	subs r0, r0, r1
+	cmp r0, #0xf
+	ble _08021E80
+	movs r0, #0xf
+_08021E80:
+	cmp r0, #0
+	bge _08021E86
+	movs r0, #0
+_08021E86:
+	movs r1, #0x84
+	lsls r1, r1, #6
+	adds r0, r0, r1
+	strh r0, [r4]
+	adds r4, #2
+	adds r6, #1
+	cmp r6, #0x1d
+	ble _08021E40
+	mov r0, r8
+	cmp r0, #0x13
+	ble _08021E32
+	movs r0, #1
+	bl BG_EnableSyncByMask
+	mov r2, sl
+	ldrh r0, [r2]
+	adds r0, #1
+	strh r0, [r2]
+	lsls r0, r0, #0x10
+	asrs r0, r0, #0x10
+	cmp r0, #0x46
+	ble _08021EB8
+	adds r0, r7, #0
+	bl Proc_ClearNativeCallback
+_08021EB8:
+	pop {r3, r4, r5}
+	mov r8, r3
+	mov r9, r4
+	mov sl, r5
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021EC8: .4byte gBG0TilemapBuffer
+
+	THUMB_FUNC_START sub_8021ECC
+sub_8021ECC: @ 0x08021ECC
+	push {r4, lr}
+	sub sp, #4
+	movs r0, #2
+	movs r1, #0
+	movs r2, #0
+	movs r3, #0x10
+	bl SetSpecialColorEffectsParameters
+	movs r4, #1
+	str r4, [sp]
+	movs r0, #1
+	movs r1, #1
+	movs r2, #1
+	movs r3, #1
+	bl sub_8001ED0
+	str r4, [sp]
+	movs r0, #1
+	movs r1, #1
+	movs r2, #1
+	movs r3, #1
+	bl sub_8001F0C
+	bl ClearBG0BG1
+	add sp, #4
+	pop {r4}
+	pop {r0}
+	bx r0
+
+	THUMB_FUNC_START sub_8021F08
+sub_8021F08: @ 0x08021F08
+	push {r4, r5, r6, r7, lr}
+	sub sp, #4
+	adds r5, r0, #0
+	adds r6, r1, #0
+	adds r7, r2, #0
+	ldr r2, _08021FA8  @ 0x06002000
+	movs r1, #0
+	ldr r4, _08021FAC  @ 0x11111111
+	movs r3, #0x1f
+_08021F1A:
+	movs r0, #7
+_08021F1C:
+	stm r2!, {r1}
+	subs r0, #1
+	cmp r0, #0
+	bge _08021F1C
+	adds r1, r1, r4
+	subs r3, #1
+	cmp r3, #0
+	bge _08021F1A
+	movs r3, #0
+	ldr r0, _08021FB0  @ gPaletteBuffer
+	adds r4, r0, #0
+	adds r4, #0x40
+_08021F34:
+	lsls r0, r3, #1
+	lsls r1, r3, #0xb
+	lsls r2, r3, #6
+	adds r1, r1, r2
+	adds r1, r1, r0
+	strh r1, [r4]
+	adds r4, #2
+	adds r3, #1
+	cmp r3, #0xf
+	ble _08021F34
+	movs r4, #0
+	bl EnablePaletteSync
+	movs r0, #1
+	movs r1, #0x10
+	movs r2, #0x10
+	movs r3, #0
+	bl SetSpecialColorEffectsParameters
+	str r4, [sp]
+	movs r0, #1
+	movs r1, #0
+	movs r2, #0
+	movs r3, #0
+	bl sub_8001ED0
+	movs r0, #1
+	str r0, [sp]
+	movs r0, #0
+	movs r1, #1
+	movs r2, #1
+	movs r3, #1
+	bl sub_8001F0C
+	movs r0, #0
+	movs r1, #0
+	movs r2, #0
+	bl BG_SetPosition
+	bl ClearBG0BG1
+	movs r0, #0
+	movs r1, #0
+	bl SetBackgroundTileDataOffset
+	ldr r0, _08021FB4  @ gUnknown_0859B4F8
+	adds r1, r5, #0
+	bl Proc_Create
+	str r6, [r0, #0x2c]
+	str r7, [r0, #0x30]
+	adds r0, #0x4c
+	strh r4, [r0]
+	add sp, #4
+	pop {r4, r5, r6, r7}
+	pop {r0}
+	bx r0
+	.align 2, 0
+_08021FA8: .4byte 0x06002000
+_08021FAC: .4byte 0x11111111
+_08021FB0: .4byte gPaletteBuffer
+_08021FB4: .4byte gUnknown_0859B4F8
+
+.align 2, 0

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -76,6 +76,11 @@ SECTIONS
         asm/lightrunefx.o(.text);
         asm/danceringfx.o(.text);
         asm/eventwarpfx.o(.text);
+        asm/whitecircularfadefx.o(.text);
+        asm/emitstarfx.o(.text);
+        asm/minefx.o(.text);
+        asm/chapterintrofx_title.o(.text);
+        asm/bmmenu.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -72,6 +72,9 @@ SECTIONS
         asm/trapfx.o(.text);
         asm/notifybox.o(.text);
         asm/chapterintrofx.o(.text);
+        asm/gameoverbgfx.o(.text);
+        asm/lightrunefx.o(.text);
+        asm/danceringfx.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -86,6 +86,8 @@ SECTIONS
         asm/bmtarget.o(.text);
         asm/bmudisp.o(.text);
         asm/bmreliance.o(.text);
+        asm/bmitemuse.o(.text);
+        asm/bmbattle.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -84,6 +84,8 @@ SECTIONS
         asm/bmphase.o(.text);
         asm/bmgold.o(.text);
         asm/bmtarget.o(.text);
+        asm/bmudisp.o(.text);
+        asm/bmreliance.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -71,6 +71,7 @@ SECTIONS
         asm/code_801F50C.o(.text); /* ChangeActiveUnitFacing */
         asm/trapfx.o(.text);
         asm/notifybox.o(.text);
+        asm/chapterintrofx.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -81,6 +81,9 @@ SECTIONS
         asm/minefx.o(.text);
         asm/chapterintrofx_title.o(.text);
         asm/bmmenu.o(.text);
+        asm/bmphase.o(.text);
+        asm/bmgold.o(.text);
+        asm/bmtarget.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -75,6 +75,7 @@ SECTIONS
         asm/gameoverbgfx.o(.text);
         asm/lightrunefx.o(.text);
         asm/danceringfx.o(.text);
+        asm/eventwarpfx.o(.text);
         asm/code.o(.text);
         asm/m4a_1.o(.text);
         src/m4a_2.o(.text);


### PR DESCRIPTION
- the following, and some more before that as well, were probably part of a single big `bmfx` file. But I feel like keeping them split is better for decompilation (we'll probably see after that whether we still want them separate or not)
  - `chapterintrofx` : Chapter Introduction proc with the twin ball effect and all
  - `gameoverbgfx` : Game over background effect
  - `lightrunefx` : Light rune placing map animation
  - `danceringfx` : Dance ring map animation
  - `eventwarpfx` : Warp effect as when called through events (*not* warp/rescue staff)
  - `whitecircularfadefx` : Some neat but unused (?) fade effect that looks like an expanding white circle
  - `emitstarfx` : Some unused (?) little star emitting effect
  - `minefx` : Mine placing map animation
  - `chapterintrofx_title` : Proc displaying (only) chapter title graphics in the middle of the screen
- `bmmenu` : Map & Unit Menu Commands and Target Selectors
- `bmphase` : Various Phase/Allegiance utility routines
- `bmgold` : Get/Set/Add gold amount
- `bmtarget` : List valid targets for various actions
- `bmudisp` : Standing Map Sprite System (**b**attle **m**ap **u**nit **disp**lay)
- `bmreliance` : Unit Support (gain) calculations
- `bmitemuse` : Item use effects and related routines
- `bmbattle` : Battle logic

Next is definitely `bmtrade`, but that's for another time.