### PR TITLE
Fix tool build and doc on project build on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It builds the following ROM:
 # for Ubuntu/WSL users
 apt install binutils-arm-none-eabi
 ```
-3. Install [agbcc](https://github.com/pret/agbcc)(or [agbcc](https://github.com/holmesmr/agbcc) for M1 Mac users) to this project.
+3. Install [agbcc](https://github.com/pret/agbcc) to this project.
 ```
 cd /path/to/agbcc
 ./build.sh

--- a/tools/textencode/Makefile
+++ b/tools/textencode/Makefile
@@ -4,9 +4,9 @@ CFLAGS = -Wall -Wextra -Werror -std=c11 -O2 -s -DBENCHMARK
 
 .PHONY: clean
 
-SRCS = textencode.h textencode.c inputfile.c huffman.c
+SRCS = textencode.c inputfile.c huffman.c
 
-textencode: $(SRCS)
+textencode: $(SRCS) textencode.h
 	$(CC) $(CFLAGS) $(SRCS) -o $@ $(LDFLAGS)
 
 clean:


### PR DESCRIPTION
Changes:
- Fix error when building `tools/textencode` on Mac
- Fix agbcc repo for Mac users in README because https://github.com/pret/agbcc/pull/52 has already been merged