### PR TITLE
(include file fix) for solving compile .c==>.o bug 

### DIFF
--- a/include/bmitem.h
+++ b/include/bmitem.h
@@ -1,6 +1,8 @@
 #ifndef GUARD_ITEMS_H
 #define GUARD_ITEMS_H
 
+#include "fontgrp.h"
+
 struct ItemStatBonuses
 {
     /* 00 */ s8 hpBonus;
@@ -146,7 +148,7 @@ enum {
 #define ITEM_INDEX(aItem) ((aItem) & 0xFF)
 #define ITEM_USES(aItem) ((aItem) >> 8)
 
-struct TextHandle;
+extern const struct ItemData gItemData[];
 
 char* GetItemNameWithArticle(int item, s8 capitalize);
 

--- a/include/bmreliance.h
+++ b/include/bmreliance.h
@@ -45,6 +45,7 @@ struct SupportBonuses
 };
 
 extern struct SupportData CONST_DATA gSupportData[];
+extern const struct SupportBonuses gAffinityBonuses[];
 
 int GetUnitSupporterCount(struct Unit* unit);
 u8 GetUnitSupporterCharacter(struct Unit* unit, int num);

--- a/include/bmunit.h
+++ b/include/bmunit.h
@@ -349,6 +349,10 @@ extern CONST_DATA struct ClassData gClassData[]; // gClassData
 extern CONST_DATA struct CharacterData gCharacterData[]; // gCharacterData
 extern struct UnitDefinition gUnitDef1;
 extern struct UnitDefinition gUnitDef2;
+extern struct UnitDefinition gUnitDefSumDK[];
+extern struct Unit gUnitArrayBlue[62];
+extern struct Unit gUnitArrayRed[50];
+extern struct Unit gUnitArrayGreen[20];
 
 void ClearUnits(void);
 void ClearUnit(struct Unit* unit);

--- a/include/prepscreen.h
+++ b/include/prepscreen.h
@@ -1,6 +1,7 @@
 #ifndef PREP_SCREEN_H
 
 #include "proc.h"
+#include "fontgrp.h"
 
 struct PrepUnitList {
     struct Unit *units[0x40];
@@ -123,6 +124,8 @@ enum proc_label_prep_unit_select {
     PROC_LABEL_PREPUNIT_GAME_START = 0x63,
     PROC_LABEL_PREPUNIT_END = 0x64,
 };
+
+extern struct TextHandle gPrepMainMenuTexts[9];
 
 void Prep_DrawChapterGoal(int VRAM_offset, int pal);
 // ??? PrepAtMenu_OnInit(???);

--- a/include/types.h
+++ b/include/types.h
@@ -15,6 +15,7 @@ struct MAInfoFrameProc;
 struct MAExpBarProc;
 struct ProcAtMenu;
 struct PrepUnitList;
+struct TextHandle;
 
 // Type definitions for types without any other home :/
 

--- a/include/variables.h
+++ b/include/variables.h
@@ -126,7 +126,6 @@ extern u16 gBmFrameTmap1[];
 extern char gStringBufferAlt[];
 // extern ??? gUnknown_0200F1C8
 // extern ??? gUnknown_0201000C
-extern struct TextHandle gPrepMainMenuTexts[9];
 extern u8 gPrepUnitPool[];
 // extern ??? gUnknown_02011BC8
 extern struct PrepUnitList gPrepUnitList;
@@ -505,9 +504,6 @@ extern struct RAMChapterData gRAMChapterData;
 // extern ??? gUnknown_0202BD31
 extern u8 gActiveUnitId;
 extern struct Vec2 gActiveUnitMoveOrigin;
-extern struct Unit gUnitArrayBlue[62];
-extern struct Unit gUnitArrayRed[50];
-extern struct Unit gUnitArrayGreen[20];
 // extern ??? gUnknown_02030B8C
 extern u8 gWorkingMovementScript[];
 extern u16 gConvoyItemArray[];
@@ -2726,7 +2722,6 @@ extern u16 gUnknown_08803590[];
 // extern ??? gUnknown_08803CB0
 // extern ??? gUnknown_08803CD0
 // extern ??? gCharacterData
-extern const struct ItemData gItemData[];
 extern const s8 gUnknown_0880B90C[]; // terrainId to ? lookup
 extern const s8 gUnknown_0880BB96[]; // Unit drop movement cost table
 extern const s8 gUnknown_0880BC18[]; // Ballista mov cost table
@@ -2798,10 +2793,8 @@ extern u8 CONST_DATA gUnknown_088ADFA6[]; // Solar Brace class list
 // extern ??? gUnknown_088AF880
 // extern ??? gUnknown_088AFB5A
 // extern ??? gUnknown_088AFBD8
-extern const struct SupportBonuses gAffinityBonuses[];
 // extern ??? gUnknown_088B39EC
 // extern ??? gUnknown_088B3AD8
-extern struct UnitDefinition gUnitDefSumDK[];
 // extern ??? gUnknown_088D2058
 // extern ??? gConvoBackgroundData
 extern u8 CONST_DATA gUnknown_0895DFA4[][2];

--- a/src/cp_data.c
+++ b/src/cp_data.c
@@ -3,6 +3,7 @@
 #include "cp_common.h"
 #include "cp_script.h"
 #include "cp_data.h"
+#include "bmunit.h"
 
 #include "constants/characters.h"
 #include "constants/items.h"


### PR DESCRIPTION
When you try to build CHAX project (for example here: https://github.com/MokhaLeee/fe8_hacks_sundries/blob/main/makefile)

via arm-none-eabi-gcc during c-hacks construction, arm tool chain may got error because of unproper include file.