### PR TITLE
Work around compress linker EABI mismatch errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,8 @@ include graphics_file_rules.mk
 %.8bpp: %.png  ; $(GBAGFX) $< $@
 %.gbapal: %.pal
 ifneq ($(OS),Windows_NT)
-	unix2dos $<
+	# unix2dos $< # not standard unix! =(
+	sed -i -e 's/\r*$$/\r/' $<
 endif
 	$(GBAGFX) $< $@
 %.gbapal: %.png ; $(GBAGFX) $< $@

--- a/scripts/arm_compressing_linker.py
+++ b/scripts/arm_compressing_linker.py
@@ -81,7 +81,7 @@ def link_to_output(outputfile, filename, section, base_addr, ld,
     if is_debug:
         print(cmd)
     os.system(cmd)
-    cmd = '%s -e 0x%X -Tdata 0x%X%s -o %s %s.bak.o %s' % (
+    cmd = '%s --no-warn-mismatch -e 0x%X -Tdata 0x%X%s -o %s %s.bak.o %s' % (
         ld, base_addr, base_addr, unique_section, outputfile, outputfile,
         filename)
     if is_debug:

--- a/scripts/arm_compressing_linker.py
+++ b/scripts/arm_compressing_linker.py
@@ -107,7 +107,7 @@ def remove_section_in_object(filename, section, objcopy, is_debug):
     if is_debug:
         print(cmd)
     os.system(cmd)
-    cmd = '%s -O elf32-littlearm -R %s %s.bak.o %s' % (
+    cmd = '%s -O elf32-littlearm -B armv4t -R %s %s.bak.o %s' % (
         objcopy, section, filename, filename)
     if is_debug:
         print(cmd)


### PR DESCRIPTION
I was getting a bunch of those errors:

    [...]/arm-none-eabi-ld: error: source object data/banim/[...].o has EABI version 5, but target data/banim/data_banim.o.bak.o has EABI version 0

Which made banims fail to build entirely, which in turn made everything fail to build entirely :/

~~I managed to fix it (for me at least) by adding a `-B armv4t` to the objcopy invocation where there wasn't one in the compressing linker.~~ See comment below.