### PR TITLE
Set git attributes for *.bin files to binary.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
+*.bin binary
+
 # Declare files that will always have CRLF line endings on checkout.
 *.pal text eol=crlf
 


### PR DESCRIPTION
Fixed the issue where /graphics/map/Ch14EphraimMapChanges_change_1.bin was identified as a text file due to text=auto, causing 0x0A to be replaced with 0x0D 0x0A after cloning on Windows.