### PR TITLE
Fix build error for sound/direct_sound_data.s.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,12 @@ else
 banim/%.o:    data_dep = $(shell $(SCANINC) -I include -I "" $*.s)
 endif
 
+ifeq ($(NODEP),1)
+sound/%.o:    data_dep :=
+else
+sound/%.o:    data_dep = $(shell $(SCANINC) -I include -I "" $*.s)
+endif
+
 .SECONDEXPANSION:
 $(ASM_OBJECTS): %.o: %.s $$(data_dep)
 	$(AS) $(ASFLAGS) -g $< -o $@


### PR DESCRIPTION
Fix build error:
```
sound/direct_sound_data.s: Assembler messages:
sound/direct_sound_data.s:6: Error: file not found: sound/direct_sound_samples/082263B4.bin
sound/direct_sound_data.s:11: Error: file not found: sound/direct_sound_samples/08227988.bin
sound/direct_sound_data.s:16: Error: file not found: sound/direct_sound_samples/0822807C.bin
......
make: *** [Makefile:197: sound/direct_sound_data.o] Error 1
```