### PR TITLE
Fix compilation failure in MSYS2 environment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ Temporary Items
 *.gba
 *.elf
 *.map
+objects.lst
 *.o
 src/*.s
 *.dump

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ BANIM_OBJECT := data/banim/data_banim.o
 MID_FILES    := $(wildcard $(MID_SUBDIR)/*.mid)
 MID_OBJECTS  := $(MID_FILES:.mid=.o)
 ALL_OBJECTS  := $(C_OBJECTS) $(ASM_OBJECTS) $(BANIM_OBJECT) $(MID_OBJECTS)
+OBJECTS_LST  := objects.lst
 DEPS_DIR     := .dep
 
 AUTO_GEN_TARGETS :=
@@ -99,7 +100,7 @@ compare: $(ROM)
 
 clean:
 	find . \( -iname '*.1bpp' -o -iname '*.4bpp' -o -iname '*.8bpp' -o -iname '*.gbapal' -o -iname '*.lz' -o -iname '*.fk' -o -iname '*.latfont' -o -iname '*.hwjpnfont' -o -iname '*.fwjpnfont' \) -exec rm {} +
-	$(RM) $(ROM) $(ELF) $(MAP) $(ALL_OBJECTS) src/*.s graphics/*.h $(CFILES_GENERATED)
+	$(RM) $(ROM) $(ELF) $(MAP) $(ALL_OBJECTS) $(OBJECTS_LST) src/*.s graphics/*.h $(CFILES_GENERATED)
 	$(RM) -rf $(DEPS_DIR)
 	# Remove battle animation binaries
 	$(RM) -f data/banim/*.bin data/banim/*.o data/banim/*.lz data/banim/*.bak
@@ -166,8 +167,11 @@ MAKEDEP = mkdir -p $(DEPS_DIR)/$(dir $*) && $(CPP) $(CPPFLAGS) $< -MM -MG -MT $*
 $(DEPS_DIR)/%.d: %.c
 	@$(MAKEDEP)
 
-$(ELF): $(ALL_OBJECTS) $(LDSCRIPT) $(SYM_FILES)
-	$(LD) -T $(LDSCRIPT) -Map $(MAP) $(ALL_OBJECTS) -R $(BANIM_OBJECT).sym.o -L tools/agbcc/lib -o $@ -lc -lgcc
+$(OBJECTS_LST): $(ALL_OBJECTS)
+	@echo $(ALL_OBJECTS) > $@
+
+$(ELF): $(ALL_OBJECTS) $(OBJECTS_LST) $(LDSCRIPT) $(SYM_FILES)
+	$(LD) -T $(LDSCRIPT) -Map $(MAP) @$(OBJECTS_LST) -R $(BANIM_OBJECT).sym.o -L tools/agbcc/lib -o $@ -lc -lgcc
 	$(STRIP) -N .gcc2_compiled. $@
 
 %.gba: %.elf

--- a/sym_iwram.txt
+++ b/sym_iwram.txt
@@ -83,9 +83,9 @@
 
 . = 0x002A68;
 . = ALIGN(4); src/agb_sram.o(.bss);
-. = ALIGN(4); tools/agbcc/lib/libc.a:syscalls.o(.bss);
-. = ALIGN(4); tools/agbcc/lib/libgcc.a:dp-bit.o(.bss);
-. = ALIGN(4); tools/agbcc/lib/libgcc.a:fp-bit.o(.bss);
+. = ALIGN(4); *libc.a:syscalls.o(.bss);
+. = ALIGN(4); *libgcc.a:dp-bit.o(.bss);
+. = ALIGN(4); *libgcc.a:fp-bit.o(.bss);
 
 /* COMMON */
 . = 0x002C60; SoundMainRAM_Buffer = .;
@@ -171,4 +171,4 @@
 . = 0x0067A4; VerifySramFast = .;
 
 . = 0x67A8;
-. = ALIGN(4); tools/agbcc/lib/libc.a:sbrkr.o(COMMON);
+. = ALIGN(4); *libc.a:sbrkr.o(COMMON);


### PR DESCRIPTION
Write all contents of $(ALL_OBJECTS) into objects.lst file, and then use @objects.lst during linking to address the issue of "make: arm-none-eabi-ld.exe: Argument list too long".
Following pokeemerald, change tools/agbcc/lib/ to * in ldscript to resolve the problem of the linker in MSYS2 producing paths like tools/agbcc/lib\, which leads to some content being discarded.