### PR TITLE
M1 Mac build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ PREFIX ?= arm-none-eabi-
 
 export PATH := $(TOOLCHAIN)/bin:$(PATH)
 
+ifeq ($(UNAME),Darwin)
+	SHELL := env PATH=$(PATH) /bin/bash
+endif
+
 CPP ?= $(PREFIX)cpp$(EXE)
 AS := $(PREFIX)as$(EXE)
 LD := $(PREFIX)ld$(EXE)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It builds the following ROM:
 # for Ubuntu/WSL users
 apt install binutils-arm-none-eabi
 ```
-3. Install [agbcc](https://github.com/pret/agbcc) to this project.
+3. Install [agbcc](https://github.com/pret/agbcc)(or [agbcc](https://github.com/holmesmr/agbcc) for M1 Mac users) to this project.
 ```
 cd /path/to/agbcc
 ./build.sh

--- a/tools/gbagfx/Makefile
+++ b/tools/gbagfx/Makefile
@@ -1,8 +1,10 @@
 CC = gcc
 
 CFLAGS = -Wall -Wextra -Werror -std=c11 -O2 -s -DPNG_SKIP_SETJMP_CHECK
+CFLAGS += $(shell pkg-config --cflags libpng)
 
 LIBS = -lpng -lz
+LDFLAGS += $(shell pkg-config --libs-only-L libpng)
 
 SRCS = main.c convert_png.c gfx.c jasc_pal.c lz.c rl.c util.c font.c
 


### PR DESCRIPTION
To build on M1 Mac natively without Rosetta.

Reference:
- https://github.com/pret/agbcc/pull/52 to build `agbcc`
- https://github.com/pret/pokeemerald/issues/1592 to build `gbagfx`
- https://stackoverflow.com/a/36226832 to fix toolchain `PATH`