### PR TITLE
un-static function headers in bmbattle

### DIFF
--- a/include/bmbattle.h
+++ b/include/bmbattle.h
@@ -216,6 +216,74 @@ void UnitLevelUp(struct Unit* unit);
 void BattleHitAdvance(void);
 void BattleHitTerminate(void);
 
+void UpdateActorFromBattle(void);
+
+void BattleGenerateSimulationInternal(struct Unit* actor, struct Unit* target, int x, int y, int actorWpnSlot);
+void BattleGenerateRealInternal(struct Unit* actor, struct Unit* target);
+
+s8 BattleRoll1RN(u16 threshold, s8 simResult);
+s8 BattleRoll2RN(u16 threshold, s8 simResult);
+
+void ComputeBattleUnitStats(struct BattleUnit* attacker, struct BattleUnit* defender);
+void ComputeBattleUnitEffectiveStats(struct BattleUnit* attacker, struct BattleUnit* defender);
+void ComputeBattleUnitSupportBonuses(struct BattleUnit* attacker, struct BattleUnit* defender);
+void ComputeBattleUnitDefense(struct BattleUnit* attacker, struct BattleUnit* defender);
+void ComputeBattleUnitBaseDefense(struct BattleUnit* bu);
+void ComputeBattleUnitAttack(struct BattleUnit* attacker, struct BattleUnit* defender);
+void ComputeBattleUnitSpeed(struct BattleUnit* bu);
+void ComputeBattleUnitHitRate(struct BattleUnit* bu);
+void ComputeBattleUnitAvoidRate(struct BattleUnit* bu);
+void ComputeBattleUnitCritRate(struct BattleUnit* bu);
+void ComputeBattleUnitDodgeRate(struct BattleUnit* bu);
+void ComputeBattleUnitEffectiveHitRate(struct BattleUnit* attacker, struct BattleUnit* defender);
+void ComputeBattleUnitEffectiveCritRate(struct BattleUnit* attacker, struct BattleUnit* defender);
+void ComputeBattleUnitSilencerRate(struct BattleUnit* attacker, struct BattleUnit* defender);
+void ComputeBattleUnitWeaponRankBonuses(struct BattleUnit* bu);
+void ComputeBattleUnitStatusBonuses(struct BattleUnit* bu);
+void ComputeBattleUnitSpecialWeaponStats(struct BattleUnit* attacker, struct BattleUnit* defender);
+
+s8 BattleGenerateRoundHits(struct BattleUnit* attacker, struct BattleUnit* defender);
+int GetBattleUnitHitCount(struct BattleUnit* attacker);
+int BattleCheckBraveEffect(struct BattleUnit* bu);
+
+s8 BattleCheckTriangleAttack(struct BattleUnit* attacker, struct BattleUnit* defender);
+void BattleUpdateBattleStats(struct BattleUnit* attacker, struct BattleUnit* defender);
+void BattleCheckSureShot(struct BattleUnit* attacker);
+void BattleCheckPierce(struct BattleUnit* attacker, struct BattleUnit* defender);
+void BattleCheckGreatShield(struct BattleUnit* attacker, struct BattleUnit* defender);
+s8 BattleCheckSilencer(struct BattleUnit* attacker, struct BattleUnit* defender);
+void BattleCheckPetrify(struct BattleUnit* attacker, struct BattleUnit* defender);
+void BattleGenerateHitAttributes(struct BattleUnit* attacker, struct BattleUnit* defender);
+void BattleGenerateHitTriangleAttack(struct BattleUnit* attacker, struct BattleUnit* defender);
+void BattleGenerateHitEffects(struct BattleUnit* attacker, struct BattleUnit* defender);
+s8 BattleGenerateHit(struct BattleUnit* attacker, struct BattleUnit* defender);
+
+int GetStatIncrease(int growth);
+
+int GetBattleUnitUpdatedWeaponExp(struct BattleUnit* bu);
+
+int GetUnitExpLevel(struct Unit* unit);
+int GetUnitRoundExp(struct Unit* actor, struct Unit* target);
+int GetUnitPowerLevel(struct Unit* unit);
+int GetUnitClassKillExpBonus(struct Unit* actor, struct Unit* target);
+int GetUnitExpMultiplier(struct Unit* actor, struct Unit* target);
+int GetUnitKillExpBonus(struct Unit* actor, struct Unit* target);
+void ModifyUnitSpecialExp(struct Unit* actor, struct Unit* target, int* exp);
+int GetBattleUnitExpGain(struct BattleUnit* actor, struct BattleUnit* target);
+void BattleApplyItemExpGains(void);
+int GetBattleUnitStaffExp(struct BattleUnit* bu);
+void BattleApplyMiscActionExpGains(void);
+
+void BattleApplyReaverEffect(struct BattleUnit* attacker, struct BattleUnit* defender);
+
+void ComputeBattleObstacleStats(void);
+
+void BattlePrintDebugUnitInfo(struct BattleUnit* actor, struct BattleUnit* target);
+void BattlePrintDebugHitInfo(void);
+
+void BattleGenerateHitScriptedDamage(struct BattleUnit* bu);
+void BattleUnwindScripted(void);
+
 #define BUNIT_IS_OBSTACLE(aBu) (((aBu)->terrainId == TERRAIN_WALL_1B) || ((aBu)->terrainId == TERRAIN_SNAG))
 
 #endif // GUARD_BMBATTLE_H

--- a/src/bmbattle.c
+++ b/src/bmbattle.c
@@ -53,8 +53,6 @@ static CONST_DATA struct WeaponTriangleRule sWeaponTriangleRules[] = {
     { -1 },
 };
 
