### PR TITLE
Fix: LF line endings aren't supported.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
+# Declare files that will always have CRLF line endings on checkout.
+*.pal text eol=crlf
+
 # Custom for Visual Studio
 *.cs     diff=csharp
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@ Q: `make: *** No rule to make target 'baserom.gba', needed by 'xxx'.  Stop.`
 
 A: You must place a copy of the Fire Emblem: The Sacred Stones ROM named `baserom.gba` in the repository directory.
 
-Q: `LF line endings aren't supported.`
-
-A: `git config --global core.autocrlf true`. Read [this](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings) for more info.
-
 Q: `unrecognized option '--add-symbol'`
 
 A: Update your devkitPro or embedded toolchain. Read [this](https://github.com/bminor/binutils-gdb/blob/3451a2d7a3501e9c3fc344cbc4950c495f30c16d/binutils/ChangeLog-2015#L120) for more info.


### PR DESCRIPTION
Always convert line endings to CRLF on checkout for `.pal` files, because they must keep CRLF endings, even on OSX or Linux, otherwise gbagfx will complain that `LF line endings aren't supported.`.
https://github.com/FireEmblemUniverse/fireemblem8u/blob/c90d89062ff25c7991efa5385f3959a2d339159c/tools/gbagfx/jasc_pal.c#L49