### PR TITLE
Small cleanups in Talk_OnIdle, GetStrTalkLen, BmBgfx_Loop, and StartGmapRm

### DIFF
--- a/src/scene.c
+++ b/src/scene.c
@@ -565,26 +565,21 @@ void Talk_OnIdle(ProcPtr proc) {
                 Proc_Break(proc);
                 return;
 
-            case 1:
-                goto _08006CD0;
-
             case 2:
                 if (sTalkState->instantScroll || sTalkState->printDelay <= 0) {
                     break;
-                    goto _08006CC2;
                 }
 
                 return;
 
             case 3:
-        _08006CC2:
                 sTalkState->printClock = sTalkState->printDelay;
                 sTalkState->instantScroll = 0;
 
                 return;
 
+            case 1:
             default:
-        _08006CD0:
                 if (!(CheckTalkFlag(TALK_FLAG_SPRITE))) {
                     if (TalkPrepNextChar(proc) == 1) {
                         return;
@@ -2285,9 +2280,7 @@ int GetStrTalkLen(const char* str, s8 isBubbleOpen) {
                             continue;
 
                         case 0x10:
-                            str++;
-                            str++;
-                            str++;
+                            str += 3;
 
                             continue;
                     }

--- a/src/sysutil.c
+++ b/src/sysutil.c
@@ -1385,23 +1385,11 @@ void BmBgfx_Loop(struct ProcBmBgfx * proc)
         if (conf->type == BMFX_CONFT_BLOCKING)
             break;
 
-#if NONMATCHING
-        switch (conf->type) {
-        case BMFX_CONFT_BREAK:
-        case BMFX_CONFT_END:
-            Proc_Break(proc);
-            return;
-
-        default:
-            break;
-        }
-#else
         if (conf->type < 11 && conf->type > 8)
         {
             Proc_Break(proc);
             break;
         }
-#endif
 
         if (proc->timer == 0)
         {

--- a/src/worldmap_rm.c
+++ b/src/worldmap_rm.c
@@ -301,15 +301,8 @@ ProcPtr StartGmapRm(int x, int y, u32 mask, ProcPtr parent)
     else
         proc = Proc_Start(ProcScr_GmapRM, PROC_TREE_3);
 
-#if NONMATCHING
-    proc->flag = mask & (~GMAPRM_FLAG_UNBLOCK);
-#else
-{
-    u8 * flag_it = &proc->flag;
-    u8 _mask = ~GMAPRM_FLAG_UNBLOCK;
-    *flag_it = _mask & mask;
-}
-#endif
+    proc->flag = (~GMAPRM_FLAG_UNBLOCK);
+    proc->flag &= mask;
 
     proc->x = x;
     proc->y = y;


### PR DESCRIPTION
I skimmed through the code and notice a handful of cleanups.

`BmBgfx_Loop`: it can't be a switch statement, since you can't break out of 2 in C (except with goto) and return prevents the last 2 lines from being executed, so I removed the tentative switch statement.