-static void UpdateActorFromBattle(void);
-
 static CONST_DATA struct ProcCmd sProcScr_BattleAnimSimpleLock[] = {
     PROC_SLEEP(1),
     PROC_CALL(UpdateActorFromBattle),
@@ -74,72 +72,6 @@ static EWRAM_DATA struct {
     u8 unk01;
     u8 unk02;
 } sUnknown_0203A60C = {};
-
-static void BattleGenerateSimulationInternal(struct Unit* actor, struct Unit* target, int x, int y, int actorWpnSlot);
-static void BattleGenerateRealInternal(struct Unit* actor, struct Unit* target);
-
-static s8 BattleRoll1RN(u16 threshold, s8 simResult);
-static s8 BattleRoll2RN(u16 threshold, s8 simResult);
-
-static void ComputeBattleUnitStats(struct BattleUnit* attacker, struct BattleUnit* defender);
-static void ComputeBattleUnitEffectiveStats(struct BattleUnit* attacker, struct BattleUnit* defender);
-static void ComputeBattleUnitSupportBonuses(struct BattleUnit* attacker, struct BattleUnit* defender);
-static void ComputeBattleUnitDefense(struct BattleUnit* attacker, struct BattleUnit* defender);
-static void ComputeBattleUnitBaseDefense(struct BattleUnit* bu);
-static void ComputeBattleUnitAttack(struct BattleUnit* attacker, struct BattleUnit* defender);
-static void ComputeBattleUnitSpeed(struct BattleUnit* bu);
-static void ComputeBattleUnitHitRate(struct BattleUnit* bu);
-static void ComputeBattleUnitAvoidRate(struct BattleUnit* bu);
-static void ComputeBattleUnitCritRate(struct BattleUnit* bu);
-static void ComputeBattleUnitDodgeRate(struct BattleUnit* bu);
-static void ComputeBattleUnitEffectiveHitRate(struct BattleUnit* attacker, struct BattleUnit* defender);
-static void ComputeBattleUnitEffectiveCritRate(struct BattleUnit* attacker, struct BattleUnit* defender);
-static void ComputeBattleUnitSilencerRate(struct BattleUnit* attacker, struct BattleUnit* defender);
-static void ComputeBattleUnitWeaponRankBonuses(struct BattleUnit* bu);
-static void ComputeBattleUnitStatusBonuses(struct BattleUnit* bu);
-static void ComputeBattleUnitSpecialWeaponStats(struct BattleUnit* attacker, struct BattleUnit* defender);
-
-static s8 BattleGenerateRoundHits(struct BattleUnit* attacker, struct BattleUnit* defender);
-static int GetBattleUnitHitCount(struct BattleUnit* attacker);
-static int BattleCheckBraveEffect(struct BattleUnit* bu);
-
-static s8 BattleCheckTriangleAttack(struct BattleUnit* attacker, struct BattleUnit* defender);
-static void BattleUpdateBattleStats(struct BattleUnit* attacker, struct BattleUnit* defender);
-static void BattleCheckSureShot(struct BattleUnit* attacker);
-static void BattleCheckPierce(struct BattleUnit* attacker, struct BattleUnit* defender);
-static void BattleCheckGreatShield(struct BattleUnit* attacker, struct BattleUnit* defender);
-static s8 BattleCheckSilencer(struct BattleUnit* attacker, struct BattleUnit* defender);
-static void BattleCheckPetrify(struct BattleUnit* attacker, struct BattleUnit* defender);
-static void BattleGenerateHitAttributes(struct BattleUnit* attacker, struct BattleUnit* defender);
-static void BattleGenerateHitTriangleAttack(struct BattleUnit* attacker, struct BattleUnit* defender);
-static void BattleGenerateHitEffects(struct BattleUnit* attacker, struct BattleUnit* defender);
-static s8 BattleGenerateHit(struct BattleUnit* attacker, struct BattleUnit* defender);
-
-static int GetStatIncrease(int growth);
-
-static int GetBattleUnitUpdatedWeaponExp(struct BattleUnit* bu);
-
-static int GetUnitExpLevel(struct Unit* unit);
-static int GetUnitRoundExp(struct Unit* actor, struct Unit* target);
-static int GetUnitPowerLevel(struct Unit* unit);
-static int GetUnitClassKillExpBonus(struct Unit* actor, struct Unit* target);
-static int GetUnitExpMultiplier(struct Unit* actor, struct Unit* target);
-static int GetUnitKillExpBonus(struct Unit* actor, struct Unit* target);
-static void ModifyUnitSpecialExp(struct Unit* actor, struct Unit* target, int* exp);
-static int GetBattleUnitExpGain(struct BattleUnit* actor, struct BattleUnit* target);
-static void BattleApplyItemExpGains(void);
-static int GetBattleUnitStaffExp(struct BattleUnit* bu);
-static void BattleApplyMiscActionExpGains(void);
-
-static void BattleApplyReaverEffect(struct BattleUnit* attacker, struct BattleUnit* defender);
-
-static void ComputeBattleObstacleStats(void);
-
-static void BattlePrintDebugUnitInfo(struct BattleUnit* actor, struct BattleUnit* target);
-static void BattlePrintDebugHitInfo(void);
-
-static void BattleGenerateHitScriptedDamage(struct BattleUnit* bu);
-static void BattleUnwindScripted(void);
 
 void BattleGenerateSimulationInternal(struct Unit* actor, struct Unit* target, int x, int y, int actorWpnSlot) {
     InitBattleUnit(&gBattleActor, actor);


### PR DESCRIPTION
There's not really a good reason to have these functions static, unless there's a really compelling reason to mark them as private.