### PR TITLE
Bump version of GitHub action dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y build-essential binutils-arm-none-eabi libpng-dev && python -m pip install ttp numpy pillow
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install agbcc
       run: git clone https://github.com/pret/agbcc.git && cd agbcc/ && ./build.sh && ./install.sh .. && cd ..
@@ -52,11 +52,11 @@ jobs:
       run: arm-none-eabi-nm -l -n fireemblem8.elf | grep -v '^00' | uniq > _site/symbols.txt
 
     - name: Setup Pages
-      uses: actions/configure-pages@v3
+      uses: actions/configure-pages@v5
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v1
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
Address CI failure: https://github.com/FireEmblemUniverse/fireemblem8u/actions/runs/13231261858

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

This PR bumps the GitHub Actions dependencies to their latest major versions:
* https://github.com/actions/checkout/tree/v4
* https://github.com/actions/configure-pages/tree/v5
* https://github.com/actions/upload-pages-artifact/tree/v3
* https://github.com/actions/deploy-pages/tree/v4

Tested on my fork and the build seems to run successfully until the upload step, since I don't have the Frogress API key: https://github.com/Eebit/fireemblem8u/actions/runs/13231492017/job/36929316652