### PR TITLE
EKR_DISTANCE_3 -> EKR_DISTANCE_MONOCOMBAT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.sym
+
 # Windows image file caches
 Thumbs.db
 ehthumbs.db

--- a/include/ekrbattle.h
+++ b/include/ekrbattle.h
@@ -73,7 +73,7 @@ enum gEkrDistanceType_index {
     EKR_DISTANCE_CLOSE,
     EKR_DISTANCE_FAR,
     EKR_DISTANCE_FARFAR,
-    EKR_DISTANCE_3,
+    EKR_DISTANCE_MONOCOMBAT,
     EKR_DISTANCE_PROMOTION
 };
 extern s16 gEkrDistanceType;

--- a/src/banim-efxhpbar.c
+++ b/src/banim-efxhpbar.c
@@ -127,7 +127,7 @@ void efxHPBarMain(struct ProcEfxHPBar *proc)
             switch (gEkrDistanceType) {
             case EKR_DISTANCE_CLOSE:
             case EKR_DISTANCE_FAR:
-            case EKR_DISTANCE_3:
+            case EKR_DISTANCE_MONOCOMBAT:
             case EKR_DISTANCE_PROMOTION:
                 proc->cur = 16;
                 NewEfxFarAttackWithDistance(GetAnimAnotherSide(anim), -1);

--- a/src/banim-ekrbattle.c
+++ b/src/banim-ekrbattle.c
@@ -501,7 +501,7 @@ void ekrBattleInRoundIdle(struct ProcEkrBattle *proc)
         } /* switch */
         break;
 
-    case EKR_DISTANCE_3:
+    case EKR_DISTANCE_MONOCOMBAT:
         if ((gBanimDoneFlag[0] + gBanimDoneFlag[1]) == 1)
             ret = 1;
         break;

--- a/src/banim-ekrbattlestarting.c
+++ b/src/banim-ekrbattlestarting.c
@@ -173,7 +173,7 @@ void ekrBaStart_InitBattleScreen(struct ProcEkrBattleStarting *proc)
         case EKR_DISTANCE_FARFAR:
             break;
 
-        case EKR_DISTANCE_3:
+        case EKR_DISTANCE_MONOCOMBAT:
             if (gEkrPairSideVaild[EKR_POS_L] == false) {
                 EkrGauge_Set4C();
                 EkrDispUpSet4C();

--- a/src/banim-ekrdispup.c
+++ b/src/banim-ekrdispup.c
@@ -202,7 +202,7 @@ void sub_8051E00(void)
 
     case EKR_DISTANCE_FAR:
     case EKR_DISTANCE_FARFAR:
-    case EKR_DISTANCE_3:
+    case EKR_DISTANCE_MONOCOMBAT:
         gUnknown_0200003C[0] = &gUnknown_020145C8[0x800];
         gUnknown_0200003C[1] = &gUnknown_020145C8[0x1800];
         break;
@@ -317,7 +317,7 @@ int GetBanimInitPosReal(void)
         return gEkrInitialHitSide;
 
     case EKR_DISTANCE_CLOSE:
-    case EKR_DISTANCE_3:
+    case EKR_DISTANCE_MONOCOMBAT:
     case EKR_DISTANCE_PROMOTION:
         return EKR_POS_R;
 

--- a/src/banim-ekrdragon-myrrh.c
+++ b/src/banim-ekrdragon-myrrh.c
@@ -165,7 +165,7 @@ void RegisterEkrDragonStatusType(void)
     case EKR_DISTANCE_FARFAR:
         break;
 
-    case EKR_DISTANCE_3:
+    case EKR_DISTANCE_MONOCOMBAT:
     case EKR_DISTANCE_PROMOTION:
     default:
         return;

--- a/src/banim-ekrmain.c
+++ b/src/banim-ekrmain.c
@@ -75,7 +75,7 @@ const u8 BattleTypeToAnimModeEndOfDodge[5] = {
     [EKR_DISTANCE_CLOSE]     = BANIM_MODE_CLOSE_DODGE,
     [EKR_DISTANCE_FAR]       = BANIM_MODE_STANDING,
     [EKR_DISTANCE_FARFAR]    = BANIM_MODE_STANDING,
-    [EKR_DISTANCE_3]         = BANIM_MODE_CLOSE_DODGE,
+    [EKR_DISTANCE_MONOCOMBAT]         = BANIM_MODE_CLOSE_DODGE,
     [EKR_DISTANCE_PROMOTION] = BANIM_MODE_CLOSE_DODGE
 };
 
@@ -83,7 +83,7 @@ const u8 BanimTypesPosLeft[5] = {
     [EKR_DISTANCE_CLOSE]     = 0x5C,
     [EKR_DISTANCE_FAR]       = 0x44,
     [EKR_DISTANCE_FARFAR]    = 0x44,
-    [EKR_DISTANCE_3]         = 0x78,
+    [EKR_DISTANCE_MONOCOMBAT]         = 0x78,
     [EKR_DISTANCE_PROMOTION] = 0x5C
 };
 
@@ -91,7 +91,7 @@ const u8 BanimTypesPosRight[5] = {
     [EKR_DISTANCE_CLOSE]     = 0x94,
     [EKR_DISTANCE_FAR]       = 0xAC,
     [EKR_DISTANCE_FARFAR]    = 0xAC,
-    [EKR_DISTANCE_3]         = 0x78,
+    [EKR_DISTANCE_MONOCOMBAT]         = 0x78,
     [EKR_DISTANCE_PROMOTION] = 0x94
 };
 
@@ -99,7 +99,7 @@ const u16 BanimLeftDefaultPos[5] = {
     [EKR_DISTANCE_CLOSE]     = 0x00,
     [EKR_DISTANCE_FAR]       = 0x20,
     [EKR_DISTANCE_FARFAR]    = 0xF0,
-    [EKR_DISTANCE_3]         = 0x00,
+    [EKR_DISTANCE_MONOCOMBAT]         = 0x00,
     [EKR_DISTANCE_PROMOTION] = 0x00
 };
 
@@ -298,7 +298,7 @@ void InitBothAIS(void)
 
     switch (gEkrDistanceType) {
     case EKR_DISTANCE_CLOSE:
-    case EKR_DISTANCE_3:
+    case EKR_DISTANCE_MONOCOMBAT:
     case EKR_DISTANCE_PROMOTION:
         InitBattleAnimFrame(ANIM_ROUND_TAKING_HIT_CLOSE, ANIM_ROUND_TAKING_HIT_CLOSE);
         break;


### PR DESCRIPTION
I think EKR_DISTANCE_3 is used for monocombat (Fortify/Latona where there is only one banim). Idk a good name, but maybe EKR_DISTANCE_MONOCOMBAT?