### PR TITLE
keep debug info in elf to help decompiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,19 @@ GBAGFX   := tools/gbagfx/gbagfx$(EXE)
 SCANINC  := tools/scaninc/scaninc$(EXE)
 PREPROC  := tools/preproc/preproc$(EXE)
 
-CC1FLAGS := -mthumb-interwork -Wimplicit -Wparentheses -Werror -O2 -fhex-asm
+ifeq ($(UNAME),Darwin)
+	SED := sed -i ''
+else
+	SED := sed -i
+endif
+
+ifeq ($(UNAME),Darwin)
+	SHASUM := shasum
+else
+	SHASUM := sha1sum
+endif
+
+CC1FLAGS := -mthumb-interwork -Wimplicit -Wparentheses -Werror -O2 -fhex-asm -g
 CPPFLAGS := -I tools/agbcc/include -iquote include -iquote . -nostdinc -undef
 ASFLAGS  := -mcpu=arm7tdmi -mthumb-interwork -I include
 
@@ -54,7 +66,7 @@ ALL_OBJECTS  := $(C_OBJECTS) $(ASM_OBJECTS) data/banim/data_banim.o
 DEPS_DIR     := .dep
 
 # Use the older compiler to build library code
-src/agb_sram.o: CC1FLAGS := -mthumb-interwork -Wimplicit -Wparentheses -Werror -O1
+src/agb_sram.o: CC1FLAGS := -mthumb-interwork -Wimplicit -Wparentheses -Werror -O1 -g
 src/m4a.o: CC1 := $(CC1_OLD)
 
 # TODO: find a more elegant solution to the inlining issue
@@ -63,11 +75,7 @@ src/bmitem.o: CC1FLAGS += -Wno-error
 #### Main Targets ####
 
 compare: $(ROM)
-ifeq ($(UNAME),Darwin)
-	shasum -c checksum.sha1
-else
-	sha1sum -c checksum.sha1
-endif
+	$(SHASUM) -c checksum.sha1
 
 clean:
 	find . \( -iname '*.1bpp' -o -iname '*.4bpp' -o -iname '*.8bpp' -o -iname '*.gbapal' -o -iname '*.lz' -o -iname '*.fk' -o -iname '*.latfont' -o -iname '*.hwjpnfont' -o -iname '*.fwjpnfont' \) -exec rm {} +
@@ -91,9 +99,9 @@ include graphics_file_rules.mk
 %.gbapal: %.pal
 ifneq ($(OS),Windows_NT)
 ifeq ($(UNAME),Darwin)
-	sed -i '' $$'s/\r*$$/\r/' $<
+	$(SED) $$'s/\r*$$/\r/' $<
 else
-	sed -i -e 's/\r*$$/\r/' $<
+	$(SED) -e 's/\r*$$/\r/' $<
 endif
 endif
 	$(GBAGFX) $< $@
@@ -133,12 +141,17 @@ $(ELF): $(ALL_OBJECTS) $(LDSCRIPT) $(SYM_FILES)
 	$(LD) -T $(LDSCRIPT) -Map $(MAP) $(ALL_OBJECTS) tools/agbcc/lib/libgcc.a tools/agbcc/lib/libc.a -o $@
 
 %.gba: %.elf
-	$(OBJCOPY) -O binary --pad-to 0x9000000 --gap-fill=0xff $< $@
+	$(OBJCOPY) --strip-debug -O binary --pad-to 0x9000000 --gap-fill=0xff $< $@
 
 $(C_OBJECTS): %.o: %.c $(DEPS_DIR)/%.d
 	@$(MAKEDEP)
 	$(CPP) $(CPPFLAGS) $< | $(CC1) $(CC1FLAGS) -o $*.s
 	echo '.ALIGN 2, 0' >> $*.s
+ifeq ($(UNAME),Darwin)
+	$(SED) -f scripts/align_2_before_debug_section_for_osx.sed $*.s
+else
+	$(SED) '/.section	.debug_/i\.align 2, 0' $*.s
+endif
 	$(AS) $(ASFLAGS) $*.s -o $@
 
 ifeq ($(NODEP),1)
