### PR TITLE
Removed goto from some functions

### DIFF
--- a/src/bmreliance.c
+++ b/src/bmreliance.c
@@ -217,21 +217,20 @@ void ProcessTurnSupportExp(void)
 
             case 0:
                 if (!(unit->rescue == other->index))
-                    break;
-
-                goto add_support_points;
+                    continue;
+                break;
 
             case 1:
                 if ((unit->state & US_RESCUED) || (other->state & US_RESCUED))
-                    break;
-
-            add_support_points:
-                if (GetUnitTotalSupportLevel(other) < MAX_SIMULTANEOUS_SUPPORT_COUNT)
-                    UnitGainSupportExp(unit, j);
-
+                    continue;
                 break;
 
+            default:
+                continue;
             }
+
+            if (GetUnitTotalSupportLevel(other) < MAX_SIMULTANEOUS_SUPPORT_COUNT)
+                UnitGainSupportExp(unit, j);
         }
     }
 }

--- a/src/eventinfo.c
+++ b/src/eventinfo.c
@@ -105,20 +105,18 @@ struct EventInfo * SearchAvailableEvent(struct EventInfo * info)
 
         if (!CheckFlag(EVT_CMD_HI(info->listScript[0])))
         {
-            if (cmdInfo[cmdId].func(info) != 1)
+            if (cmdInfo[cmdId].func(info) == 1)
             {
-            label:
-                info->listScript += len[r6 << 1];
-                continue;
+                goto _end; // FIXME: Goto appears to be required for match
             }
-
-            if (info->script)
-                return info;
-
-            break;
         }
-        goto label;
+
+        info->listScript += len[r6 << 1];
     }
+
+_end:
+    if (info->script)
+        return info;
     return NULL;
 }
 

--- a/src/prep_sallycursor.c
+++ b/src/prep_sallycursor.c
@@ -818,105 +818,105 @@ void PrepScreenProc_MapIdle(struct ProcPrepSallyCursor * proc)
         {
             TrySwitchViewedUnit(gBmSt.playerCursor.x, gBmSt.playerCursor.y);
             PlaySoundEffect(0x6B);
-            goto showcursor;
         }
-
-        if (gKeyStatusPtr->newKeys & R_BUTTON)
+        else
         {
-            if (gBmMapUnit[gBmSt.playerCursor.y][gBmSt.playerCursor.x])
+            if (gKeyStatusPtr->newKeys & R_BUTTON)
             {
-                if (CanShowUnitStatScreen(GetUnit(gBmMapUnit[gBmSt.playerCursor.y][gBmSt.playerCursor.x])))
+                if (gBmMapUnit[gBmSt.playerCursor.y][gBmSt.playerCursor.x])
                 {
-                    EndAllMus();
-                    EndPlayerPhaseSideWindows();
-                    SetStatScreenConfig(
-                        STATSCREEN_CONFIG_NONDEAD | STATSCREEN_CONFIG_NONBENCHED | STATSCREEN_CONFIG_NONUNK9 |
-                        STATSCREEN_CONFIG_NONROOFED | STATSCREEN_CONFIG_NONUNK16);
-                    StartStatScreen(GetUnit(gBmMapUnit[gBmSt.playerCursor.y][gBmSt.playerCursor.x]), proc);
-                    Proc_Goto(proc, 5);
-                    return;
+                    if (CanShowUnitStatScreen(GetUnit(gBmMapUnit[gBmSt.playerCursor.y][gBmSt.playerCursor.x])))
+                    {
+                        EndAllMus();
+                        EndPlayerPhaseSideWindows();
+                        SetStatScreenConfig(
+                            STATSCREEN_CONFIG_NONDEAD | STATSCREEN_CONFIG_NONBENCHED | STATSCREEN_CONFIG_NONUNK9 |
+                            STATSCREEN_CONFIG_NONROOFED | STATSCREEN_CONFIG_NONUNK16);
+                        StartStatScreen(GetUnit(gBmMapUnit[gBmSt.playerCursor.y][gBmSt.playerCursor.x]), proc);
+                        Proc_Goto(proc, 5);
+                        return;
+                    }
                 }
             }
-        }
 
