### PR TITLE
Fix entry point to load .elf with mGBA

### DIFF
--- a/asm/crt0.s
+++ b/asm/crt0.s
@@ -1,5 +1,6 @@
 .syntax unified
 .arm
+.global Init
 Init:
 	b crt0
 	.include "asm/rom_header.inc"

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -1,4 +1,5 @@
 OUTPUT_ARCH(arm)
+ENTRY(Init)
 
 gNumMusicPlayers = 9;
 gMaxLines = 0;


### PR DESCRIPTION
## Problem
MGBA cannot load generated .elf file.
![image](https://user-images.githubusercontent.com/8841957/155890729-83de9d22-fca1-4a9f-9d2a-1be888378b8d.png)
`[ERROR] Qt:	无法载入游戏。请确认游戏格式是否正确？`

## Cause
Entry point is not set correctly.
```
$ arm-none-eabi-readelf -h fireemblem8u/fireemblem8.elf
ELF Header:
  Magic:   7f 45 4c 46 01 01 01 00 00 00 00 00 00 00 00 00
  Class:                             ELF32
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - System V
  ABI Version:                       0
  Type:                              EXEC (Executable file)
  Machine:                           ARM
  Version:                           0x1
  Entry point address:               0x0 <----------- should be 0x8000000
  Start of program headers:          52 (bytes into file)
  Start of section headers:          24752724 (bytes into file)
  Flags:                             0x5000200, Version5 EABI, soft-float ABI
  Size of this header:               52 (bytes)
  Size of program headers:           32 (bytes)
  Number of program headers:         3
  Size of section headers:           40 (bytes)
  Number of section headers:         14
  Section header string table index: 13
```

## Solution
There are several ways to set entry point. Read [this](https://sourceware.org/binutils/docs/ld/Entry-Point.html#Entry-Point) for detail.
I choose the `ENTRY` linker script command to keep consistent with [pret](
https://github.com/pret/pokeemerald/blob/6262080e9cbdd3633a61c2723d4fe1ef4bfe9a91/ld_script.txt#L1).