### PR TITLE
Set git EOL attribute for *.sha1 files to LF.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,9 @@
 # Declare files that will always have CRLF line endings on checkout.
 *.pal text eol=crlf
 
+# Declare files that will always have LF line endings on checkout.
+*.sha1 text eol=lf
+
 # Custom for Visual Studio
 *.cs     diff=csharp
 


### PR DESCRIPTION
Fixed the issue where text=auto caused /checksum1.sha1 to have CRLF line endings after git clone on Windows, leading to the sha1sum error: "'fireemblem8.gba'$'\r': No such file or directory".