### PR TITLE
Fixes for `PrepareBattleGraphicsMaybe`

### DIFF
--- a/src/banim-ekrbattleintro.c
+++ b/src/banim-ekrbattleintro.c
@@ -861,7 +861,7 @@ bool PrepareBattleGraphicsMaybe(void)
 {
     u16 i;
     u16 pid, jid;
-    int zero;
+    void * zero;
     struct Unit * unit_bu1;
     struct Unit * unit_bu2;
     struct BattleUnit * bu1;
@@ -873,7 +873,7 @@ bool PrepareBattleGraphicsMaybe(void)
     const void * animdef2;
     s16 valid_l;
     s16 valid_r;
-    int animid1, animid2;
+    u32 animid1, animid2;
 
     int char_cnt = 1;
 
@@ -904,7 +904,6 @@ bool PrepareBattleGraphicsMaybe(void)
     }
     else
     {
-        int pos;
         u8 i1 = -0x40 & gBattleActor.unit.index;
         u16 faction1 = GetBanimFactionPalette(i1);
         u8 i2 = -0x40 & gBattleTarget.unit.index;
@@ -1304,7 +1303,7 @@ bool PrepareBattleGraphicsMaybe(void)
             gBanimEffectiveness[POS_R] = IsItemEffectiveAgainst(bu2->weapon, unit_bu1);
     }
 
-    gBanimForceUnitChgDebug[POS_L] = gBanimForceUnitChgDebug[POS_R] = (void *)zero = 0;
+    gBanimForceUnitChgDebug[POS_L] = gBanimForceUnitChgDebug[POS_R] = zero = 0;
 
     if (valid_l)
         (void)GetItemIndex(bu1->weaponBefore);
@@ -1318,7 +1317,7 @@ bool PrepareBattleGraphicsMaybe(void)
     }
     else
     {
-        gBanimUniquePaletteDisabled[POS_L] = gBanimUniquePaletteDisabled[POS_R] = zero;
+        gBanimUniquePaletteDisabled[POS_L] = gBanimUniquePaletteDisabled[POS_R] = 0;
     }
 
     ++zero; --zero; // :/


### PR DESCRIPTION
Fixes #707.

* Removed unused variable `int pos`
* Changed `zero` temporary variable to a `void *` to avoid invalid lvalue error
* Removed one instance where the temporary `zero` variable was unnecessary
* Changed `animid1` and `animid2` to `u32`s to satisfy modern compilers