-        if (gKeyStatusPtr->newKeys & B_BUTTON)
-        {
-            EndPlayerPhaseSideWindows();
-            gPlaySt.xCursor = gBmSt.playerCursor.x;
-            gPlaySt.yCursor = gBmSt.playerCursor.y;
-            Proc_Goto(proc, 0);
-            PlaySoundEffect(0x69);
-            return;
-        }
-
-        if (gKeyStatusPtr->newKeys & A_BUTTON)
-        {
-            struct Unit * unit = GetUnit(gBmMapUnit[gBmSt.playerCursor.y][gBmSt.playerCursor.x]);
-
-            switch (GetPlayerSelectKind(unit))
+            if (gKeyStatusPtr->newKeys & B_BUTTON)
             {
-                case PLAYER_SELECT_NOUNIT:
-                case PLAYER_SELECT_TURNENDED:
-                    EndPlayerPhaseSideWindows();
-                    gPlaySt.xCursor = gBmSt.playerCursor.x;
-                    gPlaySt.yCursor = gBmSt.playerCursor.y;
-
-                    switch (gBmMapTerrain[gBmSt.playerCursor.y][gBmSt.playerCursor.x])
-                    {
-                        case TERRAIN_VENDOR:
-                        case TERRAIN_ARMORY:
-                            PlaySoundEffect(0x6A);
-                            Proc_Goto(proc, 60);
-                            return;
-                        default:
-                            Proc_Goto(proc, 0);
-                            PlaySoundEffect(0x69);
-                            return;
-                    }
-
-                case PLAYER_SELECT_CONTROL:
-                    UnitBeginAction(unit);
-                    gActiveUnit->state &= ~(US_HIDDEN);
-
-                    if (proc->unk_58 == 2)
-                    {
-                        Proc_Goto(proc, 3);
-                        return;
-                    }
-
-                    Proc_Goto(proc, 1);
-
-                    return;
-
-                case PLAYER_SELECT_4:
-                    if (proc->unk_58 == 2)
-                    {
-                        PlaySoundEffect(0x6C);
-                        return;
-                    }
-
-                    // fallthrough
-
-                case PLAYER_SELECT_NOCONTROL:
-                    UnitBeginAction(unit);
-                    gActiveUnit->state &= ~(US_HIDDEN);
-
-                    Proc_Goto(proc, 1);
-
-                    return;
+                EndPlayerPhaseSideWindows();
+                gPlaySt.xCursor = gBmSt.playerCursor.x;
+                gPlaySt.yCursor = gBmSt.playerCursor.y;
+                Proc_Goto(proc, 0);
+                PlaySoundEffect(0x69);
+                return;
             }
-        }
 
-        if (gKeyStatusPtr->newKeys & START_BUTTON)
-        {
-            EndPlayerPhaseSideWindows();
-            StartMinimapPrepPhase(proc);
-            Proc_Goto(proc, 9);
-            return;
+            if (gKeyStatusPtr->newKeys & A_BUTTON)
+            {
+                struct Unit * unit = GetUnit(gBmMapUnit[gBmSt.playerCursor.y][gBmSt.playerCursor.x]);
+
+                switch (GetPlayerSelectKind(unit))
+                {
+                    case PLAYER_SELECT_NOUNIT:
+                    case PLAYER_SELECT_TURNENDED:
+                        EndPlayerPhaseSideWindows();
+                        gPlaySt.xCursor = gBmSt.playerCursor.x;
+                        gPlaySt.yCursor = gBmSt.playerCursor.y;
+
+                        switch (gBmMapTerrain[gBmSt.playerCursor.y][gBmSt.playerCursor.x])
+                        {
+                            case TERRAIN_VENDOR:
+                            case TERRAIN_ARMORY:
+                                PlaySoundEffect(0x6A);
+                                Proc_Goto(proc, 60);
+                                return;
+                            default:
+                                Proc_Goto(proc, 0);
+                                PlaySoundEffect(0x69);
+                                return;
+                        }
+
+                    case PLAYER_SELECT_CONTROL:
+                        UnitBeginAction(unit);
+                        gActiveUnit->state &= ~(US_HIDDEN);
+
+                        if (proc->unk_58 == 2)
+                        {
+                            Proc_Goto(proc, 3);
+                            return;
+                        }
+
+                        Proc_Goto(proc, 1);
+
+                        return;
+
+                    case PLAYER_SELECT_4:
+                        if (proc->unk_58 == 2)
+                        {
+                            PlaySoundEffect(0x6C);
+                            return;
+                        }
+
+                        // fallthrough
+
+                    case PLAYER_SELECT_NOCONTROL:
+                        UnitBeginAction(unit);
+                        gActiveUnit->state &= ~(US_HIDDEN);
+
+                        Proc_Goto(proc, 1);
+
+                        return;
+                }
+            }
+
+            if (gKeyStatusPtr->newKeys & START_BUTTON)
+            {
+                EndPlayerPhaseSideWindows();
+                StartMinimapPrepPhase(proc);
+                Proc_Goto(proc, 9);
+                return;
+            }
         }
     }
 
