### PR TITLE
match EkrLvup_InitScreen & refine BattleAIS_ExecCommands

### DIFF
--- a/src/banim-ekrlvup.c
+++ b/src/banim-ekrlvup.c
@@ -365,32 +365,15 @@ void EkrLvup_InitScreen(struct ProcEkrLevelup *proc)
     }
 
     if (GetBattleAnimArenaFlag() == false && GetBanimDragonStatusType() != EKRDRGON_TYPE_DEMON_KING) {
-
+        struct Struct20200E0_14 *_buf;
         sub_805AA68(buf);
 
-#if NONMATCHING
-        ((struct Struct20200E0_14 *)buf->unk14)->unk4C &= ~OAM2_LAYER(0x3);
-        ((struct Struct20200E0_14 *)buf->unk14)->unk4C |=  OAM2_LAYER(0x3);
-        ((struct Struct20200E0_14 *)buf->unk18)->unk4C &= ~OAM2_LAYER(0x3);
-        ((struct Struct20200E0_14 *)buf->unk18)->unk4C |=  OAM2_LAYER(0x3);
-#else
-    {
-        register struct Struct20200E0_14 *_buf asm("r3");
-        register u32 oam2 asm("r0");
-
         _buf = buf->unk14;
-        oam2 = _buf->unk4C;
-        oam2 &= 0xF3FF;
-        oam2 |= 0x0C00;
-        _buf->unk4C = oam2;
-
+        _buf->unk4C &= (u16)~OAM2_LAYER(0x3);
+        _buf->unk4C |=       OAM2_LAYER(0x3);
         _buf = buf->unk18;
-        oam2 = _buf->unk4C;
-        oam2 &= 0xF3FF;
-        oam2 |= 0x0C00;
-        _buf->unk4C = oam2;
-    }
-#endif
+        _buf->unk4C &= (u16)~OAM2_LAYER(0x3);
+        _buf->unk4C |=       OAM2_LAYER(0x3);
     }
 
     proc->ais_main->oam2Base &= ~OAM2_LAYER(0x3);

--- a/src/banim-main.c
+++ b/src/banim-main.c
@@ -272,28 +272,38 @@ void BattleAIS_ExecCommands(void)
                             else
                                 idx = gpBanimModesRight[frame_front];
 
-                            // TODO
+#ifndef NONMATCHING
                             {
                                 struct UnkStruct {
                                     const u32 *unk0;
                                     const u32 *unk1;
                                     u32 unk2;
                                 };
-
-                                struct UnkStruct *unk = (void *)(idx + gBanimScrLeft + GetAnimPosition(anim) * 0x2A00);
                                 register const void *_ptr asm("r4");
-                                register u32 unk1 asm("r1");
+                                register u32 r1 asm("r1");
+                                struct UnkStruct *unk = (void *)(idx + gBanimScrLeft + GetAnimPosition(anim) * 0x2A00);
 
                                 anim1->pImgSheet = unk->unk1;
                                 _ptr = anim1->pSpriteDataPool;
-                                unk1 = unk->unk2;
-                                _ptr += unk1;
+                                _ptr += r1 = unk->unk2;
                                 anim1->pSpriteData = _ptr;
+                                _ptr = anim2->pSpriteDataPool + 0x57F0;
+                                anim2->pSpriteData = _ptr;
                             }
+#else
+                            {
+                                struct UnkStruct {
+                                    const u32 *unk0;
+                                    const u32 *unk1;
+                                    u32 unk2;
+                                };
+                                struct UnkStruct *unk = (void *)(idx + gBanimScrLeft + GetAnimPosition(anim) * 0x2A00);
 
-                            idx = (int)(anim2->pSpriteDataPool);
-                            idx += 0x57F0;
-                            anim2->pSpriteData = (const void *)(idx);
+                                anim1->pImgSheet = unk->unk1;
+                                anim1->pSpriteData = anim1->pSpriteDataPool + unk->unk2;
+                                anim2->pSpriteData = anim2->pSpriteDataPool + 0x57F0;
+                            }
+#endif
 
                             if (gUnknown_0203E1A4[GetAnimPosition(anim)] == 0) {
                                 if (gpImgSheet[GetAnimPosition(anim1)] != anim1->pImgSheet) {


### PR DESCRIPTION
For latter, at least we don't need to mistakenly treat `idx` as a pointer.