### PR TITLE
Fix a mismatch on signedness of args on `DrawHpBar` (and friends)

### DIFF
--- a/src/player_interface.c
+++ b/src/player_interface.c
@@ -347,34 +347,34 @@ int GetCursorQuadrant() {
     }
 }
 
-void GetHpBarLeftTile(s16* buffer, s16 hp, int tileBase) {
-    if (hp > 5) {
+void GetHpBarLeftTile(u16 * buffer, s16 hp, int tileBase)
+{
+    if (hp > 5)
         hp = 5;
-    }
 
     *buffer = hp + tileBase;
 
     return;
 }
 
-void GetHpBarMidTiles(s16* buffer, s16 hp, int tileBase) {
+void GetHpBarMidTiles(u16 * buffer, s16 hp, int tileBase)
+{
     int i;
 
     int hpEighth = hp >> 3;
-
     int eighthTileIdx = hp & 7;
 
-    for (i = 0; i < 5; i++) {
+    for (i = 0; i < 5; i++)
+    {
         int fullTileIdx = tileBase + 14;
         int emptyTileIdx = tileBase + 6;
 
-        if (i < hpEighth) {
+        if (i < hpEighth) // full
             *buffer = fullTileIdx;
-        } else if (i == hpEighth) {
+        else if (i == hpEighth) // partial
             *buffer = emptyTileIdx + eighthTileIdx;
-        } else {
+        else // empty
             *buffer = emptyTileIdx;
-        }
 
         buffer++;
     }
@@ -382,16 +382,15 @@ void GetHpBarMidTiles(s16* buffer, s16 hp, int tileBase) {
     return;
 }
 
-void GetHpBarRightTile(s16* buffer, s16 hp, int tileBase) {
+void GetHpBarRightTile(u16 * buffer, s16 hp, int tileBase)
+{
     int base;
 
-    if (hp >= 5) {
+    if (hp >= 5)
         hp = 5;
-    }
 
-    if (hp < 0) {
+    if (hp < 0)
         hp = 0;
-    }
 
     base = tileBase + 15;
 
@@ -400,15 +399,13 @@ void GetHpBarRightTile(s16* buffer, s16 hp, int tileBase) {
     return;
 }
 
-void DrawHpBar(s16* buffer, struct Unit* unit, int tileBase) {
+void DrawHpBar(u16 * buffer, struct Unit * unit, int tileBase)
+{
     s16 hpCurrent = 50 * GetUnitCurrentHp(unit);
-
     s16 hpPercent = Div(hpCurrent, GetUnitMaxHp(unit));
 
     GetHpBarLeftTile(buffer, hpPercent, tileBase);
-
     GetHpBarMidTiles(buffer + 1, hpPercent - 5, tileBase);
-
     GetHpBarRightTile(buffer + 6, hpPercent - 45, tileBase);
 
     return;

--- a/src/player_interface.c
+++ b/src/player_interface.c
@@ -18,35 +18,36 @@
 #include "worldmap.h"
 #include "constants/terrains.h"
 
-struct PlayerInterfaceProc {
-    PROC_HEADER;
+struct PlayerInterfaceProc
+{
+    /* 00 */ PROC_HEADER;
 
-    struct Text unk_2c[2];
+    /* 2C */ struct Text unk_2c[2];
 
-    s8 unk_3c;
-    s8 unk_3d;
-    s8 unk_3e;
-    s8 unk_3f;
+    /* 3C */ s8 unk_3c;
+    /* 3D */ s8 unk_3d;
+    /* 3E */ s8 unk_3e;
+    /* 3F */ s8 unk_3f;
 
-    s16* unk_40;
-    s16 unk_44;
-    s16 unk_46;
-    s16 unk_48;
-    u8 unk_4a;
-    u8 unk_4b;
-    u8 xCursorPrev;
-    u8 yCursorPrev;
-    u8 xCursor;
-    u8 yCursor;
-    s8 unk_50;
-    u8 unk_51;
-    u8 unk_52;
-    u8 unk_53;
-    u8 unk_54;
-    s8 unk_55;
-    s8 isRetracting;
-    s8 quadrant;
-    int unk_58;
+    /* 40 */ u16 * unk_40;
+    /* 44 */ s16 unk_44;
+    /* 46 */ s16 unk_46;
+    /* 48 */ s16 unk_48;
+    /* 4A */ u8 unk_4a;
+    /* 4B */ u8 unk_4b;
+    /* 4C */ u8 xCursorPrev;
+    /* 4D */ u8 yCursorPrev;
+    /* 4E */ u8 xCursor;
+    /* 4F */ u8 yCursor;
+    /* 50 */ s8 unk_50;
+    /* 51 */ u8 unk_51;
+    /* 52 */ u8 unk_52;
+    /* 53 */ u8 unk_53;
+    /* 54 */ u8 unk_54;
+    /* 55 */ s8 unk_55;
+    /* 56 */ s8 isRetracting;
+    /* 57 */ s8 quadrant;
+    /* 58 */ int unk_58;
 };
 
 struct PlayerInterfaceConfigEntry {


### PR DESCRIPTION
As pointed out by @JesterWizard in the FEU Discord, there was a mismatch in the signedness of the arguments of the `DrawHpBar` (`FE8U:0x0808BC94`) function, and its associated helper functions. They should be using `u16 *` based on the type of `gUiTmScratchA`. Additionally, there was another mismatch on the `PlayerInterfaceProc` `unk_40`, which should also be unsigned. 

This PR makes the pointers `u16 *`, which is consistent with the FE6 decompilation: https://github.com/FireEmblemUniverse/fireemblem6j/blob/15073c1046053b7c1da6e5fc12237166c2c2fd7a/src/mapui.c#L193

Reference: https://discord.com/channels/144670830150811649/179027738454261760/1336121718527229952