-showcursor:
     PutMapCursor(gBmSt.playerCursorDisplay.x, gBmSt.playerCursorDisplay.y, 0);
 
     return;

--- a/src/titlescreen.c
+++ b/src/titlescreen.c
@@ -285,7 +285,8 @@ void Title_SetupSpecialEffectGraphics(struct TitleScreenProc* proc) {
             ApplyPalette(gPal_08AB0114, 0);
             gPaletteBuffer[PAL_BACKDROP_OFFSET] = 0x7FFF; // White
 
-            goto _080C5A14;
+            proc->timer++;
+            break;
 
         case 1:
             Decompress(gGfx_08AADC08, (void*)0x0600C000);
@@ -298,7 +299,8 @@ void Title_SetupSpecialEffectGraphics(struct TitleScreenProc* proc) {
 
             BG_EnableSyncByMask(1);
 
-            goto _080C5A14;
+            proc->timer++;
+            break;
 
         case 2:
             Decompress(gGfx_08AAE8EC, (void*)0x0600D000);
@@ -309,7 +311,8 @@ void Title_SetupSpecialEffectGraphics(struct TitleScreenProc* proc) {
                 gBG0TilemapBuffer[i] += 0x2080;
             }
 
-            goto _080C5A14;
+            proc->timer++;
+            break;
 
         case 3:
             Decompress(gGfx_TitleLargeGlowingOrb, (void*)0x06014400);
@@ -317,19 +320,16 @@ void Title_SetupSpecialEffectGraphics(struct TitleScreenProc* proc) {
             Decompress(gGfx_TitleSmallLightBubbles, (void*)0x06015400);
             ApplyPalette(gPal_TitleSmallLightBubbles, 0x17);
 
-            goto _080C5A14;
+            // fallthrough
 
         default:
-_080C5A14:
             proc->timer++;
-
-            return;
+            break;
 
         case 4:
             proc->timer = 0;
             Proc_Break(proc);
-
-            return;
+            break;
     }
 }
 

--- a/src/worldmap_main.c
+++ b/src/worldmap_main.c
@@ -629,19 +629,13 @@ s8 sub_80B92D0(struct WorldMapMainProc * param_1, int param_2)
 
     if (sub_80BCCFC(gGMData.units[0].location, param_2, 0) != 0)
     {
-        if ((sub_80BD29C() == 2))
+        if ((sub_80BD29C() == 2) && (gGMData.nodes[param_2].state & 2) != 0)
         {
-            if ((gGMData.nodes[param_2].state & 2) != 0)
-            {
-                param_1->unk_3e = param_2;
-                Proc_Goto(param_1, 14);
-            }
-            else
-                goto label;
+            param_1->unk_3e = param_2;
+            Proc_Goto(param_1, 14);
         }
         else
         {
-        label:
             Proc_Goto(param_1, 6);
         }
 


### PR DESCRIPTION
For SearchAvailableEvent, goto is still needed to match instead of break, but I rewrote the function so the flow is clearer.