### PR TITLE
Fix a mismatch on signedness of args on `GenUnitDefinitionFinalPosition`

### DIFF
--- a/include/muctrl.h
+++ b/include/muctrl.h
@@ -42,7 +42,7 @@ s8 MuCtrExists(void);
 void MU_AllForceSetMaxMoveSpeed_(void);
 void sub_8079FA8(struct Unit* unit, const struct REDA * redas, s16 count, u16 flags);
 void MoveUnit_(struct Unit *, s8, s8, u16);
-void GenUnitDefinitionFinalPosition(const struct UnitDefinition* uDef, u8* xOut, u8* yOut, s8 findNearest);
+void GenUnitDefinitionFinalPosition(const struct UnitDefinition* uDef, s8* xOut, s8* yOut, s8 findNearest);
 // ??? sub_807A0E4(???);
 // ??? sub_807A194(???);
 // ??? MuCtr_OnEnd(???);

--- a/src/muctrl.c
+++ b/src/muctrl.c
@@ -213,7 +213,7 @@ void MoveUnit_(struct Unit * unit, s8 x, s8 y, u16 flags)
 }
 
 //! FE8U = 0x0807A054
-void GenUnitDefinitionFinalPosition(const struct UnitDefinition * def, u8 * xOut, u8 * yOut, s8 findNearest)
+void GenUnitDefinitionFinalPosition(const struct UnitDefinition * def, s8 * xOut, s8 * yOut, s8 findNearest)
 {
     struct Unit * unit;
     const struct REDA * reda;


### PR DESCRIPTION
This PR corrects a mistake on the signedness of the `xOut` and `yOut` arguments in `GenUnitDefinitionFinalPosition` (`FE8U:0x0807A054`). 

@Pikmin1211 pointed out that `UnitInitFromDefinition` (`FE8U:0x08017D3C`) uses the unit's x and y positions as inputs to this function, both of which are signed:

https://github.com/FireEmblemUniverse/fireemblem8u/blob/35ccd30ac12969118323dff9a4a293fab54c8aae/src/bmunit.c#L673