### PR TITLE
gPal_NotMapSprite -> gPal_LightRune

### DIFF
--- a/data/data_59E8E0.s
+++ b/data/data_59E8E0.s
@@ -36,8 +36,8 @@ unit_icon_pal_after_action:
 gPal_MapSpriteArena:
 	.incbin "graphics/unit_icon/palette/unit_icon_pal_p4.agbpal"
 
-	.global gPal_NotMapSprite
-gPal_NotMapSprite:  @ 0x0859EEC0
+	.global gPal_LightRune
+gPal_LightRune:  @ 0x0859EEC0
 	.incbin "baserom.gba", 0x59EEC0, 0x20
 
 	.global gPal_MapSpriteSepia

--- a/include/variables.h
+++ b/include/variables.h
@@ -410,7 +410,7 @@ extern u8 gImg_UiCursorHandBottom[];
 // extern ??? gUnknown_0859EE60
 // extern ??? gUnknown_0859EEA0
 extern u16 gPal_MapSprite[];
-extern u16 gPal_NotMapSprite[];
+extern u16 gPal_LightRune[];
 extern u16 gPal_MapSpriteArena[];
 extern u16 gPal_MapSpriteSepia[];
 extern u16 Pal_Text[];

--- a/src/bmudisp.c
+++ b/src/bmudisp.c
@@ -356,7 +356,7 @@ void ApplyUnitSpritePalettes(void)
     if (gBmSt.gameStateBits & BM_FLAG_LINKARENA)
         ApplyPalette(gPal_MapSpriteArena, 0x10 + OBJPAL_UNITSPRITE_PURPLE);
     else
-        ApplyPalette(gPal_NotMapSprite, 0x10 + OBJPAL_UNITSPRITE_PURPLE);
+        ApplyPalette(gPal_LightRune, 0x10 + OBJPAL_UNITSPRITE_PURPLE);
 }
 
 void sub_8026670(void)


### PR DESCRIPTION
Extremely small name clarification: the palette at `0x0859EEC0` is used for light rune map sprites. Let me know if there's anything else I have to do for this to be merged.