### PR TITLE
[CHORE] move data declarations into statscreen.h

### DIFF
--- a/include/statscreen.h
+++ b/include/statscreen.h
@@ -172,7 +172,7 @@ void HbPopulate_SSCharacter(struct HelpBoxProc* proc);
 void HbPopulate_SSClass(struct HelpBoxProc* proc);
 void HbRedirect_SSSupports(struct HelpBoxProc* proc);
 
-// static
+// extern
 void UpdateHelpBoxDisplay(struct HelpBoxProc* proc, int arg1);
 
 void StartHelpBox(int x, int y, int mid);
@@ -185,7 +185,7 @@ void EndHelpBox(void);
 void StartMovingHelpBox(const struct HelpBoxInfo* info, struct Proc* parent);
 void StartMovingHelpBoxExt(const struct HelpBoxInfo* info, struct Proc* parent, int x, int y);
 
-// static
+// extern
 void SetHelpBoxInitPosition(struct HelpBoxProc* proc, int x, int y);
 void ResetHelpBoxInitSize(struct HelpBoxProc* proc);
 int GetHelpBoxItemInfoKind(int item);
@@ -205,10 +205,10 @@ void MoveHelpPromptSprite(int x, int y);
 
 const struct HelpBoxInfo* GetLastHelpBoxInfo(void);
 
