### PR TITLE
Improve textencode performance

### DIFF
--- a/tools/textencode/Makefile
+++ b/tools/textencode/Makefile
@@ -1,10 +1,10 @@
 CC = gcc
 
-CFLAGS = -Wall -Wextra -Werror -std=c11 -O2 -s
+CFLAGS = -Wall -Wextra -Werror -std=c11 -O2 -s -DBENCHMARK
 
 .PHONY: clean
 
-SRCS = textencode.c inputfile.c huffman.c
+SRCS = textencode.h textencode.c inputfile.c huffman.c
 
 textencode: $(SRCS)
 	$(CC) $(CFLAGS) $(SRCS) -o $@ $(LDFLAGS)

--- a/tools/textencode/huffman.c
+++ b/tools/textencode/huffman.c
@@ -163,7 +163,6 @@ struct HuffNode * HuffListPopHead(struct HuffList ** p_self)
 HuffTree_t BuildHuffmanTree(u32 * freq_table)
 {
     struct HuffList * list = HuffListCreate();
-    //uint8_t * cache = calloc(1<<16, sizeof(uint8_t));
 
     // TODO: this better
 

--- a/tools/textencode/huffman.c
+++ b/tools/textencode/huffman.c
@@ -163,6 +163,7 @@ struct HuffNode * HuffListPopHead(struct HuffList ** p_self)
 HuffTree_t BuildHuffmanTree(u32 * freq_table)
 {
     struct HuffList * list = HuffListCreate();
+    //uint8_t * cache = calloc(1<<16, sizeof(uint8_t));
 
     // TODO: this better
 
@@ -170,7 +171,9 @@ HuffTree_t BuildHuffmanTree(u32 * freq_table)
     for (size_t i = 0; i < 0x100; i++)
     {
         if (freq_table[i] > 0)
+        {
             HuffListAdd(&list, HuffNodeCreateLeaf(i, freq_table[i]));
+        }
     }
 
     // portrait codes
@@ -179,7 +182,9 @@ HuffTree_t BuildHuffmanTree(u32 * freq_table)
         size_t code = 0x0100 | i;
 
         if (freq_table[code] > 0)
+        {
             HuffListAdd(&list, HuffNodeCreateLeaf(code, freq_table[code]));
+        }
     }
 
     // everything else (double byte values)
@@ -189,25 +194,30 @@ HuffTree_t BuildHuffmanTree(u32 * freq_table)
         {
             size_t code = (hi << 8) | lo;
 
-            if (freq_table[code] > 0)
+            if (freq_table[code] > 0) {
                 HuffListAdd(&list, HuffNodeCreateLeaf(code, freq_table[code]));
+            }
         }
     }
 
     assert(!HuffListIsEmpty(list));
 
+    struct HuffNode * head;
+
     for (;;)
     {
-        struct HuffNode * head = HuffListPopHead(&list);
+        head = HuffListPopHead(&list);
 
         if (HuffListIsEmpty(list))
         {
             HuffListDestroy(list);
-            return head;
+            break;
         }
 
         HuffListAdd(&list, HuffNodeCreateNode(head, HuffListPopHead(&list)));
     }
+
+    return head;
 }
 
 void FreeHuffmanTree(HuffTree_t tree)

--- a/tools/textencode/textencode.c
+++ b/tools/textencode/textencode.c
@@ -247,17 +247,21 @@ static void write_c_file(const char * filename)
         count_freq((uint8_t *)gInputStrings[i].text);
     }
 
+    BENCH_WAYPOINT(huffbuild);
     BuildHuffmanTree(freq);
     huffmanTable = BuildHuffmanTable();
+    BENCH_REPORT(huffbuild, "huffman tree");
 
     //*
     // compressed string data
+    BENCH_WAYPOINT(compress);
     for (i = 0; i < gInputStringsCount; i++)
     {
         size = compress_string((uint8_t *)gInputStrings[i].text, outputBuffer);
         print_compressed_string(
             outCFile, gInputStrings[i].id, outputBuffer, size);
     }
+    BENCH_REPORT(compress, "compress and write out");
     fputs("\n", outCFile);
 
     // Huffman table

--- a/tools/textencode/textencode.h
+++ b/tools/textencode/textencode.h
@@ -38,6 +38,33 @@
         exit(1);                                                               \
     } while (0)
 
+#ifdef BENCHMARK
+
+#include <time.h>
+
+// TODO: somehow ensure that ids are unique
+// XXX: This should probably be clock_gettime(CLOCK_MONOTONIC, ...) to be
+// really accurate
+
+#define PPCAT(A, B) A ## B
+
+#define BENCH_WAYPOINT(name) double PPCAT(name, START) = (double) clock()/CLOCKS_PER_SEC;
+
+#define BENCH_REPORT(name, msg)                                                \
+  do                                                                           \
+  {                                                                            \
+      double PPCAT(name, END) = (double) clock()/CLOCKS_PER_SEC;               \
+      fprintf(stderr, "%s: %.3fs\n", msg, PPCAT(name, END)-PPCAT(name, START));\
+  } while (0)
+
+#else
+
+#define BENCH_WAYPOINT(name)
+
+#define BENCH_REPORT(name, msg)
+
+#endif
+
 typedef uint32_t u32;
 
 typedef void * HuffTree_t;


### PR DESCRIPTION
As it turns out, caching is really overpowered. I'm astonished at how well this worked.

![image](https://user-images.githubusercontent.com/7939129/200945587-ba13a58d-2d66-46b7-98f7-8e62534c91b2.png)
