### PR TITLE
QA for an error occurred when building on GitHub Codespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -943,3 +943,4 @@ sound/direct_sound_samples/*.bin
 
 # Converted songs
 sound/songs/midi/*.s
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Q: `unrecognized option '--add-symbol'`
 
 A: Update your devkitPro or embedded toolchain. Read [this](https://github.com/bminor/binutils-gdb/blob/3451a2d7a3501e9c3fc344cbc4950c495f30c16d/binutils/ChangeLog-2015#L120) for more info.
 
+Q: `.dep/src/xxx.d:2: *** missing separator.  Stop.`
+
+A: `rm -rf .dep` or disable [VSCode Extension: Makefile Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.makefile-tools) if installed.
+
 Check [INSTALL.md](https://github.com/pret/pokeruby/blob/master/INSTALL.md) and [INSTALL.md](https://github.com/pret/pokeemerald/blob/master/INSTALL.md) if you have trouble in setting up.
 
 Check [remove_tools](https://github.com/laqieer/fireemblem8u/tree/remove_tools) branch if you don't want to build agbcc and other tools by yourself. It uses docker to make setting up easier. Follow its [README.md](https://github.com/laqieer/fireemblem8u/blob/remove_tools/README.md) instead.


### PR DESCRIPTION
# Error
`.dep/src/xxx.d:2: *** missing separator. Stop.`
# Reason
[GitHub Codespaces](https://github.com/features/codespaces) is based on Visual Studio and it will recommend [Extension: Makefile Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.makefile-tools) based on file type detection, which will overwrite files in `.dep/src` and break `make` and `make clean`.
# Solution
`rm -rf .dep && make` and it will rewrite the correct files.