-extern struct HelpBoxInfo CONST_DATA gHelpInfo_Ss0Pow; // page 0 root help
-extern struct HelpBoxInfo CONST_DATA gHelpInfo_Ss1CharName; // hardcoded thing bad
-extern struct HelpBoxInfo CONST_DATA gHelpInfo_Ss1Item0; // page 1 root help
-extern struct HelpBoxInfo CONST_DATA gHelpInfo_Ss2Rank0; // page 2 root help
+extern struct HelpBoxInfo gHelpInfo_Ss0Pow; // page 0 root help
+extern struct HelpBoxInfo gHelpInfo_Ss1CharName; // hardcoded thing bad
+extern struct HelpBoxInfo gHelpInfo_Ss1Item0; // page 1 root help
+extern struct HelpBoxInfo gHelpInfo_Ss2Rank0; // page 2 root help
                                                          //
 struct StatScreenEffectProc
 {
@@ -338,5 +338,42 @@ void HelpPrompt_OnIdle(struct HelpPromptSprProc* proc);
 extern struct StatScreenSt gStatScreen; // statscreen state
 extern u16 gBmFrameTmap0[0x280]; // bg0 tilemap buffer for stat screen page
 extern u16 gBmFrameTmap1[0x240]; // bg2 tilemap buffer for stat screen page
+
+extern struct StatScreenInfo sStatScreenInfo;
+extern struct HelpBoxInfo sMutableHbi;
+extern const struct HelpBoxInfo* sLastHbi;
+extern struct Vec2 sHbOrigin;
+
+extern const struct SSTextDispInfo sPage0TextInfo[];
+
+extern const struct SSTextDispInfo sPage0TextInfo[];
+extern const struct SSTextDispInfo sPage1TextInfo[];
+extern const struct SSTextDispInfo sPage2TextInfo_Physical[];
+extern const struct SSTextDispInfo sPage2TextInfo_Magical[];
+extern struct TextInitInfo sSSMasterTextInitInfo[];
+extern s8 sPageSlideOffsetLut[];
+extern struct ProcCmd gProcScr_SSPageSlide[];
+extern struct ProcCmd gProcScr_SSGlowyBlendCtrl[];
+extern struct ProcCmd gProcScr_SSUnitSlide[];
+
+extern u16 sSprite_Page0Name[];
+extern u16 sSprite_Page1Name[];
+extern u16 sSprite_Page2Name[];
+extern u16 sSprite_PageNameBack[];
+extern const u16 *sPageNameSpriteLut[];
+extern u16 sSprite_PageNameBack[];
+extern const u16 *sPageNameSpriteLut[];
+extern u16 sPageNameChrOffsetLut[];
+
+extern struct ProcCmd gProcScr_SSPageNameCtrl[];
+extern struct ProcCmd gProcScr_SSPageNumCtrl[];
+extern struct ProcCmd gProcScr_SSBgOffsetCtrl[];
+extern struct ProcCmd gProcScr_StatScreen[];
+extern struct ProcCmd gProcScr_HelpBox[];
+extern struct ProcCmd gProcScr_HelpBoxMoveCtrl[];
+extern struct ProcCmd gProcScr_HelpBoxLock[];
+
+extern u16 sSprite_MetaHelp[];
+extern struct ProcCmd gProcScr_HelpPromptSpr[];
 
 #endif // GUARD_STATSCREEN_H

--- a/include/statscreen.h
+++ b/include/statscreen.h
@@ -172,7 +172,6 @@ void HbPopulate_SSCharacter(struct HelpBoxProc* proc);
 void HbPopulate_SSClass(struct HelpBoxProc* proc);
 void HbRedirect_SSSupports(struct HelpBoxProc* proc);
 
-// extern
 void UpdateHelpBoxDisplay(struct HelpBoxProc* proc, int arg1);
 
 void StartHelpBox(int x, int y, int mid);
@@ -185,7 +184,6 @@ void EndHelpBox(void);
 void StartMovingHelpBox(const struct HelpBoxInfo* info, struct Proc* parent);
 void StartMovingHelpBoxExt(const struct HelpBoxInfo* info, struct Proc* parent, int x, int y);
 
-// extern
 void SetHelpBoxInitPosition(struct HelpBoxProc* proc, int x, int y);
 void ResetHelpBoxInitSize(struct HelpBoxProc* proc);
 int GetHelpBoxItemInfoKind(int item);

--- a/src/statscreen.c
+++ b/src/statscreen.c
@@ -27,13 +27,12 @@
 
 #include "statscreen.h"
 
-static struct StatScreenInfo EWRAM_DATA sStatScreenInfo = {};
+struct StatScreenInfo EWRAM_DATA sStatScreenInfo = {};
 
-static struct HelpBoxInfo EWRAM_DATA sMutableHbi = {};
-static const struct HelpBoxInfo* EWRAM_DATA sLastHbi = NULL;
-static struct Vec2 EWRAM_DATA sHbOrigin = {};
+struct HelpBoxInfo EWRAM_DATA sMutableHbi = {};
+const struct HelpBoxInfo* EWRAM_DATA sLastHbi = NULL;
+struct Vec2 EWRAM_DATA sHbOrigin = {};
 
-static
 struct SSTextDispInfo const sPage0TextInfo[] =
 {
     { gStatScreen.text + STATSCREEN_TEXT_SKLLABEL,   gBmFrameTmap0 + TILEMAP_INDEX(1, 3),  TEXT_COLOR_SYSTEM_GOLD, 0, &gMid_Skl },
@@ -51,7 +50,6 @@ struct SSTextDispInfo const sPage0TextInfo[] =
     { }, // end
 };
 
-static
 struct SSTextDispInfo const sPage1TextInfo[] =
 {
     { gStatScreen.text + STATSCREEN_TEXT_BSATKLABEL, gBmFrameTmap0 + TILEMAP_INDEX(2, 13), TEXT_COLOR_SYSTEM_GOLD, 6, &gMid_Atk },
@@ -63,7 +61,6 @@ struct SSTextDispInfo const sPage1TextInfo[] =
     { }, // end
 };
 
-static
 struct SSTextDispInfo const sPage2TextInfo_Physical[] =
 {
     { gStatScreen.text + STATSCREEN_TEXT_WEXP0, gBmFrameTmap0 + TILEMAP_INDEX(3,  1), TEXT_COLOR_SYSTEM_WHITE, 0, &gMid_Sword },
@@ -74,7 +71,6 @@ struct SSTextDispInfo const sPage2TextInfo_Physical[] =
     { }, // end
 };
 
-static
 struct SSTextDispInfo const sPage2TextInfo_Magical[] =
 {
     { gStatScreen.text + STATSCREEN_TEXT_WEXP0, gBmFrameTmap0 + TILEMAP_INDEX(3,  1), TEXT_COLOR_SYSTEM_WHITE, 0, &gMid_Anima },
@@ -85,7 +81,6 @@ struct SSTextDispInfo const sPage2TextInfo_Magical[] =
     { }, // end
 };
 
-static
 struct TextInitInfo CONST_DATA sSSMasterTextInitInfo[] =
 {
     { gStatScreen.text + STATSCREEN_TEXT_CHARANAME,  7  },
@@ -127,7 +122,6 @@ struct TextInitInfo CONST_DATA sSSMasterTextInitInfo[] =
     { }, // end
 };
 
-static
 s8 CONST_DATA sPageSlideOffsetLut[] = // stat screen page transition draw offset lut
 {
     // transition page out
@@ -180,7 +174,7 @@ struct ProcCmd CONST_DATA gProcScr_SSUnitSlide[] =
     PROC_END,
 };
 
-static u16 CONST_DATA sSprite_Page0Name[] =
+u16 CONST_DATA sSprite_Page0Name[] =
 {
     3,
     0x4104, 0x9008, TILEREF(0, 0),
@@ -188,14 +182,14 @@ static u16 CONST_DATA sSprite_Page0Name[] =
     0x4104, 0x9048, TILEREF(8, 0),
 };
 
-static u16 CONST_DATA sSprite_Page1Name[] =
+u16 CONST_DATA sSprite_Page1Name[] =
 {
     2,
     0x4104, 0x901E, TILEREF(0, 0),
     0x4104, 0x903E, TILEREF(4, 0),
 };
 
-static u16 CONST_DATA sSprite_Page2Name[] =
+u16 CONST_DATA sSprite_Page2Name[] =
 {
     5,
     0x4108, 0x9004, TILEREF(6,  0),
@@ -205,7 +199,7 @@ static u16 CONST_DATA sSprite_Page2Name[] =
     0x0100, 0x5020, TILEREF(4,  0),
 };
 
-static u16 CONST_DATA sSprite_PageNameBack[] =
+u16 CONST_DATA sSprite_PageNameBack[] =
 {
     6,
     0x4002, 0x8000, TILEREF(0, 0),
@@ -216,14 +210,14 @@ static u16 CONST_DATA sSprite_PageNameBack[] =
     0x4002, 0x904A, TILEREF(0, 0),
 };
 
-static u16 const* CONST_DATA sPageNameSpriteLut[] =
+u16 const* CONST_DATA sPageNameSpriteLut[] =
 {
     sSprite_Page0Name,
     sSprite_Page1Name,
     sSprite_Page2Name,
 };
 
-static u16 CONST_DATA sPageNameChrOffsetLut[] = { 0, 64, 14 }; // tile offsets within an image
+u16 CONST_DATA sPageNameChrOffsetLut[] = { 0, 64, 14 }; // tile offsets within an image
 
 struct ProcCmd CONST_DATA gProcScr_SSPageNameCtrl[] =
 {
@@ -341,7 +335,6 @@ struct ProcCmd CONST_DATA gProcScr_HelpBoxLock[] =
     PROC_END,
 };
 
-static
 u16 CONST_DATA sSprite_MetaHelp[] = // 'R is info'
 {
     2,


### PR DESCRIPTION
title

I left all the static data at the bottom of statscreen.c because it seems that there's still some decisions to be made on what to do with it.