### PR TITLE
Code review on `mapanim`

### DIFF
--- a/data/data_9A31F8.s
+++ b/data/data_9A31F8.s
@@ -41,8 +41,8 @@ Obj_WallBreakAnim:  @ 0x089A6FD8
 ApHandle_GmapSoguSprites:  @ 0x089A8EF8
 	.incbin "baserom.gba", 0x9A8EF8, 0x7C
 
-	.global gUnknown_089A8F74
-gUnknown_089A8F74:  @ 0x089A8F74
+	.global Pal_MapAnimManaketeMu
+Pal_MapAnimManaketeMu:  @ 0x089A8F74
 	.incbin "baserom.gba", 0x9A8F74, 0x20
 
 	.global gGfx_ArenaBuildingFront

--- a/include/constants/songs.h
+++ b/include/constants/songs.h
@@ -87,7 +87,7 @@ enum song_idx {
     SONG_9A = 0x9A,
     SONG_9B = 0x9B,
     SONG_9C = 0x9C,
-    SONG_A0 = 0xA0,
+    SONG_SE_BMP_MOVE_BIRD1A_T1 = 0xA0, // also map anim steal
     SONG_A4 = 0xA4,
     SONG_A5 = 0xA5,
     SONG_A6 = 0xA6,

--- a/include/mapanim.h
+++ b/include/mapanim.h
@@ -187,6 +187,13 @@ struct MapAnimActorState {
     /* 12 */ STRUCT_PAD(0x12, 0x14);
 };
 
+enum
+{
+    MANIM_KIND_DAMAGE = 0,
+    MANIM_KIND_STEAL = 1,
+    MANIM_KIND_REFRESH = 2,
+};
+
 struct MapAnimState {
     /* 00 */ struct MapAnimActorState actor[4];
 
@@ -197,11 +204,11 @@ struct MapAnimState {
     /* 5A */ u16 hitAttributes;
     /* 5C */ u8 hitInfo;
     /* 5D */ s8 hitDamage;
-    /* 5E */ u8 actorCount_maybe;
+    /* 5E */ u8 actorCount;
     /* 5F */ u8 hp_changing;
     /* 60 */ u8 xtarget;
     /* 61 */ u8 ytarget;
-    /* 62 */ u8 u62;
+    /* 62 */ u8 mapAnimKind;
 };
 
 extern struct MapAnimState gManimSt;
@@ -290,13 +297,13 @@ extern CONST_DATA struct ProcCmd ProcScr_MapAnimSummon[];
 extern CONST_DATA struct ProcCmd ProcScr_MapAnimSumDK[];
 extern CONST_DATA struct ProcCmd ProcScr_MapAnimDance[];
 extern CONST_DATA struct ProcCmd ProcScr_MapAnimBattle[];
-extern CONST_DATA struct ProcCmd gProc_MapAnimEnd[];
+extern CONST_DATA struct ProcCmd ProcScr_MapAnimEnd[];
 extern CONST_DATA u16 gUnknown_089A3648[];
 extern CONST_DATA int gUnknown_089A3668[];
 extern CONST_DATA u8* TsaSet_MapBattleBoxGfx[3][2];
 extern CONST_DATA struct ProcCmd ProcScr_MapBattleInfoBox[];
 extern CONST_DATA u16 gUnknown_089A36C0[];
-extern CONST_DATA struct ProcCmd gProc_MapAnimExpBar[];
+extern CONST_DATA struct ProcCmd ProcScr_MapAnimExpBar[];
 extern CONST_DATA char *MADebugStrings1[];
 // extern ??? gUnknown_089A3798
 extern CONST_DATA char* MADebugStrings2[];
@@ -390,7 +397,7 @@ extern u16 ApConf_089A6254[];
 extern u16 CONST_DATA Obj_PoisonAnim[];
 extern u16 CONST_DATA Obj_WallBreakAnim[];
 extern const u16 ApHandle_GmapSoguSprites[];
-extern const u16 gUnknown_089A8F74[];
+extern const u16 Pal_MapAnimManaketeMu[];
 extern u8 gGfx_ArenaBuildingFront[];
 extern u8 gTsa_ArenaBuildingFront[];
 extern u16 gPal_ArenaBuildingFront[];
@@ -807,28 +814,28 @@ extern u8 Tsa_089E8200[];
 
 extern u16 gUnknown_089E7DEC[];
 
-void MapAnimProc_DisplayItemStealingPopup(ProcPtr proc);
+void MapAnim_StoleItemPopup(ProcPtr proc);
 void DisplayWpnBrokePopup(ProcPtr proc);
-s8 BattleUnit_ShouldDisplayWpnBroke(struct BattleUnit *);
+s8 BattleUnit_ShouldDisplayWpnBroke(struct BattleUnit * bu);
 void DisplayWRankUpPopup(ProcPtr proc);
-s8 BattleUnit_ShouldDisplayWRankUp(struct BattleUnit *);
-void _InitFontForUIDefault();
+s8 BattleUnit_ShouldDisplayWRankUp(struct BattleUnit * bu);
+void MapAnim_PrepareBattleTalk(void);
 void MapAnim_Cleanup(void);
 void MapAnim_AdvanceBattleRound(void);
-void MapAnim_PrepareNextBattleRound(ProcPtr p);
-void MapAnim_DisplayRoundAnim(ProcPtr p);
-void MapAnim_ShowPoisonEffectIfAny(ProcPtr p);
-void MapAnim_MoveCameraOntoSubject(ProcPtr p);
-void MapAnim_MoveCameraOntoTarget(ProcPtr p);
-void MapAnimProc_DisplayDeahQuote(void);
-void MapAnmiProc_DisplayDeathFade(void);
-void MapAnimProc_DisplayExpBar(struct Proc* proc);
+void MapAnim_PrepareNextBattleRound(ProcPtr proc);
+void MapAnim_DisplayRoundAnim(ProcPtr proc);
+void MapAnim_ShowPoisonEffectIfAny(ProcPtr proc);
+void MapAnim_MoveCameraOntoSubject(ProcPtr proc);
+void MapAnim_MoveCameraOntoTarget(ProcPtr proc);
+void MapAnim_DisplayDeathQuote(void);
+void MapAnim_DisplayDeathFade(void);
+void MapAnim_DisplayExpBar(ProcPtr proc);
 void MapAnim_InitInfoBox(ProcPtr proc);
 void MapAnim_CallBattleQuoteEvents(void);
 // ??? SetBattleMuPaletteByIndex(???);
 void SetBattleMuPalette(void);
-// ??? PlaySoundIdA0(???);
-// ??? sub_807ACEC(???);
+// ??? MapAnim_PlayStealSe(???);
+// ??? MapAnim_PlayStealSe_Unused(???);
 // ??? New6C_SummonGfx_FromActionPos(???);
 // ??? GenerateSummonUnitDef(???);
 // ??? ProcSummonDK_InitCounters(???);
@@ -863,8 +870,8 @@ void sub_807BA28(u16* tilemap, int num, int tileref, int len, u16 blankref, int 
 // ??? PrepareMapBattleBoxNumGfx(???);
 void sub_807BB10(u16* arg0, int* arg1, int arg2, int arg3, int arg4);
 void sub_807BB40(u16* tilemap, int arg1, int arg2, int arg3, u16* arg4);
-void DeleteBattleAnimInfoThing(void);
-void NewMapBattleInfoThing(int x, int y, struct Proc* parent);
+void EndMapAnimInfoWindow(void);
+void StartMapAnimInfoWindow(int x, int y, struct Proc* parent);
 void ProcMapInfoBox_OnEnd(void);
 void ProcMapInfoBox_OnDraw(struct MAInfoFrameProc* proc);
 // ??? sub_807BCA8(???);
@@ -1103,7 +1110,7 @@ void RemoveGlowingCrossDirectlyWithAnim(ProcPtr, int);
 // ??? sub_80811EC(???);
 // ??? sub_8081208(???);
 // ??? nullsub_58(???);
-const struct ProcCmd * GetItemAnim6CCode(void);
+const struct ProcCmd * MapAnim_GetRoundProcScript(void);
 void MapAnim_AnimateSubjectIdle(ProcPtr proc);
 void MapAnim_SubjectResetAnim(ProcPtr proc);
 void sub_80812C0(void);

--- a/include/spellassoc.h
+++ b/include/spellassoc.h
@@ -41,7 +41,7 @@ extern struct SpellAssoc gSpellAssocData[];
 struct SpellAssoc *GetSpellAssocStructPtr(u16 item);
 u8 GetSpellAssocCharCount(u16 item);
 u16 GetSpellAssocEfxIndex(u16 item);
-struct ProcCmd *GetSpellAssocAlt6CPointer(u16 item);
+struct ProcCmd *GetSpellAssocMapAnimProcScript(u16 item);
 u8 GetSpellAssocReturnBool(int item);
 u8 GetSpellAssocFacing(u16 item);
 u8 GetSpellAssocFlashColor(u16 item);

--- a/src/mapanim.c
+++ b/src/mapanim.c
@@ -216,9 +216,12 @@ void MapAnimProc_DisplayExpBar(struct Proc* proc)
         if (gManimSt.actor[1].bu->expGain != 0)
             actorNum = 1;
 
+        // fallthrough
+
     case 1:
         if (gManimSt.actor[0].bu->expGain != 0)
             actorNum = 0;
+
         break;
     }
 

--- a/src/mapanim.c
+++ b/src/mapanim.c
@@ -238,7 +238,8 @@ void MapAnim_InitInfoBox(ProcPtr proc)
 {
     SetDefaultColorEffects();
 
-    switch (gManimSt.u62) {
+    switch (gManimSt.u62)
+    {
     case 1:
     case 2:
         return;
@@ -247,41 +248,43 @@ void MapAnim_InitInfoBox(ProcPtr proc)
         break;
     }
 
-    if (GetSpellAssocReturnBool(gManimSt.actor[0].bu->weaponBefore)) {
+    if (GetSpellAssocReturnBool(gManimSt.actor[0].bu->weaponBefore))
+    {
         int y;
-        if (gManimSt.actorCount_maybe == 1) {
-            y = gManimSt.actor[0].unit->yPos*16 - gBmSt.camera.y;
+        if (gManimSt.actorCount_maybe == 1)
+        {
+            y = gManimSt.actor[0].unit->yPos * 16 - gBmSt.camera.y;
 
             if (y >= 112)
                 y = y - 40;
             else
                 y = y + 24;
 
-        } else {
+        }
+        else
+        {
             int array[2];
-            int i, actorNum;
+            int i;
+            int actorNum;
 
             for (i = 0; i < gManimSt.actorCount_maybe; ++i)
-                array[i] = gManimSt.actor[i].unit->yPos*16 - gBmSt.camera.y;
+                array[i] = gManimSt.actor[i].unit->yPos * 16 - gBmSt.camera.y;
 
-            if (array[0] - array[1] >= 0) {
-                if (array[0] - array[1] >= 80)
-                    goto disp_center;
-            }
-            else if (array[1] - array[0] >= 80) {
-            disp_center:
+            if (ABS(array[0] - array[1]) >= 80)
+            {
                 y = 64;
-                goto disp;
             }
-
-            actorNum = array[0] > array[1] ? 0 : 1;
-            if (array[actorNum] >= 112)
-                y = array[1 - actorNum] - 40;
             else
-                y = array[actorNum] + 24;
+            {
+                actorNum = array[0] > array[1] ? 0 : 1;
+
+                if (array[actorNum] >= 112)
+                    y = array[1 - actorNum] - 40;
+                else
+                    y = array[actorNum] + 24;
+            }
         }
 
-    disp:
         NewMapBattleInfoThing(15, y / 8, proc);
     }
 }

--- a/src/mapanim.c
+++ b/src/mapanim.c
@@ -96,20 +96,22 @@ void MapAnim_Cleanup(void) {
         EndAllMus();
 }
 
-void MapAnim_AdvanceBattleRound(void) {
-    struct MapAnimState *state = &gManimSt;
-    struct BattleHit *round = state->pCurrentRound;
-    u8 r = (round->info >> 3);
-    state->subjectActorId = r % 2;
-    state->targetActorId = 1 - state->subjectActorId;
-    state->hitAttributes = *(u32 *)round;
-    state->hitInfo = round->info;
-    state->hitDamage = round->hpChange;
-    if (state->actorCount_maybe == 1) {
-        state->subjectActorId = 0;
-        state->targetActorId = 0;
+void MapAnim_AdvanceBattleRound(void)
+{
+    gManimSt.subjectActorId = !!(gManimSt.pCurrentRound->info & BATTLE_HIT_INFO_RETALIATION);
+    gManimSt.targetActorId = 1 - gManimSt.subjectActorId;
+
+    gManimSt.hitAttributes = gManimSt.pCurrentRound->attributes;
+    gManimSt.hitInfo = gManimSt.pCurrentRound->info;
+    gManimSt.hitDamage = gManimSt.pCurrentRound->hpChange;
+
+    if (gManimSt.actorCount_maybe == 1)
+    {
+        gManimSt.subjectActorId = 0;
+        gManimSt.targetActorId = 0;
     }
-    state->pCurrentRound++;
+
+    gManimSt.pCurrentRound++;
 }
 
 void MapAnim_PrepareNextBattleRound(ProcPtr p) {

--- a/src/mapanim_api.c
+++ b/src/mapanim_api.c
@@ -69,7 +69,7 @@ void SetupBattleMOVEUNITs(void)
     int maFacing = GetSpellAssocFacing(gManimSt.actor[0].bu->weaponBefore);
     sub_807B4D0();
 
-    switch (gManimSt.actorCount_maybe) {
+    switch (gManimSt.actorCount) {
     case 2:
         if (gBattleHitArray[0].attributes & BATTLE_HIT_ATTR_TATTACK) {
             // In triangle attacks, both partners face the opponent too
@@ -90,9 +90,9 @@ void sub_807B4D0(void)
 {
     u8 array[4];
     int i, j;
-    int count = gManimSt.actorCount_maybe;
+    int count = gManimSt.actorCount;
 
-    switch (gManimSt.actorCount_maybe) {
+    switch (gManimSt.actorCount) {
     case 2:
         if (gBattleHitArray[0].attributes & BATTLE_HIT_ATTR_TATTACK)
             count += 2;
@@ -135,8 +135,8 @@ void BeginMapAnimForPoisonDmg(void)
     gBattleActor.weaponBefore = ITEM_VULNERARY;
 
     gManimSt.hp_changing = 0;
-    gManimSt.u62 = 0;
-    gManimSt.actorCount_maybe = 1;
+    gManimSt.mapAnimKind = MANIM_KIND_DAMAGE;
+    gManimSt.actorCount = 1;
 
     gManimSt.pCurrentRound = gBattleHitArray;
     MapAnim_AdvanceBattleRound();
@@ -150,8 +150,8 @@ void BeginMapAnimForEggDmg(void)
     gBattleActor.weaponBefore = ITEM_VULNERARY;
 
     gManimSt.hp_changing = 0;
-    gManimSt.u62 = 0;
-    gManimSt.actorCount_maybe = 1;
+    gManimSt.mapAnimKind = MANIM_KIND_DAMAGE;
+    gManimSt.actorCount = 1;
 
     gManimSt.pCurrentRound = gBattleHitArray;
     MapAnim_AdvanceBattleRound();
@@ -165,8 +165,8 @@ void BeginMapAnimForCritAtk(void)
     gBattleActor.weaponBefore = ITEM_VULNERARY;
 
     gManimSt.hp_changing = 0;
-    gManimSt.u62 = 0;
-    gManimSt.actorCount_maybe = 1;
+    gManimSt.mapAnimKind = MANIM_KIND_DAMAGE;
+    gManimSt.actorCount = 1;
 
     gManimSt.pCurrentRound = gBattleHitArray;
     MapAnim_AdvanceBattleRound();
@@ -180,8 +180,8 @@ void BeginMapAnimForSteal(void)
     gBattleActor.weaponBefore = ITEM_SWORD_IRON;
 
     gManimSt.hp_changing = 0;
-    gManimSt.u62 = 1;
-    gManimSt.actorCount_maybe = 2;
+    gManimSt.mapAnimKind = MANIM_KIND_STEAL;
+    gManimSt.actorCount = 2;
 
     gManimSt.subjectActorId = 0;
     gManimSt.targetActorId = 1;
@@ -195,8 +195,8 @@ void BeginMapAnimForSummon(void)
     gBattleActor.weaponBefore = ITEM_STAFF_FORTIFY;
 
     gManimSt.hp_changing = 0;
-    gManimSt.u62 = 2;
-    gManimSt.actorCount_maybe = 1;
+    gManimSt.mapAnimKind = MANIM_KIND_REFRESH;
+    gManimSt.actorCount = 1;
 
     gManimSt.subjectActorId = 0;
     gManimSt.targetActorId = 1;
@@ -210,8 +210,8 @@ void BeginMapAnimForSummonDK(void)
     gBattleActor.weaponBefore = ITEM_STAFF_FORTIFY;
 
     gManimSt.hp_changing = 0;
-    gManimSt.u62 = 2;
-    gManimSt.actorCount_maybe = 1;
+    gManimSt.mapAnimKind = MANIM_KIND_REFRESH;
+    gManimSt.actorCount = 1;
 
     gManimSt.subjectActorId = 0;
     gManimSt.targetActorId = 1;
@@ -225,8 +225,8 @@ void BeginMapAnimForDance(void)
     gBattleActor.weaponBefore = ITEM_STAFF_FORTIFY;
 
     gManimSt.hp_changing = 0;
-    gManimSt.u62 = 2;
-    gManimSt.actorCount_maybe = 1;
+    gManimSt.mapAnimKind = MANIM_KIND_REFRESH;
+    gManimSt.actorCount = 1;
 
     gManimSt.subjectActorId = 0;
     gManimSt.targetActorId = 0;
@@ -243,7 +243,7 @@ void BeginBattleMapAnims(void)
     }
 
     gManimSt.hp_changing = 0;
-    gManimSt.u62 = 0;
+    gManimSt.mapAnimKind = MANIM_KIND_DAMAGE;
 
     SetupMapAnimSpellData(&gBattleActor, &gBattleTarget, gBattleHitArray);
     SetupMapBattleAnim(&gBattleActor, &gBattleTarget, gBattleHitArray);
@@ -256,9 +256,9 @@ void BeginBattleMapAnims(void)
 
 void SetupMapAnimSpellData(struct BattleUnit* actor, struct BattleUnit* target, struct BattleHit* hit)
 {
-    gManimSt.actorCount_maybe = GetSpellAssocCharCount(actor->weaponBefore);
+    gManimSt.actorCount = GetSpellAssocCharCount(actor->weaponBefore);
     gManimSt.pCurrentRound    = hit;
-    gManimSt.specialProcScr   = GetSpellAssocAlt6CPointer(actor->weaponBefore);
+    gManimSt.specialProcScr   = GetSpellAssocMapAnimProcScript(actor->weaponBefore);
 }
 
 void SetupMapBattleAnim(struct BattleUnit* actor, struct BattleUnit* target, struct BattleHit* hit)
@@ -267,7 +267,7 @@ void SetupMapBattleAnim(struct BattleUnit* actor, struct BattleUnit* target, str
 
     MakeBattleMOVEUNIT(0, actor, &actor->unit);
 
-    if (gManimSt.actorCount_maybe > 1)
+    if (gManimSt.actorCount > 1)
     {
         HideUnitSprite(&gBattleTarget.unit); // NOTE: uses gBattleTarget instead of target argument
         MakeBattleMOVEUNIT(1, target, &target->unit);
@@ -284,7 +284,7 @@ void SetupMapBattleAnim(struct BattleUnit* actor, struct BattleUnit* target, str
 
     SetupBattleMOVEUNITs();
 
-    for (i = 0; i < gManimSt.actorCount_maybe; ++i)
+    for (i = 0; i < gManimSt.actorCount; ++i)
     {
         gManimSt.actor[i].hp_cur = gManimSt.actor[i].bu->hpInitial;
         gManimSt.actor[i].hp_max = GetUnitMaxHp(gManimSt.actor[i].unit);
@@ -329,12 +329,12 @@ CONST_DATA struct ProcCmd ProcScr_MapAnimDance[] = {
     PROC_SLEEP(0xA),
     PROC_CALL(sub_80813C0),
     PROC_SLEEP(0x14),
-    PROC_JUMP(gProc_MapAnimEnd),
+    PROC_JUMP(ProcScr_MapAnimEnd),
 };
 
 CONST_DATA struct ProcCmd ProcScr_MapAnimBattle[] = {
     PROC_CALL(LockGame),
-    PROC_CALL(_InitFontForUIDefault),
+    PROC_CALL(MapAnim_PrepareBattleTalk),
     PROC_SLEEP(0x1),
     PROC_CALL(MapAnim_MoveCameraOntoSubject),
     PROC_SLEEP(0x2),
@@ -356,16 +356,16 @@ PROC_LABEL(0x0),
     PROC_GOTO(0x0),
 };
 
-CONST_DATA struct ProcCmd gProc_MapAnimEnd[] = {
-    PROC_CALL(MapAnimProc_DisplayDeahQuote),
+CONST_DATA struct ProcCmd ProcScr_MapAnimEnd[] = {
+    PROC_CALL(MapAnim_DisplayDeathQuote),
     PROC_WHILE(BattleEventEngineExists),
-    PROC_CALL(MapAnmiProc_DisplayDeathFade),
+    PROC_CALL(MapAnim_DisplayDeathFade),
     PROC_WHILE_EXISTS(ProcScr_MuDeathFade),
-    PROC_CALL(DeleteBattleAnimInfoThing),
+    PROC_CALL(EndMapAnimInfoWindow),
     PROC_SLEEP(0x1),
-    PROC_CALL(MapAnimProc_DisplayItemStealingPopup),
+    PROC_CALL(MapAnim_StoleItemPopup),
     PROC_YIELD,
-    PROC_CALL(MapAnimProc_DisplayExpBar),
+    PROC_CALL(MapAnim_DisplayExpBar),
     PROC_YIELD,
     PROC_CALL(DisplayWpnBrokePopup),
     PROC_SLEEP(0x8),

--- a/src/mapanim_eventbattle.c
+++ b/src/mapanim_eventbattle.c
@@ -28,7 +28,7 @@ void MapEventBattle_OnEnd(void)
 {
     ResetMuAnims();
     ResetTextFont();
-    DeleteBattleAnimInfoThing();
+    EndMapAnimInfoWindow();
     InitBmBgLayers();
     LoadLegacyUiFrameGraphics();
     LoadObjUIGfx();
@@ -37,7 +37,7 @@ void MapEventBattle_OnEnd(void)
 /* section.data */
 CONST_DATA struct ProcCmd ProcScr_MapAnimEventBattle[] = {
     PROC_CALL(LockGame),
-    PROC_CALL(_InitFontForUIDefault),
+    PROC_CALL(MapAnim_PrepareBattleTalk),
     PROC_SLEEP(0x1),
     PROC_SLEEP(0x5),
     PROC_CALL(MapAnim_InitInfoBox),
@@ -51,9 +51,9 @@ PROC_LABEL(0x0),
     PROC_SLEEP(0x5),
     PROC_GOTO(0x0),
 PROC_LABEL(0x1),
-    PROC_CALL(MapAnmiProc_DisplayDeathFade),
+    PROC_CALL(MapAnim_DisplayDeathFade),
     PROC_WHILE_EXISTS(ProcScr_MuDeathFade),
-    PROC_CALL(DeleteBattleAnimInfoThing),
+    PROC_CALL(EndMapAnimInfoWindow),
     PROC_SLEEP(0x1),
     PROC_CALL(UnlockGame),
     PROC_CALL(MapEventBattle_OnEnd),

--- a/src/mapanim_expbar.c
+++ b/src/mapanim_expbar.c
@@ -125,7 +125,7 @@ CONST_DATA u16 gUnknown_089A36C0[] = {
     0x006, 0x21E, 0x000, 0x000
 };
 
-CONST_DATA struct ProcCmd gProc_MapAnimExpBar[] = {
+CONST_DATA struct ProcCmd ProcScr_MapAnimExpBar[] = {
     PROC_SET_END_CB(ProcMapInfoBox_OnEnd),
     PROC_SLEEP(0x1),
     PROC_CALL(ProcMAExpBar_OnDraw),

--- a/src/mapanim_infobox.c
+++ b/src/mapanim_infobox.c
@@ -84,12 +84,12 @@ void sub_807BB40(u16* tilemap, int arg1, int arg2, int arg3, u16* buf)
         sub_807BB10(tilemap, &unk4, gUnknown_089A3668[arg3], it[0], it[1]);
 }
 
-void DeleteBattleAnimInfoThing(void)
+void EndMapAnimInfoWindow(void)
 {
     Proc_EndEach(ProcScr_MapBattleInfoBox);
 }
 
-void NewMapBattleInfoThing(int x, int y, struct Proc* parent)
+void StartMapAnimInfoWindow(int x, int y, struct Proc* parent)
 {
     struct MAInfoFrameProc* proc = Proc_Start(ProcScr_MapBattleInfoBox, PROC_TREE_3);
 
@@ -116,7 +116,7 @@ void ProcMapInfoBox_OnDraw(struct MAInfoFrameProc* proc)
 
     PrepareMapBattleBoxNumGfx(Img_MapBattleInfoHpBar);
 
-    switch (gManimSt.actorCount_maybe) {
+    switch (gManimSt.actorCount) {
     case 1:
         DisplayBattleInfoBox(proc, 0, -5);
         break;
@@ -141,7 +141,7 @@ void sub_807BCA8(struct MAInfoFrameProc* proc)
     s8 updated = FALSE;
     int i;
 
-    for (i = 0; i < gManimSt.actorCount_maybe; ++i) {
+    for (i = 0; i < gManimSt.actorCount; ++i) {
         u16 r4 = gManimSt.actor[i].hp_displayed_q4;
 
         if (r4 > gManimSt.actor[i].hp_cur*16)
@@ -217,7 +217,7 @@ void DisplayBattleInfoBox(struct MAInfoFrameProc* proc, int index, int arg2)
         BM_BGPAL_BANIM_IFBACK + index);
 
     Decompress(
-        TsaSet_MapBattleBoxGfx[gManimSt.actorCount_maybe][index], gGenericBuffer);
+        TsaSet_MapBattleBoxGfx[gManimSt.actorCount][index], gGenericBuffer);
 
     CallARM_FillTileRect(
         TILEMAP_LOCATED(gBG1TilemapBuffer,

--- a/src/mapanim_spellassoc.c
+++ b/src/mapanim_spellassoc.c
@@ -14,7 +14,7 @@
 #include "constants/classes.h"
 #include "constants/terrains.h"
 
-const struct ProcCmd * GetItemAnim6CCode(void)
+const struct ProcCmd * MapAnim_GetRoundProcScript(void)
 {
     if (gManimSt.specialProcScr)
         return gManimSt.specialProcScr;

--- a/src/mapanim_summon.c
+++ b/src/mapanim_summon.c
@@ -311,7 +311,7 @@ CONST_DATA struct ProcCmd ProcScr_MapAnimSummon[] = {
     PROC_CALL(GenerateSummonUnitDef),
     PROC_CALL(New6C_SummonGfx_FromActionPos),
     PROC_SLEEP(0x5),
-    PROC_JUMP(gProc_MapAnimEnd),
+    PROC_JUMP(ProcScr_MapAnimEnd),
 };
 
 CONST_DATA struct ProcCmd ProcScr_MapAnimSumDK[] = {
@@ -344,5 +344,5 @@ CONST_DATA struct ProcCmd ProcScr_MapAnimSumDK[] = {
     PROC_LABEL(PROC_LABEL_SUMDK_LOAD_POS_END),
     PROC_CALL(ProcSummonDK_CheckIsEnough),
     PROC_LABEL(PROC_LABEL_SUMDK_LOAD_TERMINAL),
-    PROC_JUMP(gProc_MapAnimEnd),
+    PROC_JUMP(ProcScr_MapAnimEnd),
 };

--- a/src/mu.c
+++ b/src/mu.c
@@ -79,7 +79,7 @@ u16 CONST_DATA MuSoundScr_Mounted[] = {
 
 u16 CONST_DATA MuSoundScr_Wyvern[] = {
     0x14, 1,
-    SONG_A0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    SONG_SE_BMP_MOVE_BIRD1A_T1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 
 u16 CONST_DATA MuSoundScr_Pegasus[] = {

--- a/src/spellassoc.c
+++ b/src/spellassoc.c
@@ -31,7 +31,7 @@ u16 GetSpellAssocEfxIndex(u16 item)
     return GetSpellAssocStructPtr(item)->efx;
 }
 
-struct ProcCmd *GetSpellAssocAlt6CPointer(u16 item)
+struct ProcCmd *GetSpellAssocMapAnimProcScript(u16 item)
 {
     return GetSpellAssocStructPtr(item)->pcmd_manim;
 }


### PR DESCRIPTION
* Add explicit fallthrough comment to `MapAnim_DisplayExpBar` to silence [`-Wimplicit-fallthrough`](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-fallthrough) in modern compilers (fixes #685)
* Sync `MapAnim_InitInfoBox` with FE6 to eliminate `goto`
* Sync `MapAnim_AdvanceBattleRound` with FE6 to make code read naturally
* Add enum for `MANIM_KIND` from FE6
* Run formatter over file, rename some symbols (e.g. `gProc` to `ProcScr`, fix typos)
