### PR TITLE
Add compile_commands.txt

### DIFF
--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,0 +1,7 @@
+-Wimplicit
+-WParentheses
+-Werror
+-I
+tools/agbcc/include
+-I
+include

--- a/include/bmudisp.h
+++ b/include/bmudisp.h
@@ -34,7 +34,7 @@ int GetUnitSpritePalette(const struct Unit* unit);
 void RefreshUnitSprites(void);
 struct SMSHandle * AddUnitSprite(int);
 void PutUnitSpritesOam(void);
-// ??? PutChapterMarkedTileIconOam(???);
+void PutChapterMarkedTileIconOam(void);
 void PutUnitSpriteIconsOam(void);
 // ??? sub_8027A30(???);
 void ResetUnitSpriteHover(void);

--- a/include/global.h
+++ b/include/global.h
@@ -7,19 +7,7 @@
 
 #include "gba/gba.h"
 
-// this is for denoting objects that *should* be const, but weren't in the original source (resulting in them being emitted in the .data section)
-#define SECTION(name) __attribute__((section(name)))
-#define CONST_DATA SECTION(".data")
-#define EWRAM_OVERLAY(id) SECTION("ewram_overlay_" # id)
-
-// this is for denoting objects that *should* be const, but need to not be for functions to match.
-#define SHOULD_BE_CONST
-
-#define NAKEDFUNC __attribute__((naked))
-
-// HACK: applying this macro seems to allow for bitpacked structs to have the same layout in agbcc and modern GCC
-#define ALIGN(m) __attribute__((aligned (m)))
-#define BITPACKED __attribute__((aligned(4), packed))
+#include "prelude.h"
 
 #include "types.h"
 #include "variables.h"

--- a/include/prelude.h
+++ b/include/prelude.h
@@ -1,0 +1,17 @@
+#ifndef PRELUDE_H
+
+// HACK: applying this macro seems to allow for bitpacked structs to have the same layout in agbcc and modern GCC
+#define ALIGN(m) __attribute__((aligned (m)))
+#define BITPACKED __attribute__((aligned(4), packed))
+
+// this is for denoting objects that *should* be const, but weren't in the original source (resulting in them being emitted in the .data section)
+#define SECTION(name) __attribute__((section(name)))
+#define CONST_DATA SECTION(".data")
+#define EWRAM_OVERLAY(id) SECTION("ewram_overlay_" # id)
+
+// this is for denoting objects that *should* be const, but need to not be for functions to match.
+#define SHOULD_BE_CONST
+
+#define NAKEDFUNC __attribute__((naked))
+
+#endif // PRELUDE_H

--- a/include/types.h
+++ b/include/types.h
@@ -1,6 +1,7 @@
 #ifndef GUARD_TYPES_H
 #define GUARD_TYPES_H
 
+#include "prelude.h"
 #include "gba/types.h"
 #include <limits.h>
 

--- a/include/variables.h
+++ b/include/variables.h
@@ -3,7 +3,7 @@
 
 #include "gba/types.h"
 #include "types.h"
-#include "global.h"
+#include "prelude.h"
 #include "proc.h"
 
 extern u8 __ewram_start[];
@@ -666,7 +666,7 @@ extern CONST_DATA u8 Unk_088ADFAB[];
 // extern ??? Events_WM_Beginning
 // extern ??? Events_WM_ChapterIntro
 // extern ??? gUnknown_088D2058
-extern struct CONST_DATA gfx_set gConvoBackgroundData[];
+extern struct gfx_set CONST_DATA gConvoBackgroundData[];
 extern u8 CONST_DATA gPromoJidLut[][2];
 extern u8 gAnimCharaPalConfig[0x100][7];
 extern u8 gAnimCharaPalIt[0x100][7];


### PR DESCRIPTION
This adds a basic `compile_commands.txt`, enabling the use of the [clangd language server](https://github.com/clangd/clangd) in this codebase for jump-to-definition, hover and basic typechecking.

It'd be nice if we could automatically generate it from the Makefile instead, but I'm not sure how often `CC1FLAGS` and the like get changed anyway.

The other changes in this PR are to rearrange some definitions to suppress some spurious errors that clang emits. This doesn't fix all of them (several of them are real errors that will cause the code to no longer match, like some `missing return statement` bugs), but on a random smattering of files I checked there's nothing truly outrageous.