### PR TITLE
Fix CI - Add missing Python dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get install -y build-essential binutils-arm-none-eabi libpng-dev && python -m pip install ttp
+      run: sudo apt-get update && sudo apt-get install -y build-essential binutils-arm-none-eabi libpng-dev && python -m pip install ttp numpy pillow
 
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
PR #673 introduced a new script `tsa_generator.py` that requires the NumPy and Pillow dependencies to be installed. This PR adds those dependencies to the CI build.