### PR TITLE
UnknownMenu -> WeaponSelectMenu

### DIFF
--- a/include/bmmenu.h
+++ b/include/bmmenu.h
@@ -42,10 +42,10 @@ u8 StartUnitBallistaSelect(struct MenuProc * menu, struct MenuItemProc * menuIte
 u8 StartUnitWeaponSelect(struct MenuProc * menu, struct MenuItemProc * menuItem);
 int DisplayUnitStandingAttackRange(struct MenuProc * menu, struct MenuItemProc * menuItem);
 int HideMoveRangeGraphicsWrapper(struct MenuProc * menu, struct MenuItemProc * menuItem);
-u8 UnknownMenu_IsAvailable(const struct MenuItemDef * def, int number);
-u8 UnknownMenu_Selected(struct MenuProc * menu, struct MenuItemProc * menuItem);
-int UnknownMenu_Draw(struct MenuProc * menu, struct MenuItemProc * menuItem);
-int UnknownMenu_SwitchIn(struct MenuProc * menu, struct MenuItemProc * menuItem);
+u8 WeaponSelectMenu_IsAvailable(const struct MenuItemDef * def, int number);
+u8 WeaponSelectMenu_Selected(struct MenuProc * menu, struct MenuItemProc * menuItem);
+int WeaponSelectMenu_Draw(struct MenuProc * menu, struct MenuItemProc * menuItem);
+int WeaponSelectMenu_SwitchIn(struct MenuProc * menu, struct MenuItemProc * menuItem);
 int BallistaRangeMenu_SwitchOut(struct MenuProc * menu, struct MenuItemProc * menuItem);
 u8 AttackMapSelect_Select(ProcPtr proc, struct SelectTarget * target);
 void sub_8022E38(void);

--- a/include/menu_def.h
+++ b/include/menu_def.h
@@ -17,7 +17,7 @@ extern const struct MenuDef gItemMenuDef;
 extern const struct MenuDef gStaffItemSelectMenuDef;
 extern const struct MenuDef gItemSelectMenuDef;
 extern const struct MenuDef gBallistaRangeMenuDef;
-extern const struct MenuDef gUnknownMenuDef;
+extern const struct MenuDef gWeaponSelectMenuDef;
 extern const struct MenuDef gUnitActionMenuDef;
 
 extern struct SelectInfo CONST_DATA gSelectInfo_OffensiveStaff;

--- a/src/bmmenu.c
+++ b/src/bmmenu.c
@@ -469,7 +469,7 @@ u8 StartUnitBallistaSelect(struct MenuProc* menu, struct MenuItemProc* menuItem)
 }
 
 u8 StartUnitWeaponSelect(struct MenuProc* menu, struct MenuItemProc* menuItem) {
-    ProcPtr proc = StartOrphanMenu(&gUnknownMenuDef);
+    ProcPtr proc = StartOrphanMenu(&gWeaponSelectMenuDef);
 
     if (gActiveUnit->pClassData->number != CLASS_PHANTOM) {
         StartFace(0, GetUnitPortraitId(gActiveUnit), 0xB0, 0xC, 2);
@@ -505,7 +505,7 @@ int HideMoveRangeGraphicsWrapper(struct MenuProc* menu, struct MenuItemProc* men
     return 0;
 }
 
-u8 UnknownMenu_IsAvailable(const struct MenuItemDef* def, int number) {
+u8 WeaponSelectMenu_IsAvailable(const struct MenuItemDef* def, int number) {
     int item = gActiveUnit->items[number];
 
     if (!(GetItemAttributes(item) & IA_WEAPON)) {
@@ -525,7 +525,7 @@ u8 UnknownMenu_IsAvailable(const struct MenuItemDef* def, int number) {
     return MENU_ENABLED;
 }
 
-u8 UnknownMenu_Selected(struct MenuProc* menu, struct MenuItemProc* menuItem) {
+u8 WeaponSelectMenu_Selected(struct MenuProc* menu, struct MenuItemProc* menuItem) {
 
     EquipUnitItemSlot(gActiveUnit, menuItem->itemNumber);
     gActionData.itemSlotIndex = 0;
@@ -541,7 +541,7 @@ u8 UnknownMenu_Selected(struct MenuProc* menu, struct MenuItemProc* menuItem) {
     return MENU_ACT_SKIPCURSOR | MENU_ACT_END | MENU_ACT_SND6A | MENU_ACT_ENDFACE;
 }
 
-int UnknownMenu_Draw(struct MenuProc* menu, struct MenuItemProc* menuItem) {
+int WeaponSelectMenu_Draw(struct MenuProc* menu, struct MenuItemProc* menuItem) {
     int item = gActiveUnit->items[menuItem->itemNumber];
 
     s8 isUsable = CanUnitUseWeapon(gActiveUnit, item);
@@ -556,7 +556,7 @@ int UnknownMenu_Draw(struct MenuProc* menu, struct MenuItemProc* menuItem) {
     return 0;
 }
 
-int UnknownMenu_SwitchIn(struct MenuProc* menu, struct MenuItemProc* menuItem) {
+int WeaponSelectMenu_SwitchIn(struct MenuProc* menu, struct MenuItemProc* menuItem) {
 
     int reach;
 
@@ -923,7 +923,7 @@ int ItemSelectMenu_TextDraw(struct MenuProc* menu, struct MenuItemProc* menuItem
     int item = gActiveUnit->items[menuItem->itemNumber];
 
     if (GetItemAttributes(item) & IA_WEAPON) {
-        UnknownMenu_Draw(menu, menuItem);
+        WeaponSelectMenu_Draw(menu, menuItem);
         return 0;
     }
 
@@ -953,7 +953,7 @@ u8 ItemSelectMenu_Usability(const struct MenuItemDef* def, int number) {
     }
 
     if (GetItemAttributes(item) & IA_WEAPON) {
-        UnknownMenu_IsAvailable(def, number);
+        WeaponSelectMenu_IsAvailable(def, number);
     }
 
     return CanUnitUseItem(gActiveUnit, item)

--- a/src/menu_def.c
+++ b/src/menu_def.c
@@ -137,12 +137,12 @@ CONST_DATA struct MenuItemDef gBallistaRangeMenuItems[] = {
     MenuItemsEnd
 };
 
-CONST_DATA struct MenuItemDef gUnknownMenuItems[] = {
-    {"", 0, 0, 0, 0x49, UnknownMenu_IsAvailable, UnknownMenu_Draw, UnknownMenu_Selected, 0, UnknownMenu_SwitchIn, BallistaRangeMenu_SwitchOut},
-    {"", 0, 0, 0, 0x4A, UnknownMenu_IsAvailable, UnknownMenu_Draw, UnknownMenu_Selected, 0, UnknownMenu_SwitchIn, BallistaRangeMenu_SwitchOut},
-    {"", 0, 0, 0, 0x4B, UnknownMenu_IsAvailable, UnknownMenu_Draw, UnknownMenu_Selected, 0, UnknownMenu_SwitchIn, BallistaRangeMenu_SwitchOut},
-    {"", 0, 0, 0, 0x4C, UnknownMenu_IsAvailable, UnknownMenu_Draw, UnknownMenu_Selected, 0, UnknownMenu_SwitchIn, BallistaRangeMenu_SwitchOut},
-    {"", 0, 0, 0, 0x4D, UnknownMenu_IsAvailable, UnknownMenu_Draw, UnknownMenu_Selected, 0, UnknownMenu_SwitchIn, BallistaRangeMenu_SwitchOut},
+CONST_DATA struct MenuItemDef gWeaponSelectMenuItems[] = {
+    {"", 0, 0, 0, 0x49, WeaponSelectMenu_IsAvailable, WeaponSelectMenu_Draw, WeaponSelectMenu_Selected, 0, WeaponSelectMenu_SwitchIn, BallistaRangeMenu_SwitchOut},
+    {"", 0, 0, 0, 0x4A, WeaponSelectMenu_IsAvailable, WeaponSelectMenu_Draw, WeaponSelectMenu_Selected, 0, WeaponSelectMenu_SwitchIn, BallistaRangeMenu_SwitchOut},
+    {"", 0, 0, 0, 0x4B, WeaponSelectMenu_IsAvailable, WeaponSelectMenu_Draw, WeaponSelectMenu_Selected, 0, WeaponSelectMenu_SwitchIn, BallistaRangeMenu_SwitchOut},
+    {"", 0, 0, 0, 0x4C, WeaponSelectMenu_IsAvailable, WeaponSelectMenu_Draw, WeaponSelectMenu_Selected, 0, WeaponSelectMenu_SwitchIn, BallistaRangeMenu_SwitchOut},
+    {"", 0, 0, 0, 0x4D, WeaponSelectMenu_IsAvailable, WeaponSelectMenu_Draw, WeaponSelectMenu_Selected, 0, WeaponSelectMenu_SwitchIn, BallistaRangeMenu_SwitchOut},
     MenuItemsEnd
 };
 
@@ -338,10 +338,10 @@ CONST_DATA struct MenuDef gBallistaRangeMenuDef = {
     BallistaRangeMenuHelpBox
 };
 
-CONST_DATA struct MenuDef gUnknownMenuDef = {
+CONST_DATA struct MenuDef gWeaponSelectMenuDef = {
     {1, 1, 14, 0},
     0,
-    gUnknownMenuItems,
+    gWeaponSelectMenuItems,
     0, 0, 0,
     ItemMenu_ButtonBPressed,
     MenuAutoHelpBoxSelect,


### PR DESCRIPTION
Just a name change for this menu as I noticed that it was still called "Unknown", when it is used for Weapon Selection upon attacking.