### PR TITLE
Mini UB/nonmatching fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ src/m4a.o: CC1 := $(CC1_OLD)
 
 # TODO: find a more elegant solution to the inlining issue
 src/bmitem.o: CC1FLAGS += -Wno-error
+src/menu_def.o: CC1FLAGS += -Wno-error
 
 #### Main Targets ####
 

--- a/include/bmmenu.h
+++ b/include/bmmenu.h
@@ -74,7 +74,7 @@ int Menu_SwitchIn(struct MenuProc * menu, struct MenuItemProc * menuItem);
 int Menu_SwitchOut_DoNothing(struct MenuProc * menu, struct MenuItemProc * menuItem);
 void sub_80234AC(int x, int y);
 void ItemSubMenuEnd(struct MenuProc * menu);
-u8 MenuCommand_SelectNo(struct MenuProc * menu, struct MenuItemProc * menuItem);
+u8 MenuCommand_SelectNo(struct MenuProc * menu);
 u8 sub_8023538(struct MenuProc * menu);
 u8 sub_8023550(struct MenuProc * menu);
 u8 sub_80235A8(struct MenuProc * menu);

--- a/src/bmmenu.c
+++ b/src/bmmenu.c
@@ -1002,7 +1002,7 @@ void ItemSubMenuEnd(struct MenuProc* menu) {
     return;
 }
 
-u8 MenuCommand_SelectNo(struct MenuProc* menu, struct MenuItemProc* menuItem) {
+u8 MenuCommand_SelectNo(struct MenuProc* menu) {
     SetTextFont(NULL);
 
     TileMap_CopyRect(gUiTmScratchA, gBG0TilemapBuffer + 0x2B, 9, 19);
@@ -1026,8 +1026,7 @@ u8 sub_8023550(struct MenuProc* menu) {
     ProcPtr proc;
 
     sub_8023538(menu);
-    // This is really caused by implicit declaration
-    ((void (*)(struct MenuProc*))MenuCommand_SelectNo)(menu); // TODO: FIXME: UB
+    MenuCommand_SelectNo(menu);
 
     proc = StartOrphanMenu(&gItemSelectMenuDef);
 

--- a/src/eventscr_utils.c
+++ b/src/eventscr_utils.c
@@ -252,17 +252,20 @@ struct Unit * GetUnitStructFromEventParameter(s16 pid)
         break;
 
     case CHAR_EVT_POSITION_AT_SLOTB:
+    {
+        struct Unit * ptr;
+
         if (gBmMapUnit[((u16 *)(gEventSlots + 0xB))[1]][((u16 *)(gEventSlots + 0xB))[0]] != 0)
         {
-            return GetUnit(gBmMapUnit[((u16 *)(gEventSlots + 0xB))[1]][((u16 *)(gEventSlots + 0xB))[0]]);
+            ptr = GetUnit(gBmMapUnit[((u16 *)(gEventSlots + 0xB))[1]][((u16 *)(gEventSlots + 0xB))[0]]);
         }
         else
         {
-            #ifndef NONMATCHING
-            asm(""); // :/
-            #endif
-            return NULL;
+            ptr = NULL;
         }
+
+        return ptr;
+    }
 
     case CHAR_EVT_ACTIVE_UNIT:
         return gActiveUnit;


### PR DESCRIPTION
I made 2 commits so you can only merge the first one if you don't *like* the second one.

I wouldn't be surprised if the UB with MenuCommand_SelectNo was just an ignored warning. I don't think there is a better way, and it's less ugly that the cast.

Once the project switches to modern GCC, it could be changed to using `#pragma diagnostic push/pop` around the lines that generate the warnings.