@@ -167,7 +180,7 @@ endif
 
 .SECONDEXPANSION:
 $(ASM_OBJECTS): %.o: %.s $$(data_dep)
-	$(AS) $(ASFLAGS) $< -o $@
+	$(AS) $(ASFLAGS) -g $< -o $@
 
 # Don't delete intermediate files
 .SECONDARY:

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -302,6 +302,49 @@ SECTIONS
         . = 0xFFF000; data/data_FFF000.o(.data);
     } = 0
 
+  /* Stabs debugging sections.  */
+  .stab          0 : { *(.stab) }
+  .stabstr       0 : { *(.stabstr) }
+  .stab.excl     0 : { *(.stab.excl) }
+  .stab.exclstr  0 : { *(.stab.exclstr) }
+  .stab.index    0 : { *(.stab.index) }
+  .stab.indexstr 0 : { *(.stab.indexstr) }
+  .comment       0 : { *(.comment) }
+  .gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* SGI/MIPS DWARF 2 extensions */
+  .debug_weaknames 0 : { *(.debug_weaknames) }
+  .debug_funcnames 0 : { *(.debug_funcnames) }
+  .debug_typenames 0 : { *(.debug_typenames) }
+  .debug_varnames  0 : { *(.debug_varnames) }
+  /* DWARF 3 */
+  .debug_pubtypes 0 : { *(.debug_pubtypes) }
+  .debug_ranges   0 : { *(.debug_ranges) }
+  /* DWARF Extension.  */
+  .debug_macro    0 : { *(.debug_macro) }
+  .debug_addr     0 : { *(.debug_addr) }
+  .ARM.attributes 0 : { KEEP (*(.ARM.attributes)) KEEP (*(.gnu.attributes)) }
+  .note.gnu.arm.ident 0 : { KEEP (*(.note.gnu.arm.ident)) }
+
     /* Discard everything not specifically mentioned above. */
     /DISCARD/ :
     {

--- a/scripts/align_2_before_debug_section_for_osx.sed
+++ b/scripts/align_2_before_debug_section_for_osx.sed
@@ -1,0 +1,4 @@
+#!/usr/bin/env sed
+
+/.section	.debug_/i\
+.align 2, 0


### PR DESCRIPTION
It doesn't affect binary match. However, though fireemblem8.elf contains debug info, idk how to fix it to let decompiler accept it yet. Someone may figure it out.
```
fireemblem8u % arm-none-eabi-objdump -h fireemblem8.elf 

fireemblem8.elf:     file format elf32-littlearm

Sections:
Idx Name          Size      VMA       LMA       File off  Algn
  0 EWRAM         0003efb8  02000000  02000000  00010000  2**2
                  ALLOC
  1 IWRAM         00007ff8  03000000  03000000  00010000  2**3
                  ALLOC
  2 ROM           00ffff00  08000000  08000000  00010000  2**4
                  CONTENTS, ALLOC, LOAD, CODE
  3 .debug_aranges 00000d80  00000000  00000000  0100ff00  2**3
                  CONTENTS, READONLY, DEBUGGING
  4 .debug_pubnames 000081f0  00000000  00000000  01010c80  2**2
                  CONTENTS, READONLY, DEBUGGING
  5 .debug_info   000fb064  00000000  00000000  01018e70  2**2
                  CONTENTS, READONLY, DEBUGGING
  6 .debug_abbrev 000060ac  00000000  00000000  01113ed4  2**2
                  CONTENTS, READONLY, DEBUGGING
  7 .debug_line   00069f4f  00000000  00000000  01119f80  2**2
                  CONTENTS, READONLY, DEBUGGING
  8 .debug_str    000004c1  00000000  00000000  01183ecf  2**0
                  CONTENTS, READONLY, DEBUGGING
  9 .ARM.attributes 00000020  00000000  00000000  01184390  2**0
                  CONTENTS, READONLY
```