### PR TITLE
shiftcheck: add a shiftability QA harness (hardcoded-pointer detection)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,59 @@ compare: $(ROM)
 
 .PHONY: compare
 
-CLEAN_FILES := $(ROM) $(ELF) $(MAP) $(OBJECTS_LST) $(SFILES_COMPILED) graphics/*.h $(CFILES_GENERATED)
-CLEAN_DIRS := $(DEPS_DIR)
+#### Shiftability harness (scripts/shiftcheck/) ####
+# Detects hardcoded pointers (raw absolute addresses that bypass the symbol system)
+# which would break if the ROM layout shifted. Entirely separate from the matching
+# build: never touches $(ROM)/$(ELF)/compare. See scripts/shiftcheck/README.md.
+RELOCS_ELF  := fireemblem8_relocs.elf
+SHIFTDIR    := build/shiftcheck
+SHIFT       ?= 0x40000
+SHIFT2      ?= 0x80000
+SHIFTCHECK  := scripts/shiftcheck
+
+# Layer 0: audit hardcoded addresses in the build system (Makefile/ldscripts).
+shiftcheck-build:
+	$(PYTHON) $(SHIFTCHECK)/scan_build_addrs.py --makefile Makefile \
+	    --ldscript $(LDSCRIPT) --banim-ldscript linker_script_banim.txt
+
+# Layer 1: relink with --emit-relocs, then flag ROM-pointer words with no relocation.
+$(RELOCS_ELF): $(ALL_OBJECTS) $(OBJECTS_LST) $(LDSCRIPT)
+	LD='$(LD)' OBJECTS_LST='$(OBJECTS_LST)' BANIM_OBJECT='$(BANIM_OBJECT)' \
+	    $(SHIFTCHECK)/emit_relocs_link.sh $@ $(LDSCRIPT) -q
+
+shiftcheck-static: $(RELOCS_ELF) $(ROM) $(MAP)
+	$(PYTHON) $(SHIFTCHECK)/scan_relocs.py --elf $(RELOCS_ELF) --gba $(ROM) \
+	    --map $(MAP) --ref-elf $(ELF) --prefix $(PREFIX) \
+	    --allowlist $(SHIFTCHECK)/allowlist.txt
+
+# Layer 1b: flag relocations against the WRONG base symbol -- a stored pointer written
+# "ResourceA + hardcoded offset" that lands in a different resource B (breaks if A is resized).
+shiftcheck-offsets: $(RELOCS_ELF) $(ROM) $(MAP)
+	$(PYTHON) $(SHIFTCHECK)/scan_offsets.py --elf $(RELOCS_ELF) --gba $(ROM) \
+	    --map $(MAP) --ref-elf $(ELF) --prefix $(PREFIX)
+
+# Layer 2: differential two-shift build; an independent (reloc-table-free) confirm.
+shiftcheck-diff: $(ROM) $(MAP) $(OBJECTS_LST)
+	LD='$(LD)' OBJCOPY='$(OBJCOPY)' OBJECTS_LST='$(OBJECTS_LST)' \
+	    BANIM_OBJECT='$(BANIM_OBJECT)' \
+	    $(PYTHON) $(SHIFTCHECK)/diff_shift.py --base-gba $(ROM) --ldscript $(LDSCRIPT) \
+	    --map $(MAP) --ref-elf $(ELF) --prefix $(PREFIX) --shifts $(SHIFT),$(SHIFT2) \
+	    --outdir $(SHIFTDIR) --allowlist $(SHIFTCHECK)/allowlist.txt
+
+# Layer 3: runtime smoke test (needs mGBA python bindings; non-blocking if absent).
+shiftcheck-run: $(ROM) $(MAP) $(OBJECTS_LST)
+	LD='$(LD)' OBJCOPY='$(OBJCOPY)' OBJECTS_LST='$(OBJECTS_LST)' \
+	    BANIM_OBJECT='$(BANIM_OBJECT)' \
+	    $(PYTHON) $(SHIFTCHECK)/run_dynamic.py --base-gba $(ROM) --shift $(SHIFT) \
+	    --ldscript $(LDSCRIPT) --map $(MAP) --outdir $(SHIFTDIR) --prefix $(PREFIX)
+
+# Static layers (the CI gate): build-system audit + reloc scan + cross-resource offsets + differential.
+shiftcheck: shiftcheck-build shiftcheck-static shiftcheck-offsets shiftcheck-diff
+
+.PHONY: shiftcheck shiftcheck-build shiftcheck-static shiftcheck-offsets shiftcheck-diff shiftcheck-run
+
+CLEAN_FILES := $(ROM) $(ELF) $(MAP) $(OBJECTS_LST) $(SFILES_COMPILED) graphics/*.h $(CFILES_GENERATED) $(RELOCS_ELF) $(RELOCS_ELF:.elf=.map)
+CLEAN_DIRS := $(DEPS_DIR) $(SHIFTDIR)
 CLEAN_BINS := graphics/statscreen/*.bin $(SAMPLE_SUBDIR)/*.bin $(MAP_LAYOUT_SUBDIR)/*.bin $(AUTO_GEN_TARGETS)
 CLEAN_SONGS := $(MID_SUBDIR)/*.s
 

--- a/scripts/shiftcheck/README.md
+++ b/scripts/shiftcheck/README.md
@@ -1,0 +1,183 @@
+# Shiftability harness
+
+Tools that test whether the ROM is **shiftable** — i.e. whether it could be edited,
+recompiled, and run correctly without breaking pointer integrity. The build being
+byte-identical (`make compare`) does **not** prove this: a pointer stored as a raw
+absolute address (`(u8*)0x08A39148`) holds the correct value only because everything
+sits at its original offset. It carries no relocation, so it breaks the moment the
+layout moves. These tools find such hardcoded pointers.
+
+Nothing here touches the matching build — every target is `.PHONY` and uses a
+separate ELF / a generated ldscript, never `ldscript.txt`, `$(ROM)`, or `compare`.
+
+> **Scope of this PR:** this adds the harness *tooling* only — the ROM stays
+> byte-identical. Running `make shiftcheck` against the current tree will flag the
+> pre-existing hardcoded pointers documented below (`opinfo` `gOpinfo_1`, chapter-7
+> `redas`, banim `FORCE_SPRITE`, cross-resource offsets). The **byte-identical fixes**
+> for them, and the full-game TAS validation, live in
+> [laqieer/fireemblem8u#744](https://github.com/FireEmblemUniverse/fireemblem8u/pull/744)
+> and can land as focused follow-ups; the "now fixed / HIGH = 0" notes below describe
+> that branch where the fixes are applied.
+
+## Layers (cheapest → strongest)
+
+| Make target | Layer | What it does |
+| --- | --- | --- |
+| `make shiftcheck-build` | 0 | Audits hardcoded GBA addresses in the **build system** (Makefile, ldscripts). Cross-checks coupled constants — e.g. the banim link base `-b 0x8c02000` must equal the ldscript pin `0xC02000` — and fails on a mismatch. |
+| `make shiftcheck-static` | 1 | Relinks with `ld --emit-relocs`, then flags every ROM-pointer-looking word that carries **no relocation**. Ranked by signal (see below). |
+| `make shiftcheck-offsets` | 1b | Of the words that *do* relocate, flags any relocated against the **wrong base symbol** — `ResourceA + hardcoded offset` that lands at the start of a different resource B (`scan_offsets.py`). |
+| `make shiftcheck-diff` | 2 | Builds the ROM **shifted** by two amounts and diffs: a real pointer's value tracks the shift; a hardcoded literal stays put. Independent of the reloc table; confirms Layer 1. |
+| `make shiftcheck-run` | 3 | Runs the matching vs a shifted ROM headless under identical input and compares framebuffer/RAM at checkpoints. End-to-end proof. Needs mGBA python bindings (non-blocking if absent). |
+| `make shiftcheck` | 0+1+1b+2 | The static gate (no emulator). |
+
+## Why ranking, not a flat list
+
+Perfect static precision is impossible: incbin'd audio/graphics/animation data
+contains byte runs that coincidentally look like unrelocated ROM pointers. The
+shared classifier (`_classify.py`) buckets findings so the signal isn't drowned:
+
+- **[A] HIGH** — a *coherent* pointer table (≥4 consecutive entries pointing into
+  1–2 symbols) inside a **MIXED** object (one that also has real relocated pointers).
+  This is the actionable worklist; the tools exit non-zero when it is non-empty.
+- **[B] MIXED scattered** — unrelocated words in pointer-bearing objects that aren't
+  a coherent table. Review / let Layers 2–3 adjudicate.
+- **[C] BLOB** — objects with no relocations at all (pure incbin data); almost
+  certainly coincidental.
+- **[D] BLOB-INTERNAL** — a word inside the very symbol it points at (embedded blob
+  data, e.g. a banim palette), not a typed pointer table.
+
+Coincidental values in the cartridge header range (`< 0x08000100`) and `.text`
+literal pools are filtered out; pinned-region (`≥ 0x08C00000`) words are bucketed
+separately.
+
+## Validation case (now fixed)
+
+When first run, both Layers 1 and 2 independently isolated exactly one
+high-confidence finding:
+
+```
+src/opinfo.o  (64 suspects in 1 table(s); targets: gUnkData_96(64))
+  0x08A2F340 = 0x08A39148  -> gUnkData_96+0x1E48
+  ...
+```
+
+`gOpinfo_1[]` in `src/opinfo.c` was a 64-entry table of raw `(u8*)0x08A3xxxx` casts
+into the graphics blob `gUnkData_96`. Each was rewritten as a symbol reference,
+`(u8*)gUnkData_96 + 0x1E48` (gUnkData_96 is `u16[]`, so the byte offset needs the
+`(u8*)` cast). This is **byte-identical** in the matching build (so `make compare`
+still passes) but is now a relocation, so it shifts correctly. After the fix the
+HIGH bucket is empty:
+
+```
+[A] HIGH-CONFIDENCE ... : 0 in 0 object(s)
+RESULT: no high-confidence shiftable-region suspects.
+```
+
+A separate probe also confirmed there are no hardcoded *jump* tables (runs of
+unrelocated pointers at distinct symbol starts) elsewhere in the shiftable region —
+`gOpinfo_1` was the only real hardcoded-pointer table in the typed data. The
+remaining `[B]`/`[C]`/`[D]` words are coincidental incbin data, not pointers; the
+definitive check on those is Layer 3 (runtime).
+
+## Layer 3 runtime results
+
+Backend: `mgba_oracle.c`, a small program linking `libmgba` (apt: `libmgba-dev`);
+`run_dynamic.py` compiles it on demand. (The mGBA Python bindings aren't on PyPI for
+this environment.) It is validated and non-vacuous:
+
+- **Positive** — fixed ROM vs a shifted ROM (`+0x40000` and `+0x80000`): framebuffers
+  are **identical at every checkpoint** through boot → title → intro → menus
+  (frames 120–3000). The per-frame hashes vary (real changing screens), so the
+  oracle is reading actual output, not a constant.
+- **Oracle sanity** — base vs a heavily-corrupted ROM: correctly reports
+  **DIVERGENCE**. So it does detect differences.
+- **Coverage caveat** — reverting the fix and shifting did *not* diverge under
+  generic input, because `gOpinfo_1` is only used on the deep in-game class-reel
+  screen, which START/A spam doesn't reach in ~50 s. Layer 3 confirms the broadly
+  exercised paths are shiftable; the **static layers** are what conclusively caught
+  `opinfo` (the literal had no relocation; the fix gives it one). Reaching the
+  class-reel screen would need a targeted input script / save state.
+
+## Cross-resource hardcoded offsets — Layer 1b (`scan_offsets.py`)
+
+Layers 1/2 ask "which ROM-pointer words carry **no** relocation?" (raw literals).
+Layer 1b asks the complementary question: of the words that **do** relocate, which
+point at a *different* resource than the symbol they relocate against — i.e.
+`&ResourceA + hardcoded_offset` that actually lands in resource B.
+
+A pointer written `Img_LimitViewSquares + 0x280` carries a relocation (so Layers 1–3
+think it is safe), but the relocation tracks **Img_LimitViewSquares**, not the resource
+that lives at `+0x280`. Grow `Img_LimitViewSquares.4bpp` and the next resource slides
+down, while `+ 0x280` stays put → the pointer now lands in the middle of the enlarged
+image. The shiftable form is a direct `&B` reference (addend 0), which relocates to
+follow B.
+
+`scan_offsets.py` parses the retained `R_ARM_ABS32` relocations: for each one against a
+**named global** S it computes `addend = word − S.value` and the symbol T that owns the
+word; `T ≠ S` means the offset crossed out of S. It buckets:
+
+- **[A] HIGH** — `word == T.start`, location is a **data** section, addend `> 0`: a stored
+  pointer that reaches the *start* of a different resource. The actionable bug shape;
+  exits non-zero when non-empty.
+- **[B] REVIEW** — negative addends and mid-symbol landings: compiler `&arr[-1]`
+  1-based-index bias bases and base-register reuse in `.text` literal pools. These are
+  regenerated correctly every build and move with their object under a uniform shift.
+
+**Blind spot — section symbols and runtime `ADD`.** binutils collapses relocations
+against *local* symbols / asm labels onto the section symbol (`ROM`, `IWRAM`,
+`ewram_data`), losing the source symbol — so a local-base `A + offset` is invisible here
+(catch it at the source level). And when the compiler applies the offset as a runtime
+`ADD #imm` reusing the base register, the relocated word is the base with addend 0 — also
+invisible. Both classes must be found by reading the source.
+
+### Validation cases (now fixed)
+
+Three real cross-resource offsets were found, each resolved by its nature (all
+byte-identical — `make compare` still passes):
+
+- `src/playerphase.c` `gOpenLimitViewImgLut[]` — entry 6 was
+  `Img_LimitViewSquares + (5*4*CHR_SIZE)` = `+0x280`, which fell into the *separate*
+  resource `gUnkData_34` (the image was only `0x280` = 5 frames). These are six uniform
+  frames of one animation, so the **stray 6th-frame asset was merged** into
+  `Img_LimitViewSquares.png` (now `0x300` = 6 frames) and the table uses a clean
+  `Img_LimitViewSquares + (n * LIMIT_VIEW_FRAME_SIZE)` formula that is genuinely
+  within-resource. `gUnkData_34` is gone. (Was a HIGH-bucket hit; now within-resource.)
+- `src/fontgrp.c` `InitTalkTextFont` — `Pal_Text + 0x10` (`Pal_Text` is `u16[]`, so
+  `+0x20` bytes) was the separate talk-text palette `gUiPalettes_0`. Now references it
+  directly; the palette was also **renamed `Pal_TalkText`** (it is the talk/sprite text
+  palette in `fontgrp`, `scene`, and `bb`). (HIGH-bucket hit, now resolved.)
+- `src/worldmap_rm.c` `WmDotPalAnim_Loop1`/`Loop2` — `Pal_WmPlaceDot_Standard - 0x10` and
+  `Pal_WmPlaceDot_Highlight + 0x10` are the adjacent opposite palette. agbcc emits these as
+  a runtime `ADD`/`SUB #0x20` reusing the other arg's base register, and the two loops
+  anchor on different symbols, so there is **no byte-identical symbol form**; documented in
+  place (keep the two palettes adjacent if the layout is edited). Invisible to this scan by
+  construction — `Loop1` was found only via the source scan (subtraction form).
+
+After the fixes the HIGH bucket is empty.
+
+## Source-level raw-pointer scan (`scan_raw_casts.sh`)
+
+The binary delta-0 heuristic in `scan_relocs.py` is noisy (coincidental data words
+that equal symbol addresses). The **reliable** detector for the redas bug class is
+at the source level: `scan_raw_casts.sh` greps for raw pointer casts in C
+(`(T *)0x08…`) and raw `.4byte/.word 0x08…` literals in committed asm data. A full-
+game TAS replay (see `tas/`) found one such bug that the binary scan ranked low:
+`src/events_udefs.c` had `.redas = (void *)0x88b6e28` (9 chapter-7 `UnitDefinition.redas`
+pointers) instead of the `REDA_*` symbols — they didn't relocate, so a shifted ROM
+read garbage unit positions and desynced. Lesson: a *scattered* pointer (one per
+struct, not a contiguous table) pointing exactly at a data symbol is the signal the
+coherence heuristic misses; `scan_raw_casts.sh` catches it directly.
+
+## Files
+
+- `scan_raw_casts.sh` — source-level raw-pointer-cast detector (the redas class).
+- `scan_build_addrs.py` — Layer 0.
+- `emit_relocs_link.sh` — single source of truth for the production link line,
+  parameterized (used with `-q` for Layer 1 and with a shifted ldscript for Layer 2).
+- `scan_relocs.py` — Layer 1.
+- `scan_offsets.py` — Layer 1b (cross-resource wrong-base relocations).
+- `gen_shifted_ldscript.py`, `diff_shift.py` — Layer 2.
+- `run_dynamic.py` — Layer 3.
+- `_classify.py` — shared classifier (Layers 1 and 2 feed it different "relocated"
+  oracles: the reloc table vs. tracks-the-shift).
+- `allowlist.txt` — value ranges proven coincidental (keep tight; prefer fixing).

--- a/scripts/shiftcheck/_classify.py
+++ b/scripts/shiftcheck/_classify.py
@@ -1,0 +1,215 @@
+"""Shared suspect classifier for the shiftability harness.
+
+Both layers reduce to the same question -- "which ROM-pointer-looking words are
+NOT relocatable?" -- they only differ in how they decide "relocatable":
+
+  * Layer 1 (scan_relocs.py): the word carries an R_ARM_ABS32 relocation.
+  * Layer 2 (diff_shift.py):  the word's value tracks a layout shift.
+
+Given a boolean `relocated` mask over words, this module applies identical
+structural precision filters and returns the same buckets, so the two layers'
+HIGH-confidence findings are directly comparable (and should agree).
+
+Buckets:
+  high    {obj: [recs]} -- coherent unrelocated pointer table in a MIXED object
+  medium  {obj: count}  -- other unrelocated words in a MIXED object (scattered)
+  blob    {obj: count}  -- owner has no relocatable pointers (pure incbin data)
+  selfref {obj: count}  -- word lies inside the very symbol it points at
+Plus a `stats` dict.
+"""
+
+import bisect
+
+ROM_BASE = 0x08000000
+ROM_HI = 0x09000000
+MIN_PTR = 0x08000100  # below this is header/logo; small packed data, not pointers
+PIN = 0x08C00000      # first absolute-pinned ldscript block
+MIN_RUN = 4           # a pointer array is at least this many consecutive ptr/NULL
+
+
+def _owner_lookup(ranges):
+    starts = [r[0] for r in ranges]
+
+    def of(vma):
+        i = bisect.bisect_right(starts, vma) - 1
+        if i >= 0 and ranges[i][0] <= vma < ranges[i][1]:
+            return ranges[i][2], ranges[i][3]
+        return None, None
+
+    return of
+
+
+def _sym_lookup(syms):
+    addrs = [s[0] for s in syms]
+
+    def at(val):
+        i = bisect.bisect_right(addrs, val) - 1
+        if i >= 0:
+            return syms[i][1], val - syms[i][0]
+        return None, None
+
+    return at
+
+
+def _in_ranges(val, sorted_ranges):
+    if not sorted_ranges:
+        return False
+    los = [r[0] for r in sorted_ranges]
+    i = bisect.bisect_right(los, val) - 1
+    return i >= 0 and sorted_ranges[i][0] <= val < sorted_ranges[i][1]
+
+
+def classify(words, relocated, ranges, syms, allow=(),
+             include_text=False, min_ptr=MIN_PTR, candidate_mask=None):
+    """words: np.int64 array; relocated: np.bool_ array (same length).
+
+    ranges: sorted [(start,end,obj,sect)]; syms: sorted [(addr,name)];
+    allow: sorted [(lo,hi)] value ranges to suppress.
+    candidate_mask: optional np.bool_ array further restricting which ROM-pointer
+        words may be flagged (Layer 2 can only assess pointers whose target moved).
+    """
+    import numpy as np
+
+    n = words.size
+    owner_of = _owner_lookup(ranges)
+    sym_at = _sym_lookup(syms)
+
+    romptr = (words >= min_ptr) & (words < ROM_HI)
+    ptr_or_null = romptr | (words == 0)
+    cand = romptr & ~relocated
+    if candidate_mask is not None:
+        cand = cand & candidate_mask
+    suspect_idx = np.nonzero(cand)[0]
+
+    # Per-object count of relocatable pointers -> MIXED (>0) vs BLOB (0).
+    reloc_obj = {}
+    for idx in np.nonzero(relocated & romptr)[0].tolist():
+        obj, _ = owner_of(idx * 4 + ROM_BASE)
+        if obj:
+            reloc_obj[obj] = reloc_obj.get(obj, 0) + 1
+    live_targets = set(words[relocated & romptr].tolist())
+
+    # Maximal runs of consecutive ptr-or-NULL words (pointer arrays).
+    run_id = np.full(n, -1, dtype=np.int64)
+    run_len = {}
+    pe = ptr_or_null
+    i = rid = 0
+    while i < n:
+        if pe[i]:
+            j = i
+            while j < n and pe[j]:
+                j += 1
+            if (j - i) >= MIN_RUN:
+                run_id[i:j] = rid
+                run_len[rid] = j - i
+                rid += 1
+            i = j
+        else:
+            i += 1
+
+    recs_all, blob, selfref = [], {}, {}
+    pinned_n = text_n = allow_n = 0
+    for idx in suspect_idx.tolist():
+        vma = idx * 4 + ROM_BASE
+        val = int(words[idx])
+        if _in_ranges(val, allow):
+            allow_n += 1
+            continue
+        obj, sect = owner_of(vma)
+        if vma >= PIN:
+            pinned_n += 1
+            continue
+        if sect == "text" and not include_text:
+            text_n += 1
+            continue
+        if not (obj and reloc_obj.get(obj, 0) > 0):
+            blob[obj] = blob.get(obj, 0) + 1
+            continue
+        sym, delta = sym_at(val)
+        loc_sym, _ = sym_at(vma)
+        if loc_sym is not None and loc_sym == sym:
+            selfref[obj] = selfref.get(obj, 0) + 1
+            continue
+        recs_all.append(dict(vma=vma, val=val, sym=sym, delta=delta, sect=sect,
+                             obj=obj, run=int(run_id[idx]),
+                             live=(val in live_targets)))
+
+    by_run = {}
+    for r in recs_all:
+        by_run.setdefault(r["run"], []).append(r)
+
+    def coherent(entries):
+        if len(entries) < MIN_RUN:
+            return False
+        distinct = len(set(e["sym"] for e in entries))
+        return distinct <= max(2, len(entries) // 4)
+
+    coherent_runs = {
+        rid for rid, es in by_run.items()
+        if rid >= 0 and run_len.get(rid, 0) >= MIN_RUN and coherent(es)
+    }
+
+    high, medium = {}, {}
+    for r in recs_all:
+        if r["run"] in coherent_runs:
+            high.setdefault(r["obj"], []).append(r)
+        else:
+            medium[r["obj"]] = medium.get(r["obj"], 0) + 1
+
+    stats = dict(romptr=int(romptr.sum()), relocated=int((relocated & romptr).sum()),
+                 candidates=int(suspect_idx.size), allow=allow_n, text=text_n,
+                 pinned=pinned_n)
+    return dict(high=high, medium=medium, blob=blob, selfref=selfref, stats=stats)
+
+
+def report(buckets, title, max_list=80, result_verb="suspect"):
+    """Print the standard bucketed report; return the HIGH count."""
+    from collections import Counter
+    high, medium, blob, selfref = (buckets["high"], buckets["medium"],
+                                   buckets["blob"], buckets["selfref"])
+    s = buckets["stats"]
+    print("=" * 78)
+    print(title)
+    print("=" * 78)
+    print(f"ROM-pointer-looking words: {s['romptr']} | relocatable: {s['relocated']}"
+          f" | unrelocated candidates: {s['candidates']}")
+    print(f"allowlisted: {s['allow']} | in .text (quiet): {s['text']} | "
+          f"pinned region >=0x{PIN:08X}: {s['pinned']}")
+
+    n_high = sum(len(v) for v in high.values())
+    print("\n" + "-" * 78)
+    print(f"[A] HIGH-CONFIDENCE -- coherent unrelocated pointer table in a MIXED "
+          f"object: {n_high} in {len(high)} object(s)")
+    print("-" * 78)
+    for obj in sorted(high, key=lambda o: -len(high[o])):
+        recs = sorted(high[obj], key=lambda r: r["vma"])
+        tc = Counter(r["sym"] for r in recs)
+        dom = ", ".join(f"{x}({c})" for x, c in tc.most_common(3))
+        nruns = len(set(r["run"] for r in recs))
+        print(f"\n  {obj}  ({len(recs)} {result_verb}s in {nruns} table(s); "
+              f"targets: {dom})")
+        for r in recs[:max_list]:
+            tgt = f"{r['sym']}+0x{r['delta']:X}" if r["sym"] else "<no symbol>"
+            live = " *live" if r["live"] else ""
+            print(f"    0x{r['vma']:08X} = 0x{r['val']:08X}  -> {tgt}{live}")
+        if len(recs) > max_list:
+            print(f"    ... and {len(recs) - max_list} more")
+
+    n_mid = sum(medium.values())
+    print("\n" + "-" * 78)
+    print(f"[B] MIXED-object scattered (lower confidence; review): {n_mid} in "
+          f"{len(medium)} object(s)")
+    print("-" * 78)
+    for obj, c in sorted(medium.items(), key=lambda t: -t[1])[:20]:
+        print(f"    {c:5d}  {obj}")
+
+    for tag, name, d in (("C", "BLOB (no relocatable pointers -> pure incbin data)",
+                          blob),
+                         ("D", "BLOB-INTERNAL self-references (embedded blob data)",
+                          selfref)):
+        print("\n" + "-" * 78)
+        print(f"[{tag}] {name}: {sum(d.values())} in {len(d)} object(s)")
+        print("-" * 78)
+        for obj, c in sorted(d.items(), key=lambda t: -t[1])[:10]:
+            print(f"    {c:5d}  {obj}")
+    return n_high

--- a/scripts/shiftcheck/allowlist.txt
+++ b/scripts/shiftcheck/allowlist.txt
@@ -1,0 +1,9 @@
+# Shiftability scan allowlist (Layer 1).
+# Format:  0xLO 0xHI   comment
+# Any ROM-pointer-looking word whose VALUE falls in [LO, HI) is suppressed as a
+# known-legitimate constant (not a relocatable pointer). Keep this tight: prefer
+# fixing real pointers over allowlisting. Add entries only after Layer 2 (the
+# two-shift differential) proves a flagged word is coincidental data, not a pointer.
+#
+# (Hardware IO 0x04xxxxxx, palette/VRAM/OAM 0x05-0x07, EWRAM/IWRAM 0x02-0x03 are
+#  never flagged: the scan only considers ROM-range 0x08000000-0x09000000 values.)

--- a/scripts/shiftcheck/diff_shift.py
+++ b/scripts/shiftcheck/diff_shift.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Layer 2 of the shiftability harness: differential two-shift build.
+
+Builds the ROM shifted by two different amounts (N1, N2) and compares each against
+the base, word by word, with position correction. For a ROM-pointer word whose
+TARGET lies in the shifted region (so the target moved):
+
+  * a correctly-relocated pointer holds value+N1 in build 1 and value+N2 in build 2
+    -> it TRACKS the shift (good, relocatable);
+  * a hardcoded literal holds the same value in both builds -> it is STUCK; since
+    its target moved, it now points at the wrong place -> a shiftability bug.
+
+Two distinct shifts eliminate coincidences: a stray data word that merely happens
+to equal value+N1 in one build will not also equal value+N2 in the other.
+
+This is an independent, emulator-free confirmation of Layer 1 (which uses the ELF's
+relocation table). The STUCK set, intersected with owning objects, reproduces
+Layer 1's opinfo finding from a completely different mechanism.
+
+Needs: emit_relocs_link.sh + objcopy (to build the shifted ROMs), gen_shifted_
+ldscript.py, the base .gba, the .map, and numpy.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+import numpy as np
+
+import _classify as C
+
+ROM_BASE = C.ROM_BASE
+ROM_HI = C.ROM_HI
+MIN_PTR = C.MIN_PTR
+PIN = C.PIN
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def sh(cmd, **kw):
+    return subprocess.run(cmd, check=True, **kw)
+
+
+def map_bounds(map_path):
+    """Return (shift_start_vma, data_end_vma): crt0 .text end, and last natural data."""
+    rx = re.compile(r"^\s+\.(\w[\w.]*)\s+(0x[0-9a-fA-F]+)\s+(0x[0-9a-fA-F]+)\s+(\S+\.o)\b")
+    crt0_end = None
+    data_end = ROM_BASE
+    for ln in open(map_path, errors="replace"):
+        m = rx.match(ln)
+        if not m:
+            continue
+        a = int(m.group(2), 16)
+        s = int(m.group(3), 16)
+        obj = m.group(4)
+        if obj.endswith("crt0.o") and m.group(1) == "text":
+            crt0_end = a + s
+        if s and ROM_BASE <= a < PIN:
+            data_end = max(data_end, a + s)
+    if crt0_end is None:
+        sys.exit("could not find crt0.o(.text) in map")
+    return crt0_end, data_end
+
+
+def build_shifted(shift, ldscript, map_path, outdir, env):
+    """Generate a shifted ldscript, link, objcopy to a flat .gba. Return path."""
+    lds = os.path.join(outdir, f"ldscript_{shift:#x}.txt")
+    sh([sys.executable, os.path.join(HERE, "gen_shifted_ldscript.py"),
+        "--ldscript", ldscript, "--map", map_path,
+        "--shift", hex(shift), "--out", lds])
+    elf = os.path.join(outdir, f"shift_{shift:#x}.elf")
+    gba = os.path.join(outdir, f"shift_{shift:#x}.gba")
+    sh([os.path.join(HERE, "emit_relocs_link.sh"), elf, lds], env=env)
+    objcopy = env.get("OBJCOPY", "arm-none-eabi-objcopy")
+    sh([objcopy, "--strip-debug", "-O", "binary", "--pad-to", "0x9000000",
+        "--gap-fill=0xff", elf, gba])
+    return gba
+
+
+def load_words(path):
+    return np.frombuffer(open(path, "rb").read(), dtype="<u4").astype(np.int64)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base-gba", default="fireemblem8.gba")
+    ap.add_argument("--ldscript", default="ldscript.txt")
+    ap.add_argument("--map", default="fireemblem8.map")
+    ap.add_argument("--shifts", default="0x40000,0x80000")
+    ap.add_argument("--outdir", default="build/shiftcheck")
+    ap.add_argument("--prefix", default="arm-none-eabi-")
+    ap.add_argument("--ref-elf", default="fireemblem8.elf")
+    ap.add_argument("--allowlist", default="scripts/shiftcheck/allowlist.txt")
+    ap.add_argument("--max-list", type=int, default=40)
+    args = ap.parse_args()
+
+    shifts = [int(x, 0) for x in args.shifts.split(",")]
+    if len(shifts) != 2:
+        sys.exit("--shifts needs exactly two values, e.g. 0x40000,0x80000")
+    os.makedirs(args.outdir, exist_ok=True)
+
+    env = dict(os.environ)
+    env.setdefault("LD", args.prefix + "ld")
+    env.setdefault("OBJCOPY", args.prefix + "objcopy")
+    env.setdefault("OBJECTS_LST", "objects.lst")
+    env.setdefault("BANIM_OBJECT", "banim/data_banim.o")
+
+    shift_start, data_end = map_bounds(args.map)
+    print(f"shift_start (after crt0) = {shift_start:#010x} | "
+          f"natural data end = {data_end:#010x} | pin = {PIN:#010x}")
+
+    base = load_words(args.base_gba)
+    builds = []
+    for s in shifts:
+        print(f"\n--- building shifted ROM (+{s:#x}) ---")
+        gba = build_shifted(s, args.ldscript, args.map, args.outdir, env)
+        builds.append((s, load_words(gba)))
+
+    n = base.size
+    base_off = np.arange(n, dtype=np.int64) * 4
+    base_vma = base_off + ROM_BASE
+
+    # A base word is in the shifted region if its LOCATION is in [shift_start, data_end).
+    loc_shifted = (base_vma >= shift_start) & (base_vma < data_end)
+    # A base word's TARGET moved if its VALUE points into [shift_start, data_end).
+    is_ptr = (base >= MIN_PTR) & (base < ROM_HI)
+    tgt_moved = is_ptr & (base >= shift_start) & (base < data_end)
+
+    # For each shift, fetch the corresponding shifted word (position-corrected).
+    tracked = np.ones(n, dtype=bool)   # tracks the shift in BOTH builds
+    stuck = np.ones(n, dtype=bool)     # unchanged in BOTH builds
+    for s, sw in builds:
+        dw = s // 4
+        # shifted index: +dw where the location moved, same index otherwise.
+        idx = np.arange(n, dtype=np.int64) + np.where(loc_shifted, dw, 0)
+        idx = np.clip(idx, 0, n - 1)
+        corr = sw[idx]
+        tracked &= (corr == base + s)
+        stuck &= (corr == base)
+
+    consider = tgt_moved & loc_shifted  # pointer to-shifted, located in shifted region
+    n_consider = int(consider.sum())
+    n_tracked = int((consider & tracked).sum())
+    n_stuck_raw = int((consider & stuck).sum())
+    print("\n" + "-" * 78)
+    print("Differential oracle (target in shifted region, located in shifted region):")
+    print(f"  considered: {n_consider} | TRACKED both shifts (relocatable): "
+          f"{n_tracked} | STUCK both shifts: {n_stuck_raw}")
+    print("  (STUCK raw mixes hardcoded pointers with coincidental data; the shared")
+    print("   classifier below reduces it to high-confidence pointer tables.)")
+
+    # Feed the differential's verdict into the SAME classifier Layer 1 uses, with
+    # "tracks the shift" as the relocated oracle (independent of the ELF reloc
+    # table) and "target moved" as the candidate restriction (the only pointers the
+    # differential can assess). This yields the same HIGH bucket as Layer 1.
+    syms = parse_nm(args.ref_elf, args.prefix + "nm")
+    ranges = parse_map(args.map)
+    allow = load_allowlist(args.allowlist)
+    buckets = C.classify(base, tracked, ranges, syms, allow=allow,
+                         candidate_mask=tgt_moved)
+    n_high = C.report(
+        buckets,
+        "Layer 2 - differential two-shift scan (oracle: tracks-the-shift)",
+        max_list=args.max_list, result_verb="stuck-ptr")
+
+    print("\n" + "=" * 78)
+    if n_high:
+        print(f"RESULT: {n_high} HIGH-CONFIDENCE hardcoded pointer(s) confirmed by "
+              f"the differential (independent of the reloc table; matches Layer 1).")
+        return 1
+    print("RESULT: no high-confidence hardcoded pointers (differential).")
+    return 0
+
+
+def parse_map(path):
+    rx = re.compile(r"^\s+\.(\w[\w.]*)\s+(0x[0-9a-fA-F]+)\s+(0x[0-9a-fA-F]+)\s+(\S+\.o)\b")
+    ranges = []
+    for ln in open(path, errors="replace"):
+        m = rx.match(ln)
+        if not m:
+            continue
+        a, s = int(m.group(2), 16), int(m.group(3), 16)
+        if s and ROM_BASE <= a < ROM_HI:
+            ranges.append((a, a + s, m.group(4), m.group(1)))
+    ranges.sort()
+    return ranges
+
+
+def parse_nm(elf, nm):
+    syms = []
+    for ln in subprocess.run([nm, "-n", elf], capture_output=True, text=True,
+                             check=True).stdout.splitlines():
+        p = ln.split()
+        if len(p) < 3:
+            continue
+        try:
+            a = int(p[0], 16)
+        except ValueError:
+            continue
+        if ROM_BASE <= a < ROM_HI:
+            syms.append((a, " ".join(p[2:])))
+    syms.sort()
+    return syms
+
+
+def load_allowlist(path):
+    out = []
+    try:
+        for ln in open(path, errors="replace"):
+            ln = ln.split("#", 1)[0].strip()
+            if not ln:
+                continue
+            p = ln.split()
+            lo = int(p[0], 16)
+            hi = int(p[1], 16) if len(p) > 1 else lo + 1
+            out.append((lo, hi))
+    except FileNotFoundError:
+        pass
+    return sorted(out)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shiftcheck/emit_relocs_link.sh
+++ b/scripts/shiftcheck/emit_relocs_link.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Single source of truth for the production link command, parameterized so the
+# shiftability harness can produce variant ELFs without duplicating the link line
+# (which lives in the Makefile $(ELF) rule). Two uses:
+#   - Layer 1: relink with `-q` (--emit-relocs) so the ELF retains R_ARM_ABS32
+#     relocations; scan_relocs.py uses them to separate symbol-derived pointers
+#     (safe) from raw hardcoded address literals (unsafe).
+#   - Layer 2: relink against a *shifted* ldscript to produce a moved image.
+#
+# It NEVER touches the matching build: it writes to a separate output ELF/map.
+#
+# Usage: emit_relocs_link.sh <out.elf> <ldscript> [extra ld flags...]
+# Env (default to the project's values): LD, OBJECTS_LST, BANIM_OBJECT.
+set -e
+
+OUT="$1"
+LDSCRIPT="$2"
+shift 2
+
+LD="${LD:-arm-none-eabi-ld}"
+OBJECTS_LST="${OBJECTS_LST:-objects.lst}"
+BANIM_OBJECT="${BANIM_OBJECT:-banim/data_banim.o}"
+
+exec "$LD" -T "$LDSCRIPT" -Map "${OUT%.elf}.map" @"$OBJECTS_LST" \
+    -R "${BANIM_OBJECT}.sym.o" -L tools/agbcc/lib -o "$OUT" -lc -lgcc "$@"

--- a/scripts/shiftcheck/gen_shifted_ldscript.py
+++ b/scripts/shiftcheck/gen_shifted_ldscript.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Layer 2 helper: emit a SHIFTED copy of ldscript.txt.
+
+Inserts `. += <S>;` immediately after `src/crt0.o(.text);` so every section laid
+out after crt0 (all remaining .text, all .rodata, all natural .data) moves forward
+by S, while the cartridge header + entry stay put and the absolute-pinned blocks
+(`. = 0xC00000;` ...) stay put. A correctly-written (symbol-referenced) pointer is
+relocated by the linker to track the move; a hardcoded address literal does not --
+which is exactly what diff_shift.py detects.
+
+NEVER overwrites ldscript.txt: writes to a separate --out path. Validates that S
+keeps the shifted data below the first pin (else the link would overlap the banim
+block / ld would refuse to move `.` backwards).
+"""
+
+import argparse
+import re
+import sys
+
+ROM_BASE = 0x08000000
+PIN = 0x08C00000
+CRT0_LINE = "src/crt0.o(.text);"
+
+
+def natural_data_end(map_path):
+    rx = re.compile(r"^\s+\.(\w[\w.]*)\s+(0x[0-9a-fA-F]+)\s+(0x[0-9a-fA-F]+)\s+(\S+\.o)\b")
+    end = ROM_BASE
+    for ln in open(map_path, errors="replace"):
+        m = rx.match(ln)
+        if not m:
+            continue
+        a = int(m.group(2), 16)
+        s = int(m.group(3), 16)
+        if s and ROM_BASE <= a < PIN:
+            end = max(end, a + s)
+    return end
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--ldscript", default="ldscript.txt")
+    ap.add_argument("--map", default="fireemblem8.map")
+    ap.add_argument("--shift", required=True, help="shift amount, e.g. 0x40000")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--align", type=lambda x: int(x, 0), default=0x1000,
+                    help="S must be a multiple of this so alignments are preserved")
+    args = ap.parse_args()
+
+    s = int(args.shift, 0)
+    if s <= 0:
+        sys.exit("shift must be positive")
+    if s % args.align:
+        sys.exit(f"shift {s:#x} must be a multiple of {args.align:#x} to keep "
+                 f"section alignments identical (uniform shift)")
+
+    end = natural_data_end(args.map)
+    slack = PIN - end
+    if s > slack:
+        sys.exit(f"shift {s:#x} exceeds slack {slack:#x} (natural data ends at "
+                 f"{end:#010x}, first pin at {PIN:#010x}); would overlap the pinned "
+                 f"banim block")
+
+    lines = open(args.ldscript, encoding="utf-8").read().splitlines(keepends=True)
+    out = []
+    injected = False
+    for line in lines:
+        out.append(line)
+        if not injected and CRT0_LINE in line:
+            indent = line[: len(line) - len(line.lstrip())]
+            out.append(f"{indent}. += {s:#x}; /* shiftcheck: injected padding "
+                       f"(NOT the matching build) */\n")
+            injected = True
+    if not injected:
+        sys.exit(f"could not find injection anchor '{CRT0_LINE}' in {args.ldscript}")
+
+    with open(args.out, "w", encoding="utf-8") as fh:
+        fh.writelines(out)
+    print(f"wrote {args.out}: shift {s:#x} after crt0 "
+          f"(data {end:#010x}->{end + s:#010x}, slack {slack:#x})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shiftcheck/mgba_oracle.c
+++ b/scripts/shiftcheck/mgba_oracle.c
@@ -1,0 +1,143 @@
+/* Layer 3 backend: headless mGBA framebuffer oracle (links libmgba).
+ *
+ * The Python bindings aren't on PyPI for this environment, but libmgba + headers
+ * are (apt: libmgba-dev). This runs two ROMs headless under an IDENTICAL scripted
+ * input sequence and compares the VIDEO FRAMEBUFFER at checkpoints.
+ *
+ * Only the framebuffer is a valid oracle: the shifted ROM's RAM legitimately
+ * differs (correctly-relocated pointers stored in RAM now hold shifted addresses),
+ * but what is DRAWN must be identical regardless of where code/data live. A
+ * framebuffer divergence therefore means a pointer did NOT relocate -- wrong
+ * graphics, a crash, or a hang -- i.e. a shiftability bug.
+ *
+ * Usage: mgba_oracle <base.gba> <shifted.gba> [checkpoint_frame ...]
+ * Exit:  0 = identical at every checkpoint; 1 = divergence; 2 = setup error.
+ */
+#include <mgba/core/core.h>
+#include <mgba/core/interface.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* GBA key bit positions (mgba/internal/gba/input.h order). */
+enum { K_A = 1 << 0, K_B = 1 << 1, K_SELECT = 1 << 2, K_START = 1 << 3,
+       K_RIGHT = 1 << 4, K_LEFT = 1 << 5, K_UP = 1 << 6, K_DOWN = 1 << 7,
+       K_R = 1 << 8, K_L = 1 << 9 };
+
+static int cmp_int(const void* a, const void* b)
+{
+	int x = *(const int*) a, y = *(const int*) b;
+	return (x > y) - (x < y);
+}
+
+static void* xmalloc(size_t n)
+{
+	void* p = malloc(n);
+	if (!p) {
+		fprintf(stderr, "mgba_oracle: out of memory\n");
+		exit(2);
+	}
+	return p;
+}
+
+static uint64_t fnv1a(const void* data, size_t n)
+{
+	uint64_t h = 1469598103934665603ULL;
+	const uint8_t* p = (const uint8_t*) data;
+	for (size_t i = 0; i < n; i++) {
+		h ^= p[i];
+		h *= 1099511628211ULL;
+	}
+	return h;
+}
+
+/* Identical input for both ROMs: tap START then A in turn, briefly, every second,
+ * to advance through title / intro / first menus. Deterministic in frame number. */
+static uint32_t keys_for(int frame)
+{
+	if (frame >= 90 && ((frame - 90) % 60) < 6)
+		return (((frame - 90) / 60) % 2) ? K_START : K_A;
+	return 0;
+}
+
+static int run(const char* path, const int* cps, int ncps, uint64_t* out)
+{
+	struct mCore* core = mCoreFind(path);
+	if (!core) {
+		fprintf(stderr, "mgba_oracle: no core for %s\n", path);
+		return 2;
+	}
+	core->init(core);
+	mCoreInitConfig(core, NULL);
+	if (!mCoreLoadFile(core, path)) {
+		fprintf(stderr, "mgba_oracle: cannot load %s\n", path);
+		return 2;
+	}
+	unsigned w, h;
+	core->desiredVideoDimensions(core, &w, &h);
+	color_t* buf = (color_t*) xmalloc((size_t) w * h * sizeof(color_t));
+	core->setVideoBuffer(core, buf, w);
+	core->reset(core);
+
+	int maxf = cps[ncps - 1], ci = 0;
+	for (int f = 0; f <= maxf; f++) {
+		core->setKeys(core, keys_for(f));
+		core->runFrame(core);
+		while (ci < ncps && f == cps[ci]) {
+			out[ci] = fnv1a(buf, (size_t) w * h * sizeof(color_t));
+			ci++;
+		}
+	}
+	free(buf);
+	mCoreConfigDeinit(&core->config);
+	core->deinit(core);
+	return 0;
+}
+
+int main(int argc, char** argv)
+{
+	if (argc < 3) {
+		fprintf(stderr, "usage: %s <base.gba> <shifted.gba> [frame ...]\n", argv[0]);
+		return 2;
+	}
+	int default_cps[] = { 120, 300, 600, 900, 1200 };
+	int ncps = argc > 3 ? argc - 3 : 5;
+	int* cps = (int*) xmalloc(sizeof(int) * ncps);
+	if (argc > 3)
+		for (int i = 0; i < ncps; i++)
+			cps[i] = atoi(argv[3 + i]);
+	else
+		memcpy(cps, default_cps, sizeof(default_cps));
+	/* The frame loop runs to cps[ncps-1] and advances ci in order, so checkpoints
+	 * must be ascending; sort user-supplied frames so out[] is always fully written. */
+	qsort(cps, ncps, sizeof(int), cmp_int);
+
+	uint64_t* a = (uint64_t*) xmalloc(sizeof(uint64_t) * ncps);
+	uint64_t* b = (uint64_t*) xmalloc(sizeof(uint64_t) * ncps);
+	int rc = run(argv[1], cps, ncps, a);
+	if (rc) return rc;
+	rc = run(argv[2], cps, ncps, b);
+	if (rc) return rc;
+
+	printf("======================================================================\n");
+	printf("Layer 3 - mGBA framebuffer oracle (base vs shifted)\n");
+	printf("======================================================================\n");
+	int diverged = 0;
+	for (int i = 0; i < ncps; i++) {
+		int ok = a[i] == b[i];
+		printf("  frame %5d: base fb=%016llx | shifted fb=%016llx  [%s]\n",
+		       cps[i], (unsigned long long) a[i], (unsigned long long) b[i],
+		       ok ? "OK" : "DIVERGE");
+		if (!ok) diverged = 1;
+	}
+	printf("======================================================================\n");
+	if (diverged) {
+		printf("RESULT: DIVERGENCE -> the shifted ROM renders differently; a "
+		       "hardcoded pointer is hit.\n");
+		return 1;
+	}
+	printf("RESULT: identical at every checkpoint -> shiftable through this depth.\n");
+	return 0;
+}

--- a/scripts/shiftcheck/run_dynamic.py
+++ b/scripts/shiftcheck/run_dynamic.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Layer 3 of the shiftability harness: dynamic (runtime) smoke test.
+
+Layers 1-2 locate hardcoded pointers statically. This layer is the end-to-end
+proof: run the matching ROM and a SHIFTED ROM headless under an IDENTICAL scripted
+input sequence and compare the video framebuffer (and a few RAM globals) at
+checkpoints. The matching build is the ORACLE -- because both ROMs get the same
+input, any divergence is caused by the shift, i.e. a pointer that did not relocate.
+
+  * all checkpoints identical  -> shiftable through that depth (boot -> title ->
+    past the first menus).
+  * a checkpoint diverges       -> a shift-sensitive (hardcoded) pointer was hit;
+    the frame where it first diverges localizes when.
+
+Uses mGBA's Python bindings (`pip install mgba`, which links libmgba). If they are
+not importable it prints install instructions and exits 0 (non-blocking), so the
+static layers still gate CI.
+
+Build the shifted ROM with the same mechanism as Layer 2 (gen_shifted_ldscript +
+the production link + objcopy) unless --shifted-gba is supplied.
+"""
+
+import argparse
+import hashlib
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+# GBA key bitmask (mGBA order): A B SELECT START RIGHT LEFT UP DOWN R L.
+KEY = dict(A=1 << 0, B=1 << 1, SELECT=1 << 2, START=1 << 3, RIGHT=1 << 4,
+           LEFT=1 << 5, UP=1 << 6, DOWN=1 << 7, R=1 << 8, L=1 << 9)
+
+INSTALL_HINT = """\
+Layer 3 needs mGBA. Neither the C library (libmgba) nor the Python bindings are
+available here.
+
+Install the C library (preferred; the harness compiles a small oracle against it):
+    sudo apt-get install -y libmgba-dev
+
+Then re-run:  make shiftcheck-run
+(Static layers 0-2 already gate CI, so this layer is optional/non-blocking.)
+"""
+
+
+def try_import_mgba():
+    try:
+        import mgba.core  # noqa: F401
+        import mgba.image  # noqa: F401
+        import mgba.log
+        mgba.log.silence()
+        return True
+    except Exception:
+        return False
+
+
+def run_rom(path, input_script, checkpoints, ram_addrs):
+    """Run `path` headless; return {frame: (fb_hash, [ram values])} at checkpoints."""
+    import mgba.core
+    import mgba.image
+
+    core = mgba.core.load_path(path)
+    if core is None:
+        raise RuntimeError(f"mGBA could not load {path}")
+    image = mgba.image.Image(*core.desired_video_dimensions())
+    core.set_video_buffer(image)
+    core.reset()
+
+    last = max(checkpoints)
+    cps = set(checkpoints)
+    result = {}
+    for frame in range(last + 1):
+        keys = 0
+        for start, dur, name in input_script:
+            if start <= frame < start + dur:
+                keys |= KEY[name]
+        core.set_keys(keys)
+        core.run_frame()
+        if frame in cps:
+            buf = bytes(image.buffer) if hasattr(image, "buffer") else b""
+            if not buf:
+                # fall back to PIL tobytes if .buffer isn't exposed
+                buf = image.to_pil().tobytes()
+            fbh = hashlib.sha1(buf).hexdigest()[:12]
+            ram = []
+            for a in ram_addrs:
+                try:
+                    ram.append(core.read32(a) & 0xFFFFFFFF)
+                except Exception:
+                    ram.append(None)
+            result[frame] = (fbh, ram)
+    return result
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base-gba", default="fireemblem8.gba")
+    ap.add_argument("--shifted-gba", default=None,
+                    help="prebuilt shifted ROM; if omitted, one is built")
+    ap.add_argument("--shift", default="0x40000")
+    ap.add_argument("--ldscript", default="ldscript.txt")
+    ap.add_argument("--map", default="fireemblem8.map")
+    ap.add_argument("--outdir", default="build/shiftcheck")
+    ap.add_argument("--prefix", default="arm-none-eabi-")
+    ap.add_argument("--checkpoints", default="120,300,600,900,1200",
+                    help="frame numbers to compare (60 fps)")
+    ap.add_argument("--ram", default="",
+                    help="comma-separated hex RAM addresses to compare")
+    args = ap.parse_args()
+
+    checkpoints = [int(x) for x in args.checkpoints.split(",") if x.strip()]
+
+    # Build the shifted ROM (Layer 2 mechanism) unless one was supplied.
+    shifted = args.shifted_gba
+    if not shifted:
+        import diff_shift
+        env = dict(os.environ)
+        env.setdefault("LD", args.prefix + "ld")
+        env.setdefault("OBJCOPY", args.prefix + "objcopy")
+        env.setdefault("OBJECTS_LST", "objects.lst")
+        env.setdefault("BANIM_OBJECT", "banim/data_banim.o")
+        os.makedirs(args.outdir, exist_ok=True)
+        print(f"building shifted ROM (+{args.shift}) ...")
+        shifted = diff_shift.build_shifted(int(args.shift, 0), args.ldscript,
+                                           args.map, args.outdir, env)
+
+    # Preferred backend: the C oracle linking libmgba (the Python bindings are not
+    # on PyPI for this environment). Compile on demand if libmgba headers exist.
+    oracle = ensure_c_oracle()
+    if oracle:
+        import subprocess
+        cmd = [oracle, args.base_gba, shifted] + [str(c) for c in checkpoints]
+        return subprocess.run(cmd).returncode
+
+    # Fallback: Python bindings, if importable.
+    if try_import_mgba():
+        return run_via_python(args.base_gba, shifted, checkpoints)
+
+    print(INSTALL_HINT)
+    return 0
+
+
+def ensure_c_oracle():
+    """Return path to a working mgba_oracle binary, compiling it if libmgba is
+    present; else None."""
+    import subprocess
+    binpath = os.path.join(HERE, "mgba_oracle")
+    src = os.path.join(HERE, "mgba_oracle.c")
+    if os.path.exists(binpath) and os.path.getmtime(binpath) >= os.path.getmtime(src):
+        return binpath
+    if not os.path.exists("/usr/include/mgba/core/core.h"):
+        return None
+    cc = os.environ.get("CC", "cc")
+    r = subprocess.run([cc, "-O2", "-o", binpath, src, "-lmgba"],
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        sys.stderr.write(r.stderr)
+        return None
+    return binpath
+
+
+def run_via_python(base_gba, shifted, checkpoints):
+    # Must match mgba_oracle.c keys_for(): tap A then START in turn from frame 90,
+    # i.e. ((f - 90) / 60) % 2 -> START else A (the two backends must drive identically).
+    input_script = [(f, 6, "START" if ((f - 90) // 60) % 2 else "A")
+                    for f in range(90, max(checkpoints), 60)]
+    base = run_rom(base_gba, input_script, checkpoints, [])
+    shi = run_rom(shifted, input_script, checkpoints, [])
+    print("\nLayer 3 - runtime oracle (python backend)")
+    diverged = [f for f in checkpoints if base.get(f) != shi.get(f)]
+    for f in checkpoints:
+        ok = base.get(f) == shi.get(f)
+        print(f"  frame {f:5d}: base={base[f][0]} shifted={shi[f][0]} "
+              f"[{'OK' if ok else 'DIVERGE'}]")
+    if diverged:
+        print(f"RESULT: DIVERGENCE at {diverged}")
+        return 1
+    print("RESULT: identical at every checkpoint -> shiftable through this depth.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shiftcheck/scan_build_addrs.py
+++ b/scripts/shiftcheck/scan_build_addrs.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Layer 0 of the shiftability harness: audit hardcoded GBA addresses in the
+BUILD SYSTEM (Makefile, linker scripts, *.mk).
+
+The data-pointer scan (scan_relocs.py) only sees the linked ROM image; it cannot
+see addresses baked into the build files. Those constants also encode layout
+assumptions, and -- worse -- some are DUPLICATED across files with no single
+source of truth, so a future layout shift could desync them and silently corrupt
+a subsystem.
+
+This tool:
+  1. lists every GBA-range literal in the build files, classified, and
+  2. cross-checks COUPLED constants, exiting nonzero on any mismatch.
+
+The canonical coupled pair: the banim sub-link base (`-b 0x8c02000` in the
+Makefile) must equal the absolute address of the banim pin in ldscript.txt
+(`. = 0xC02000; banim/data_banim.o(.data);`, i.e. ROM_BASE + 0xC02000).
+"""
+
+import argparse
+import re
+import sys
+
+ROM_BASE = 0x08000000
+ROM_END = 0x0A000000  # ROM + mirror
+EWRAM_LO, EWRAM_HI = 0x02000000, 0x02040000
+IWRAM_LO, IWRAM_HI = 0x03000000, 0x03008000
+
+HEX_RE = re.compile(r"0x[0-9a-fA-F]{6,8}")
+
+
+def classify(val):
+    if val == 0x09000000:
+        return "LAYOUT (ROM size / pad-to)"
+    if ROM_BASE <= val < ROM_END:
+        return "ROM"
+    if EWRAM_LO <= val < EWRAM_HI:
+        return "EWRAM"
+    if IWRAM_LO <= val < IWRAM_HI:
+        return "IWRAM"
+    return None
+
+
+def scan_file(path):
+    """Yield (lineno, literal, value, is_comment, text) for GBA-range hex hits."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            for lineno, line in enumerate(fh, 1):
+                stripped = line.lstrip()
+                is_comment = stripped.startswith(("#", "@", "//", "/*", "*"))
+                for m in HEX_RE.finditer(line):
+                    val = int(m.group(0), 16)
+                    if classify(val) is not None:
+                        yield lineno, m.group(0), val, is_comment, line.rstrip()
+    except FileNotFoundError:
+        return
+
+
+def first_match(path, pattern):
+    """Return (lineno, regex match) of the first line matching pattern, or None."""
+    rx = re.compile(pattern)
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            for lineno, line in enumerate(fh, 1):
+                m = rx.search(line)
+                if m:
+                    return lineno, m, line.rstrip()
+    except FileNotFoundError:
+        pass
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--makefile", default="Makefile")
+    ap.add_argument("--ldscript", default="ldscript.txt")
+    ap.add_argument("--banim-ldscript", default="linker_script_banim.txt")
+    ap.add_argument("--extra", nargs="*", default=[], help="additional *.mk files")
+    args = ap.parse_args()
+
+    files = [args.makefile, args.ldscript, args.banim_ldscript] + args.extra
+
+    # ---- 1. Inventory -----------------------------------------------------
+    print("=" * 72)
+    print("Layer 0 - build-system hardcoded GBA addresses")
+    print("=" * 72)
+    total = 0
+    for path in files:
+        hits = list(scan_file(path))
+        if not hits:
+            continue
+        print(f"\n{path}:")
+        for lineno, lit, val, is_comment, text in hits:
+            total += 1
+            tag = classify(val)
+            note = " (comment)" if is_comment else ""
+            print(f"  L{lineno:<5} {lit:<12} {tag}{note}")
+            print(f"         | {text.strip()[:90]}")
+    print(f"\n{total} GBA-range literal(s) found across build files.")
+
+    # ---- 2. Coupled-pair cross-checks ------------------------------------
+    print("\n" + "-" * 72)
+    print("Coupled-constant checks (must agree -- a mismatch corrupts a subsystem):")
+    print("-" * 72)
+    failures = []
+
+    # banim base (Makefile `-b 0xXXXX`) vs ldscript banim pin.
+    mk_base = first_match(args.makefile, r"-b\s+(0x[0-9a-fA-F]+)")
+    ld_pin = first_match(
+        args.ldscript, r"\.\s*=\s*(0x[0-9a-fA-F]+)\s*;\s*banim/data_banim\.o\(\.data\)"
+    )
+    if mk_base and ld_pin:
+        base_val = int(mk_base[1].group(1), 16)
+        pin_val = int(ld_pin[1].group(1), 16)
+        expect = ROM_BASE + pin_val
+        ok = base_val == expect
+        status = "PASS" if ok else "FAIL"
+        print(
+            f"  [{status}] banim base  Makefile:{mk_base[0]} -b {base_val:#08x}"
+            f"  ==  ROM_BASE + ldscript:{ld_pin[0]} pin {pin_val:#x} ({expect:#08x})"
+        )
+        if not ok:
+            failures.append(
+                f"banim base {base_val:#x} != {expect:#x} "
+                f"(Makefile -b vs ldscript pin desynced)"
+            )
+    else:
+        print(
+            "  [WARN] could not locate both banim base (Makefile -b) and "
+            "ldscript banim pin; coupling not checked"
+        )
+
+    # ROM size: objcopy --pad-to vs ROM_BASE + length implied by the top pin.
+    mk_pad = first_match(args.makefile, r"--pad-to\s+(0x[0-9a-fA-F]+)")
+    if mk_pad:
+        pad_val = int(mk_pad[1].group(1), 16)
+        ok = pad_val == 0x09000000  # 16 MB cart: 0x08000000 + 0x01000000
+        status = "PASS" if ok else "FAIL"
+        print(
+            f"  [{status}] ROM pad-to  Makefile:{mk_pad[0]} --pad-to {pad_val:#x}"
+            f"  ==  0x09000000 (16 MB cart)"
+        )
+        if not ok:
+            failures.append(f"--pad-to {pad_val:#x} != 0x09000000")
+    else:
+        print("  [WARN] --pad-to not found; ROM-size constant not checked")
+
+    # ---- 3. Pinned layout constants (informational) ----------------------
+    print("\n" + "-" * 72)
+    print("Layout pins in ldscript.txt (non-shiftable BY CONSTRUCTION):")
+    print("-" * 72)
+    pin_rx = re.compile(r"\.\s*=\s*(0x[0-9a-fA-F]+)\s*;\s*(\S+)")
+    in_rom = False
+    npins = 0
+    with open(args.ldscript, encoding="utf-8", errors="replace") as fh:
+        for lineno, line in enumerate(fh, 1):
+            if "ROM __text_start" in line:
+                in_rom = True
+            if in_rom:
+                m = pin_rx.search(line)
+                if m and int(m.group(1), 16) >= 0xC00000:
+                    npins += 1
+                    print(f"  L{lineno:<5} . = {m.group(1):<10} {m.group(2)}")
+    print(
+        f"\n  {npins} pinned block(s). These keep data at a fixed ROM offset; making\n"
+        f"  them shiftable (un-pinning + relocating internal pointers) is separate,\n"
+        f"  larger work. The banim base above should derive from its pin (one source\n"
+        f"  of truth) so a shift can never desync the pair."
+    )
+
+    # ---- verdict ----------------------------------------------------------
+    print("\n" + "=" * 72)
+    if failures:
+        print("RESULT: FAIL")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("RESULT: PASS (coupled build-system constants are consistent)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shiftcheck/scan_offsets.py
+++ b/scripts/shiftcheck/scan_offsets.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Layer 1b of the shiftability harness: cross-resource hardcoded-offset scan.
+
+`scan_relocs.py` asks "which ROM-pointer words carry NO relocation?" (raw address
+literals). This tool asks the complementary question: of the words that DO carry a
+relocation, which point at a *different* resource than the symbol they relocate
+against -- i.e. `&ResourceA + hardcoded_offset` that actually lands in ResourceB.
+
+Why that matters: if such a word is written `Img_A + 0x280` (a literal offset that
+happens to equal `&Img_B` in the current layout), the linker tracks Img_A, not
+Img_B. Grow Img_A and Img_B slides down, but `Img_A + 0x280` stays put -> the word
+now points into the middle of the enlarged Img_A. The shiftable form is a direct
+`&Img_B` reference (addend 0), which the linker relocates to follow Img_B.
+
+Detection: for every retained R_ARM_ABS32 against a NAMED symbol S (section symbols
+like `ROM` are skipped -- binutils collapses local/asm-label targets onto them, so
+the source symbol is lost; those must be caught at the source level, see
+scan_raw_casts.sh), compute addend = word - S.value and the symbol T that owns the
+word. T != S means the offset crosses out of S into T.
+
+Buckets:
+  HIGH   word == T.start, location in a DATA section, addend > 0 -- a stored pointer
+         that reaches the START of a different resource. This is the actionable
+         "A + offset = &B" bug shape (e.g. the gOpenLimitViewImgLut entry that was
+         `Img_LimitViewSquares + 0x280` instead of `gUnkData_34`).
+  REVIEW everything else: negative addends and mid-symbol landings are almost always
+         compiler artifacts -- `&arr[-1]` 1-based-index bias bases and base-register
+         reuse in .text literal pools, which the compiler regenerates correctly on
+         every build (and which move with their object under a uniform shift).
+
+NOTE: the binary view cannot see offsets the compiler applies as a runtime `ADD #imm`
+(it reuses the base register, so the relocated word is the base with addend 0). Those
+are real but only visible in source -- run the source scans too. Exit nonzero if HIGH
+is non-empty.
+"""
+
+import argparse
+import bisect
+import re
+import subprocess
+import sys
+
+import _classify as C
+
+SECTION_SYMS = {"ROM", "__text_start", "Init"}
+
+
+def sh(cmd):
+    return subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+
+
+def parse_relocs(elf, readelf):
+    """Yield (offset, sym_value, sym_name) for ROM-located R_ARM_ABS32 relocs."""
+    rx = re.compile(
+        r"^([0-9a-fA-F]{8})\s+[0-9a-fA-F]{8}\s+R_ARM_ABS32\s+([0-9a-fA-F]{8})\s+(\S+)")
+    for ln in sh([readelf, "-r", "-W", elf]).splitlines():
+        m = rx.match(ln)
+        if not m:
+            continue
+        off, sv, nm = int(m.group(1), 16), int(m.group(2), 16), m.group(3)
+        if C.ROM_BASE <= off < C.ROM_HI:
+            yield off, sv, nm
+
+
+def parse_syms(elf, nm):
+    syms, section_names = [], set()
+    for ln in sh([nm, elf]).splitlines():
+        p = ln.split()
+        if len(p) < 3:
+            continue
+        try:
+            a = int(p[0], 16)
+        except ValueError:
+            continue
+        typ, name = p[1], " ".join(p[2:])
+        if C.ROM_BASE <= a < C.ROM_HI:
+            syms.append((a, name))
+            if typ in ("a", "N") or name.startswith(".") or name in SECTION_SYMS:
+                section_names.add(name)
+    syms.sort()
+    return syms, section_names
+
+
+def parse_map_text_ranges(path):
+    """Return sorted .text VMA ranges (to tell code literal pools from data tables)."""
+    rx = re.compile(r"^\s+\.(\w[\w.]*)\s+(0x[0-9a-fA-F]+)\s+(0x[0-9a-fA-F]+)\s+(\S+\.o)\b")
+    out = []
+    for ln in open(path, errors="replace"):
+        m = rx.match(ln)
+        if not m:
+            continue
+        a, s, sect = int(m.group(2), 16), int(m.group(3), 16), m.group(1)
+        if s and sect == "text" and C.ROM_BASE <= a < C.ROM_HI:
+            out.append((a, a + s))
+    out.sort()
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--elf", default="fireemblem8_relocs.elf")
+    ap.add_argument("--gba", default="fireemblem8.gba")
+    ap.add_argument("--map", default="fireemblem8.map")
+    ap.add_argument("--ref-elf", default="fireemblem8.elf")
+    ap.add_argument("--prefix", default="arm-none-eabi-")
+    args = ap.parse_args()
+
+    import numpy as np
+    words = np.frombuffer(open(args.gba, "rb").read(), dtype="<u4")
+    syms, section_names = parse_syms(args.ref_elf, args.prefix + "nm")
+    starts = [s[0] for s in syms]
+    text = parse_map_text_ranges(args.map)
+    tstarts = [t[0] for t in text]
+
+    def owner(v):
+        i = bisect.bisect_right(starts, v) - 1
+        return syms[i] if i >= 0 else (None, None)
+
+    def in_text(o):
+        i = bisect.bisect_right(tstarts, o) - 1
+        return i >= 0 and text[i][0] <= o < text[i][1]
+
+    high, review = {}, {}
+    for off, sv, nm in parse_relocs(args.elf, args.prefix + "readelf"):
+        if nm in section_names:
+            continue
+        w = int(words[(off - C.ROM_BASE) // 4])
+        if w == sv or not (C.MIN_PTR <= w < C.ROM_HI):
+            continue
+        t_start, t_name = owner(w)
+        b_start, _ = owner(sv)
+        if t_start is None or b_start == t_start:
+            continue  # offset stays within the base symbol -> safe (relative)
+        rec = dict(off=off, sv=sv, w=w, addend=w - sv, base=nm, tgt=t_name,
+                   tdelta=w - t_start)
+        actionable = (w == t_start and not in_text(off) and (w - sv) > 0)
+        (high if actionable else review).setdefault((nm, t_name), []).append(rec)
+
+    def dump(d, title):
+        n = sum(len(v) for v in d.values())
+        print(f"\n{title}: {n} instance(s) in {len(d)} pair(s)")
+        for (b, t), lst in sorted(d.items(), key=lambda kv: -len(kv[1])):
+            r = lst[0]
+            note = "" if r["tdelta"] == 0 else f" (mid-{t}+0x{r['tdelta']:X})"
+            print(f"    {len(lst):4d}  {b} {'+' if r['addend']>=0 else '-'}0x"
+                  f"{abs(r['addend']):X} -> {t}{note}   @0x{r['off']:08X}")
+        return n
+
+    print("=" * 78)
+    print("Layer 1b - cross-resource hardcoded-offset scan (wrong-base relocations)")
+    print("=" * 78)
+    n_high = dump(high, "[A] HIGH (data pointer reaches a different resource's START)")
+    dump(review, "[B] REVIEW (compiler bias-base / .text reuse / mid-symbol -- usually benign)")
+    print("\n" + "=" * 78)
+    if n_high:
+        print(f"RESULT: {n_high} HIGH cross-resource offset(s) -> reference the target "
+              f"symbol directly (byte-identical, shiftable).")
+        return 1
+    print("RESULT: no HIGH cross-resource hardcoded offsets (named-global bases).")
+    print("        (Runtime-ADD offsets are invisible here -- see the source scans.)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shiftcheck/scan_raw_casts.sh
+++ b/scripts/shiftcheck/scan_raw_casts.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Source-level detector for the "redas" bug class: raw absolute-address pointers in
+# data that won't relocate (and break a shifted ROM). This is more reliable than the
+# binary delta-0 heuristic in scan_relocs.py -- it finds the pointer at its source.
+#
+#   1. C raw pointer casts to a ROM/RAM address, e.g. `.redas = (void *)0x88b6e28`
+#      or `(struct Foo *)0x080abcde`. Hardware 0x04-0x07 (IO/VRAM/OAM/palette) are
+#      legitimate fixed addresses and excluded.
+#   2. Raw 32-bit ROM-address literals in COMMITTED hand-written asm data
+#      (data_*/anim_*/const_data_*.s, asm/*.s, *.inc): `.4byte 0x08..` / `.word 0x08..`.
+#      (Compiler-intermediate .s are git-ignored and skipped.)
+#
+# A non-empty result is a candidate non-relocatable pointer to convert to a symbol
+# reference. Exit nonzero if any are found.
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+echo "== (1) C raw ROM/RAM pointer casts in typed data/source =="
+# The type may be multi-word (e.g. `unsigned char *`, `const struct Foo *`), so the
+# bare-identifier branch allows trailing words to avoid false negatives.
+c_hits=$(grep -rnE '\((const +)?(void|struct +[A-Za-z_]+|union +[A-Za-z_]+|u8|u16|u32|s8|s16|s32|[A-Za-z_]+( +[A-Za-z_]+)*) ?\*+\) ?0x0[2389][0-9A-Fa-f]{6}' \
+  src/ include/ 2>/dev/null | grep -vE '0x0[4567][0-9A-Fa-f]{6}')
+[ -n "$c_hits" ] && echo "$c_hits" || echo "  (none)"
+
+echo
+echo "== (2) raw .4byte/.word ROM-address literals in committed asm data =="
+asm_hits=""
+while IFS= read -r f; do
+  h=$(grep -HnE '\.(4byte|word|long)[[:space:]]+0x0[89][0-9A-Fa-f]{6}\b' "$f" 2>/dev/null)
+  [ -n "$h" ] && asm_hits+="$h"$'\n'
+done < <(git ls-files 'src/**/*.s' 'asm/*.s' 'src/**/*.inc' 'src/*.inc' 2>/dev/null \
+         | grep -E 'data_[^/]*\.s$|anim_[^/]*\.s$|const_data_[^/]*\.s$|^asm/|\.inc$')
+[ -n "$asm_hits" ] && printf '%s' "$asm_hits" || echo "  (none)"
+
+echo
+if [ -n "$c_hits" ] || [ -n "$asm_hits" ]; then
+  echo "RESULT: raw non-relocatable pointer(s) found -> convert each to a symbol reference"
+  exit 1
+fi
+echo "RESULT: no raw ROM/RAM pointer literals in source (the redas class is clean)"

--- a/scripts/shiftcheck/scan_relocs.py
+++ b/scripts/shiftcheck/scan_relocs.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Layer 1 of the shiftability harness: static relocation-coverage scan.
+
+In the matching build every pointer holds the correct value because everything
+sits at its original address. A pointer written as a SYMBOL reference (`&foo`)
+compiles to a word the linker RELOCATES (R_ARM_ABS32); a pointer written as a raw
+literal (`(u8*)0x08A39148`) compiles to a word with NO relocation. So a 4-byte
+word that looks like a ROM pointer but carries no relocation is a hardcoded-pointer
+suspect that would break if the layout shifted.
+
+Perfect static precision is impossible (incbin'd audio/graphics/animation data
+contains byte runs that coincidentally look like unrelocated ROM pointers), so the
+shared classifier (_classify.py) ranks suspects: HIGH = a coherent pointer table in
+a MIXED object (one that also has real relocated pointers); lower buckets for
+scattered words, pure data blobs, and blob-internal self-references. The HIGH
+bucket is the actionable worklist; the tool exits nonzero when it is non-empty.
+Layers 2 (differential shift) and 3 (runtime) confirm the rest.
+
+Needs the production ELF re-linked with `-q` (relocs retained), the .gba, the .map,
+and `nm`. numpy for the bulk scan.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+
+import numpy as np
+
+import _classify as C
+
+
+def sh(cmd):
+    return subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+
+
+def abs32_offsets(elf, readelf):
+    out = sh([readelf, "-r", elf])
+    offs = []
+    rx = re.compile(r"^([0-9a-fA-F]{8})\s+[0-9a-fA-F]{8}\s+R_ARM_ABS32")
+    for ln in out.splitlines():
+        m = rx.match(ln)
+        if m:
+            o = int(m.group(1), 16)
+            if C.ROM_BASE <= o < C.ROM_HI:
+                offs.append(o - C.ROM_BASE)
+    return offs
+
+
+def parse_map(path):
+    rx = re.compile(r"^\s+\.(\w[\w.]*)\s+(0x[0-9a-fA-F]+)\s+(0x[0-9a-fA-F]+)\s+(\S+\.o)\b")
+    ranges = []
+    for ln in open(path, errors="replace"):
+        m = rx.match(ln)
+        if not m:
+            continue
+        a, s = int(m.group(2), 16), int(m.group(3), 16)
+        if s and C.ROM_BASE <= a < C.ROM_HI:
+            ranges.append((a, a + s, m.group(4), m.group(1)))
+    ranges.sort()
+    return ranges
+
+
+def parse_nm(elf, nm):
+    syms = []
+    for ln in sh([nm, "-n", elf]).splitlines():
+        p = ln.split()
+        if len(p) < 3:
+            continue
+        try:
+            a = int(p[0], 16)
+        except ValueError:
+            continue
+        if C.ROM_BASE <= a < C.ROM_HI:
+            syms.append((a, " ".join(p[2:])))
+    syms.sort()
+    return syms
+
+
+def load_allowlist(path):
+    out = []
+    try:
+        for ln in open(path, errors="replace"):
+            ln = ln.split("#", 1)[0].strip()
+            if not ln:
+                continue
+            p = ln.split()
+            lo = int(p[0], 16)
+            hi = int(p[1], 16) if len(p) > 1 else lo + 1
+            out.append((lo, hi))
+    except FileNotFoundError:
+        pass
+    return sorted(out)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--elf", default="fireemblem8_relocs.elf")
+    ap.add_argument("--gba", default="fireemblem8.gba")
+    ap.add_argument("--map", default="fireemblem8.map")
+    ap.add_argument("--allowlist", default="scripts/shiftcheck/allowlist.txt")
+    ap.add_argument("--prefix", default="arm-none-eabi-")
+    ap.add_argument("--ref-elf", default="fireemblem8.elf")
+    ap.add_argument("--include-text", action="store_true")
+    ap.add_argument("--max-list", type=int, default=80)
+    args = ap.parse_args()
+
+    words = np.frombuffer(open(args.gba, "rb").read(), dtype="<u4").astype(np.int64)
+    relocated = np.zeros(words.size, dtype=bool)
+    idx = np.array(abs32_offsets(args.elf, args.prefix + "readelf"),
+                   dtype=np.int64) // 4
+    idx = idx[idx < words.size]
+    relocated[idx] = True
+
+    buckets = C.classify(
+        words, relocated,
+        parse_map(args.map), parse_nm(args.ref_elf, args.prefix + "nm"),
+        allow=load_allowlist(args.allowlist), include_text=args.include_text)
+
+    n_high = C.report(
+        buckets,
+        "Layer 1 - relocation-coverage scan (unrelocated ROM-pointer words)",
+        max_list=args.max_list)
+
+    print("\n" + "=" * 78)
+    if n_high:
+        print(f"RESULT: {n_high} HIGH-CONFIDENCE suspect(s) -> shiftable-region "
+              f"hardcoded pointers to fix. Confirm with `make shiftcheck-diff`.")
+        return 1
+    print("RESULT: no high-confidence shiftable-region suspects.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shiftcheck/tas/README.md
+++ b/scripts/shiftcheck/tas/README.md
@@ -1,0 +1,68 @@
+# Full-game TAS shiftability validation (GBAHawk)
+
+The deepest shiftability check: replay a **full-game TAS to the ending** on both the
+matching ROM and a shifted ROM, and confirm they render identically. This exercises
+*every* screen the run visits — battles, the world map, chapter transitions, the
+class-reel screen where `gOpinfo_1` is used, the ending — far beyond what the mGBA
+boot/title/menu oracle (`../run_dynamic.py`) reaches.
+
+A TAS is a fixed per-frame input log recorded against one ROM. Our build is
+byte-identical to the original, so the TAS syncs on it. Feeding the **same inputs**
+to a correctly-shifted ROM must produce the **same frames**; a hardcoded pointer
+that didn't relocate shows up as a framebuffer divergence (render bug) or a
+desync/crash (the run stops matching / never reaches the ending). RAM is *not* a
+valid oracle — it holds relocated pointers (= shifted addresses); only the
+**framebuffer** is.
+
+## Pieces
+
+| File | Role |
+| --- | --- |
+| `get_gbahawk.sh` | Download the portable GBAHawk (default `v2.1.1`, the movie's `emuVersion`) and place the GBA BIOS in its `Firmware/`. |
+| `repack_movie.py` | Copy the `.gbmv` (a BK2 zip) and rewrite `Header.txt`'s `SHA1` to the shifted ROM's, so GBAHawk plays the same inputs on it with no hash-mismatch dialog. |
+| `fingerprint.lua` | GBAHawk Lua: replay the loaded movie headless (`invisibleemulation`), screenshot the framebuffer at ~40 evenly-spaced checkpoints + the final frame, write a manifest, `client.exit()`. |
+| `run_tas.sh` | Drive `GBAHawk.exe` from WSL2 for one (rom, movie, tag). |
+| `compare.py` | Hash the matching vs shifted checkpoint PNGs; report identical / first divergent checkpoint and whether both reached the movie end. |
+
+## How to run
+
+```bash
+# 1. emulator + BIOS. The movie requires the real GBA BIOS (sha1 300c20df...);
+#    get_gbahawk.sh downloads it (and the portable emulator) and verifies the sha1.
+#    Pass a local gba_bios.bin as the 3rd arg to use your own instead.
+scripts/shiftcheck/tas/get_gbahawk.sh v2.1.1 /mnt/c/gbahawk_test [/path/to/gba_bios.bin]
+# 2. movie + matching ROM into the C:\ working dir; build + stage the shifted ROM
+#    (reuse diff_shift.build_shifted) and repack the movie for it:
+python3 scripts/shiftcheck/tas/repack_movie.py <movie.gbmv> <shifted.gba> <shifted.gbmv>
+# 3. replay both (parallel = two GBAHawk instances, ~53 min each at ~80 fps), then
+python3 scripts/shiftcheck/tas/compare.py /mnt/c/gbahawk_test/out matching shifted
+```
+
+## Confirmed setup (this run)
+
+- TAS: `vykan12-v2-fesacredstones.gbmv` (254,468 frames, ~71 min). Its `Header.txt`
+  `SHA1 = C25B145E…` — **exactly our build**, so the matching ROM is recognized.
+- Requires the real GBA BIOS (`GBA_Firmware_Bios 300C20DF…`); GBAHawk auto-resolves
+  it from `Firmware/` (`Active Firmwares: GBA+Bios : 300C20DF…`).
+- Use GBAHawk **v2.1.1** (the movie's `emuVersion`); the host's old v2.3.2 risked a
+  core-version desync.
+- Shift: `+0x40000` (reuses the Layer-2 shifted-ROM build).
+- `invisibleemulation` keeps `client.screenshot()` byte-identical (verified) — frame
+  3000 hashed the same with and without it.
+
+## Result
+
+_(populated after the run; "identical at all checkpoints incl. the ending" ⇒ the
+game was beaten identically after a layout shift — shiftable across the whole run.)_
+
+## Notes / gotchas
+
+- `.gbmv` = BizHawk BK2 zip (`Header.txt` / `Input Log.txt` / `SyncSettings.json`).
+- Files must live under a `C:\` working dir (`/mnt/c/...`); the Windows `GBAHawk.exe`
+  can't conveniently read the WSL filesystem. Use Windows-style path args.
+- GBAHawk's accurate core runs ~80 fps; `invisibleemulation` only saves ~10%, so the
+  cost is the ~254k frames. Two parallel instances (separate extracted dirs to avoid
+  `config.ini` clashes) halve wall-clock.
+- This is intentionally *not* wired into `make`/CI: it needs the copyrighted BIOS,
+  the Windows emulator, the external movie, and ~1 hour. It is a manual deep-proof on
+  top of the static layers + the mGBA runtime layer.

--- a/scripts/shiftcheck/tas/capture.lua
+++ b/scripts/shiftcheck/tas/capture.lua
@@ -1,0 +1,59 @@
+-- GBAHawk Lua: during a movie replay, at each checkpoint frame dump ALL GBA memory
+-- regions (EWRAM, IWRAM, Palette, VRAM, OAM) + a screenshot, and optionally a
+-- savestate, for matching-vs-shifted diffing (ramdiff.py).
+--
+-- EWRAM/IWRAM hold game state (incl. FE8's render buffers gOam/gBGxTilemapBuffer/
+-- gPaletteBuffer); Palette(0x05)/VRAM(0x06)/OAM(0x07) hold the final composited
+-- output, which maps directly to screenshot differences when troubleshooting a UI
+-- divergence.
+--
+-- cfg (out/cfg.txt): line1 = tag, line2 = comma/space-separated dump frames,
+--                    line3 = savestate frame (0 = none).
+
+local OUT = "C:\\gbahawk_test\\out\\"
+local cfg = io.open(OUT .. "cfg.txt", "r")
+local tag = cfg:read("*l")
+local frames = {}
+for x in cfg:read("*l"):gmatch("%d+") do frames[tonumber(x)] = true end
+local ssf = tonumber(cfg:read("*l")) or 0
+cfg:close()
+
+client.invisibleemulation(true)
+if client.speedmode then client.speedmode(6399) end
+memory.usememorydomain("System Bus")
+
+-- whole GBA memory map except ROM (0x08, the program) and BIOS (0x00, fixed).
+local REGIONS = {
+  { "ew",   0x02000000, 0x40000 },  -- EWRAM (game state, incl. FE8 render buffers)
+  { "iw",   0x03000000, 0x08000 },  -- IWRAM
+  { "io",   0x04000000, 0x00400 },  -- I/O regs (DISPCNT, DMA src/dst pointers, ...)
+  { "pal",  0x05000000, 0x00400 },  -- Palette
+  { "vram", 0x06000000, 0x18000 },  -- VRAM (tiles)
+  { "oam",  0x07000000, 0x00400 },  -- OAM (sprites)
+  { "sram", 0x0E000000, 0x10000 },  -- GamePak save (battery/Flash); empty if Use_SRAM=false
+}
+
+local function dump(addr, len, path)
+  local t = memory.readbyterange(addr, len)
+  local b = {}
+  for i = 0, len - 1 do b[i + 1] = string.char(t[i] or 0) end
+  local f = io.open(path, "wb"); f:write(table.concat(b)); f:close()
+end
+
+local maxf = 0
+for fr in pairs(frames) do if fr > maxf then maxf = fr end end
+
+while emu.framecount() <= maxf do
+  local fc = emu.framecount()
+  if ssf > 0 and fc == ssf then savestate.save(OUT .. tag .. "_" .. fc .. ".State") end
+  if frames[fc] then
+    client.screenshot(OUT .. tag .. "_" .. string.format("%07d", fc) .. ".png")
+    for _, r in ipairs(REGIONS) do
+      dump(r[2], r[3], OUT .. tag .. "_" .. fc .. "_" .. r[1] .. ".bin")
+    end
+  end
+  emu.frameadvance()
+end
+
+local d = io.open(OUT .. tag .. "_cap_done.txt", "w"); d:write("done@" .. emu.framecount()); d:close()
+client.exit()

--- a/scripts/shiftcheck/tas/compare.py
+++ b/scripts/shiftcheck/tas/compare.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Compare two GBAHawk TAS-replay runs (matching ROM vs shifted ROM).
+
+fingerprint.lua saves a PNG per checkpoint frame as <tag>_<frame7>.png and lists
+the frames in <tag>_manifest.txt, plus a <tag>_done.txt with the frame it reached.
+This hashes the corresponding PNGs and reports, per checkpoint, whether the shifted
+run rendered identically to the matching run -- and whether both reached the movie
+end. The framebuffer is the valid oracle (RAM legitimately differs because relocated
+pointers in RAM hold shifted addresses).
+
+Usage: compare.py <out_dir> <tagA=matching> <tagB=shifted>
+"""
+
+import argparse
+import hashlib
+import os
+import sys
+
+
+def sha(path):
+    return hashlib.sha1(open(path, "rb").read()).hexdigest()[:16] if os.path.exists(path) else None
+
+
+def read_manifest(d, tag):
+    p = os.path.join(d, f"{tag}_manifest.txt")
+    if not os.path.exists(p):
+        return []
+    return [int(x) for x in open(p).read().split()]
+
+
+def read_done(d, tag):
+    p = os.path.join(d, f"{tag}_done.txt")
+    return open(p).read().strip() if os.path.exists(p) else "(no done marker)"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("out_dir")
+    ap.add_argument("tagA", nargs="?", default="matching")
+    ap.add_argument("tagB", nargs="?", default="shifted")
+    args = ap.parse_args()
+    d = args.out_dir
+
+    fa, fb = read_manifest(d, args.tagA), read_manifest(d, args.tagB)
+    frames = sorted(set(fa) & set(fb))
+    print("=" * 70)
+    print(f"GBAHawk TAS replay comparison: {args.tagA} vs {args.tagB}")
+    print("=" * 70)
+    print(f"{args.tagA}: {read_done(d, args.tagA)}")
+    print(f"{args.tagB}: {read_done(d, args.tagB)}")
+    if fa != fb:
+        print(f"NOTE: manifests differ ({len(fa)} vs {len(fb)} checkpoints); "
+              f"comparing the {len(frames)} common frames.")
+    print("-" * 70)
+
+    diverged = []
+    for fr in frames:
+        name = f"_{fr:07d}.png"
+        ha = sha(os.path.join(d, args.tagA + name))
+        hb = sha(os.path.join(d, args.tagB + name))
+        ok = ha is not None and ha == hb
+        if not ok:
+            diverged.append(fr)
+        mark = "OK" if ok else "DIVERGE"
+        print(f"  frame {fr:7d}: {args.tagA}={ha} {args.tagB}={hb}  [{mark}]")
+
+    print("=" * 70)
+    if not frames:
+        print("RESULT: no comparable checkpoints (a run did not produce screenshots).")
+        return 2
+    if diverged:
+        print(f"RESULT: DIVERGENCE at {len(diverged)} checkpoint(s); first at frame "
+              f"{diverged[0]} -> a shift-sensitive pointer renders differently there.")
+        return 1
+    print(f"RESULT: identical at all {len(frames)} checkpoints. If both reached the "
+          f"movie end, the shifted ROM played the entire TAS to the ending "
+          f"identically -> shiftable across the whole run.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shiftcheck/tas/fingerprint.lua
+++ b/scripts/shiftcheck/tas/fingerprint.lua
@@ -1,0 +1,47 @@
+-- GBAHawk Lua: replay the loaded movie headless and screenshot the framebuffer at
+-- evenly-spaced checkpoints + the final frame, then exit. Run via:
+--   GBAHawk.exe <rom> --movie=<gbmv> --lua=fingerprint.lua
+-- Config from out/cfg.txt: line1 = tag (output prefix), line2 = ncheckpoints,
+-- line3 = maxframe (0 => full movie length; >0 stops early for testing).
+--
+-- The framebuffer is the valid shiftability oracle: a correctly-shifted ROM, fed
+-- the same TAS inputs, must render identical frames; RAM is NOT comparable (it
+-- holds relocated pointers = shifted addresses). invisibleemulation skips the GUI
+-- blit (verified to keep client.screenshot() byte-identical) for a little speed.
+
+local OUT = "C:\\gbahawk_test\\out\\"
+
+local cfg = io.open(OUT .. "cfg.txt", "r")
+local tag = cfg:read("*l")
+local ncp = tonumber(cfg:read("*l"))
+local maxf = tonumber(cfg:read("*l"))
+cfg:close()
+
+client.invisibleemulation(true)
+if client.speedmode then client.speedmode(6399) end
+
+local len = movie.isloaded() and movie.length() or 0
+local limit = len
+if maxf and maxf > 0 and maxf < len then limit = maxf end
+
+local cps = {}
+for k = 1, ncp do cps[math.floor(k * limit / ncp)] = true end
+cps[limit - 1] = true
+
+local man = io.open(OUT .. tag .. "_manifest.txt", "w")
+while emu.framecount() < limit do
+  local fc = emu.framecount()
+  if cps[fc] then
+    client.screenshot(OUT .. tag .. "_" .. string.format("%07d", fc) .. ".png")
+    man:write(fc .. "\n"); man:flush()
+  end
+  emu.frameadvance()
+end
+local fc = emu.framecount()
+client.screenshot(OUT .. tag .. "_" .. string.format("%07d", fc) .. ".png")
+man:write(fc .. "\n"); man:close()
+
+local d = io.open(OUT .. tag .. "_done.txt", "w")
+d:write("reached=" .. fc .. " movie_length=" .. len .. " limit=" .. limit)
+d:close()
+client.exit()

--- a/scripts/shiftcheck/tas/get_gbahawk.sh
+++ b/scripts/shiftcheck/tas/get_gbahawk.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Fetch the portable GBAHawk emulator + stage it for the TAS replay validation.
+# GBAHawk is portable (no install). Run from WSL2; everything lands under a
+# Windows-accessible working dir so the Windows GBAHawk.exe can read it.
+#
+# Usage: get_gbahawk.sh [version] [work_dir] [gba_bios_path]
+#   version       default v2.1.1 (the version the vykan12 movie was recorded on;
+#                 use the movie's emuVersion to avoid core-version desync)
+#   work_dir      default /mnt/c/gbahawk_test  (= C:\gbahawk_test)
+#   gba_bios_path optional path to a local gba_bios.bin (sha1 300c20df...). If
+#                 omitted, the real GBA BIOS the movie requires is downloaded from
+#                 the public retrobios collection and verified by sha1.
+set -euo pipefail
+
+VER="${1:-v2.1.1}"
+# GBAHawk is a Windows binary driven from WSL2, so a Windows-visible path (/mnt/c) is
+# the default; fall back to a user-local dir when not under WSL (pure Linux/macOS).
+if [ -d /mnt/c ]; then WORK="${2:-/mnt/c/gbahawk_test}"; else WORK="${2:-$HOME/gbahawk_test}"; fi
+BIOS="${3:-}"
+BIOS_SHA1="300c20df6731a33952ded8c436f7f186d25d3492"
+BIOS_URL="https://raw.githubusercontent.com/Abdess/retrobios/main/bios/Nintendo/Game%20Boy%20Advance/gba_bios.bin"
+
+mkdir -p "$WORK"
+zip="$WORK/GBAHawk.${VER}.zip"
+url="https://github.com/alyosha-tas/GBAHawk/releases/download/${VER}/GBAHawk.${VER}.zip"
+[ -f "$zip" ] || { echo "downloading $url"; curl -L -s -o "$zip" "$url"; }
+
+dest="$WORK/GBAHawk_${VER}"
+python3 -c "import zipfile,sys; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" "$zip" "$dest"
+exe="$(find "$dest" -maxdepth 2 -iname GBAHawk.exe | head -1)"
+[ -n "$exe" ] || { echo "GBAHawk.exe not found after extract" >&2; exit 1; }
+echo "extracted: $exe"
+
+# The movie requires the real GBA BIOS (sha1 300c20df...). Use a local copy if
+# given, else download it from the public retrobios collection; verify the sha1.
+fw="$(dirname "$exe")/Firmware/gba_bios.bin"
+if [ -z "$BIOS" ]; then
+  BIOS="$WORK/gba_bios.bin"
+  [ -f "$BIOS" ] || { echo "downloading GBA BIOS from $BIOS_URL"; curl -L -s -o "$BIOS" "$BIOS_URL"; }
+fi
+got="$(sha1sum "$BIOS" | cut -d' ' -f1)"
+[ "$got" = "$BIOS_SHA1" ] || { echo "GBA BIOS sha1 $got != $BIOS_SHA1 (need the real BIOS)" >&2; exit 1; }
+cp "$BIOS" "$fw"
+echo "placed GBA BIOS in Firmware/ (sha1 ok)"
+echo "GBAHAWK_EXE=$exe"

--- a/scripts/shiftcheck/tas/live_compare.sh
+++ b/scripts/shiftcheck/tas/live_compare.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Live checkpoint comparison: as the (slower) shifted replay writes each checkpoint
+# screenshot, compare it to the matching replay's (already produced, since matching
+# runs ahead). Reports OK/DIVERGE per checkpoint in real time; exits when shifted
+# finishes or a divergence is confirmed.
+OUT="${1:-/mnt/c/gbahawk_test/out}"
+# Portable file mtime (epoch seconds): GNU `stat -c %Y` vs BSD/macOS `stat -f %m`.
+mtime() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"; }
+declare -A seen
+ndiv=0; nok=0
+echo "live-compare started $(date +%H:%M:%S)  (OUT=$OUT)"
+while true; do
+  for f in "$OUT"/shifted_*.png; do
+    [ -e "$f" ] || continue
+    fr=$(basename "$f" .png); fr=${fr#shifted_}
+    [ -n "${seen[$fr]:-}" ] && continue
+    m="$OUT/matching_${fr}.png"
+    [ -f "$m" ] || continue
+    # stability guard: skip if written in the last 3s (avoid partial-write false diff)
+    age=$(( $(date +%s) - $(mtime "$f") ))
+    [ "$age" -lt 3 ] && continue
+    s=$(sha1sum "$f" | cut -d' ' -f1); mm=$(sha1sum "$m" | cut -d' ' -f1)
+    seen[$fr]=1
+    if [ "$s" = "$mm" ]; then
+      nok=$((nok+1)); echo "$(date +%H:%M:%S)  frame ${fr}: OK   (${nok} ok, ${ndiv} diverge)"
+    else
+      ndiv=$((ndiv+1)); echo "$(date +%H:%M:%S)  frame ${fr}: *** DIVERGE ***  shifted=$s matching=$mm"
+    fi
+  done
+  if [ -f "$OUT/shifted_done.txt" ]; then
+    echo "shifted reached the end: $(cat "$OUT/shifted_done.txt")"
+    echo "FINAL: $nok checkpoints OK, $ndiv divergent"
+    break
+  fi
+  sleep 12
+done

--- a/scripts/shiftcheck/tas/proc_compare.py
+++ b/scripts/shiftcheck/tas/proc_compare.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Compare the live Proc array (matching vs shifted ROM) from EWRAM dumps.
+
+The engine is driven by Procs (src/proc.c, sProcArray[64] @ 0x02024e68, stride 0x6C).
+Every active proc holds ROM pointers: proc_script@0, proc_scrCur@4, proc_endCb@8,
+proc_idleCb@0xC, proc_name@0x10. In a correctly-shifted ROM every one of these must
+be matching+SHIFT. A field that stays UNSHIFTED (== matching) came from a hardcoded
+pointer -- the bug -- and its symbol names the culprit ProcCmd table / routine.
+
+Usage: proc_compare.py <frame> [--dir DIR] [--elf ELF] [--shift 0x40000]
+"""
+
+import argparse
+import bisect
+import struct
+import subprocess
+import sys
+
+ARRAY = 0x02024E68
+EW_BASE = 0x02000000
+STRIDE = 0x6C
+COUNT = 64
+FIELDS = [("proc_script", 0x00), ("proc_scrCur", 0x04), ("proc_endCb", 0x08),
+          ("proc_idleCb", 0x0C), ("proc_name", 0x10)]
+ROM_LO, ROM_HI = 0x08000000, 0x0A000000
+
+
+def rom_syms(elf, nm):
+    out = subprocess.run([nm, "-n", elf], capture_output=True, text=True).stdout
+    syms = []
+    for ln in out.splitlines():
+        p = ln.split()
+        if len(p) < 3:
+            continue
+        try:
+            a = int(p[0], 16)
+        except ValueError:
+            continue
+        if ROM_LO <= a < ROM_HI:
+            syms.append((a, " ".join(p[2:])))
+    syms.sort()
+    return syms
+
+
+def sym_of(syms, addrs, a):
+    if not (ROM_LO <= a < ROM_HI):
+        return None
+    i = bisect.bisect_right(addrs, a) - 1
+    if i >= 0:
+        return f"{syms[i][1]}+0x{a - syms[i][0]:X}" if a != syms[i][0] else syms[i][1]
+    return "?"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("frame")
+    ap.add_argument("--dir", default="/mnt/c/gbahawk_test/out")
+    ap.add_argument("--elf", default="fireemblem8.elf")
+    ap.add_argument("--prefix", default="arm-none-eabi-")
+    ap.add_argument("--shift", default="0x40000")
+    args = ap.parse_args()
+    shift = int(args.shift, 0)
+    syms = rom_syms(args.elf, args.prefix + "nm")
+    addrs = [s[0] for s in syms]
+
+    m = open(f"{args.dir}/matching_{args.frame}_ew.bin", "rb").read()
+    s = open(f"{args.dir}/shifted_{args.frame}_ew.bin", "rb").read()
+    off0 = ARRAY - EW_BASE
+
+    def fields(buf, i):
+        base = off0 + i * STRIDE
+        return {name: struct.unpack_from("<I", buf, base + o)[0] for name, o in FIELDS}
+
+    print("=" * 78)
+    print(f"Proc array compare @ frame {args.frame}  (shifted should be matching+{shift:#x})")
+    print("=" * 78)
+    bugs = []
+    for i in range(COUNT):
+        mf = fields(m, i)
+        sf = fields(s, i)
+        m_active = mf["proc_script"] != 0
+        s_active = sf["proc_script"] != 0
+        if not m_active and not s_active:
+            continue
+        name = sym_of(syms, addrs, mf["proc_script"]) or "<none>"
+        # check each ROM-ptr field relocates
+        bad = []
+        for fn, _ in FIELDS:
+            mv, sv = mf[fn], sf[fn]
+            if mv == 0 and sv == 0:
+                continue
+            if ROM_LO <= mv < ROM_HI:
+                if sv != ((mv + shift) & 0xFFFFFFFF):
+                    # unshifted (==mv) is the hardcoded-pointer signature
+                    tag = "UNSHIFTED" if sv == mv else "MISMATCH"
+                    bad.append(f"{fn}={mv:#010x}->{sv:#010x} [{tag} {sym_of(syms,addrs,mv)}]")
+        flag = "  <<< BUG" if any("UNSHIFTED" in b for b in bad) else ""
+        if bad or (m_active != s_active):
+            state = ("M" if m_active else "-") + ("S" if s_active else "-")
+            print(f"\nslot {i:2d} [{state}] {name}{flag}")
+            for b in bad:
+                print(f"      {b}")
+            if any("UNSHIFTED" in b for b in bad):
+                bugs.append((i, name, bad))
+    print("\n" + "=" * 78)
+    if bugs:
+        print(f"RESULT: {len(bugs)} proc(s) with an UNSHIFTED (hardcoded) ROM pointer:")
+        for i, name, bad in bugs:
+            print(f"  slot {i}: {name}")
+    else:
+        print("RESULT: all proc ROM pointers relocated correctly at this frame "
+              "(divergence may be in proc DATA, not the script pointer).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shiftcheck/tas/ramdiff.py
+++ b/scripts/shiftcheck/tas/ramdiff.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Diff matching-vs-shifted memory dumps to find the real divergence.
+
+Regions (capture.lua writes <tag>_<frame>_<region>.bin):
+  ew (EWRAM 0x02), iw (IWRAM 0x03) -- game state. The shifted ROM's RAM here
+    legitimately differs wherever a correctly-relocated pointer is stored
+    (shifted = matching + SHIFT, value is a ROM pointer); those are benign and
+    excluded. The rest are REAL divergences, each resolved to its EWRAM/IWRAM
+    symbol so the diverged structure is named.
+  pal (Palette 0x05), vram (VRAM 0x06), oam (OAM 0x07) -- the final composited
+    output (what the screenshot shows). These hold NO pointers, so every differing
+    word is a real rendered-output difference, decoded to color index / tile /
+    sprite slot to localize a UI divergence.
+
+Usage: ramdiff.py <frame> [--dir DIR] [--elf ELF] [--shift 0x40000]
+"""
+
+import argparse
+import bisect
+import struct
+import subprocess
+import sys
+
+REGIONS = [  # (name, base, is_ram_with_pointers); whole map minus ROM/BIOS
+    ("ew", 0x02000000, True), ("iw", 0x03000000, True), ("io", 0x04000000, False),
+    ("pal", 0x05000000, False), ("vram", 0x06000000, False), ("oam", 0x07000000, False),
+    ("sram", 0x0E000000, False),
+]
+
+
+def ram_syms(elf, nm):
+    out = subprocess.run([nm, "-n", elf], capture_output=True, text=True).stdout
+    syms = []
+    for ln in out.splitlines():
+        p = ln.split()
+        if len(p) < 3:
+            continue
+        try:
+            a = int(p[0], 16)
+        except ValueError:
+            continue
+        if 0x02000000 <= a < 0x02040000 or 0x03000000 <= a < 0x03008000:
+            syms.append((a, " ".join(p[2:])))
+    syms.sort()
+    return syms
+
+
+def owner(syms, addrs, a):
+    i = bisect.bisect_right(addrs, a) - 1
+    return (syms[i][1], a - syms[i][0]) if i >= 0 else ("?", 0)
+
+
+def decode(name, off):
+    if name == "pal":
+        return f"color #{off // 2} ({'OBJ' if off >= 0x200 else 'BG'} pal {(off % 0x200)//0x20})"
+    if name == "oam":
+        return f"sprite {off // 8} attr{(off % 8)}"
+    if name == "vram":
+        return f"+0x{off:X} (tile ~{off // 32})"
+    return ""
+
+
+def diff_region(name, base, is_ram, mpath, spath, shift, syms, addrs, out):
+    try:
+        m = open(mpath, "rb").read()
+        s = open(spath, "rb").read()
+    except FileNotFoundError:
+        return False
+    n = min(len(m), len(s))
+    for i in range(0, n - 3, 4):
+        mw = struct.unpack_from("<I", m, i)[0]
+        sw = struct.unpack_from("<I", s, i)[0]
+        if mw == sw:
+            continue
+        if is_ram and 0x08000100 <= mw < 0x08C00000 and sw == ((mw + shift) & 0xFFFFFFFF):
+            continue  # benign relocated pointer
+        if is_ram:
+            sym, o = owner(syms, addrs, base + i)
+            label = f"{sym}+0x{o:X}"
+        else:
+            label = decode(name, i)
+        out.append((name, base + i, mw, sw, label))
+    return True
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("frame")
+    ap.add_argument("--dir", default="/mnt/c/gbahawk_test/out")
+    ap.add_argument("--elf", default="fireemblem8.elf")
+    ap.add_argument("--prefix", default="arm-none-eabi-")
+    ap.add_argument("--shift", default="0x40000")
+    ap.add_argument("--max", type=int, default=50)
+    args = ap.parse_args()
+    shift = int(args.shift, 0)
+    syms = ram_syms(args.elf, args.prefix + "nm")
+    addrs = [s[0] for s in syms]
+
+    total = []
+    present = []
+    for name, base, is_ram in REGIONS:
+        ok = diff_region(name, base, is_ram,
+                         f"{args.dir}/matching_{args.frame}_{name}.bin",
+                         f"{args.dir}/shifted_{args.frame}_{name}.bin",
+                         shift, syms, addrs, total)
+        if ok:
+            present.append(name)
+
+    print("=" * 74)
+    print(f"Memory divergence @ frame {args.frame}  (regions: {','.join(present) or 'none'})")
+    print("=" * 74)
+    from collections import Counter
+    byregion = Counter(t[0] for t in total)
+    print("by region: " + ", ".join(f"{r}={byregion.get(r,0)}" for r, _, _ in REGIONS))
+    bysym = Counter(t[4].split('+')[0] if t[0] in ("ew", "iw") else t[0] for t in total)
+    print("\nby owning symbol / region:")
+    for k, n in bysym.most_common(25):
+        print(f"  {n:5d}  {k}")
+    print("-" * 74)
+    for name, addr, mw, sw, label in total[: args.max]:
+        print(f"  [{name:4}] 0x{addr:08X} {label}: {mw:#010x} -> {sw:#010x}")
+    if len(total) > args.max:
+        print(f"  ... and {len(total) - args.max} more")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shiftcheck/tas/repack_movie.py
+++ b/scripts/shiftcheck/tas/repack_movie.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Repackage a GBAHawk .gbmv (BK2 zip) to target a different ROM.
+
+A GBMV's Header.txt records the ROM's SHA1; GBAHawk warns (a blocking dialog) when
+the loaded ROM's hash doesn't match. To replay the SAME inputs on the shifted ROM
+without a dialog, copy the movie verbatim but rewrite Header.txt's `SHA1` (and
+`GameName`) to the shifted ROM's. Everything else -- Input Log, SyncSettings, the
+required BIOS hash -- is unchanged, so the inputs and timing are identical.
+
+Usage: repack_movie.py <in.gbmv> <new_rom.gba> <out.gbmv> [--name "<GameName>"]
+"""
+
+import argparse
+import hashlib
+import sys
+import zipfile
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("in_movie")
+    ap.add_argument("rom")
+    ap.add_argument("out_movie")
+    ap.add_argument("--name", default=None, help="override GameName")
+    args = ap.parse_args()
+
+    sha1 = hashlib.sha1(open(args.rom, "rb").read()).hexdigest().upper()
+
+    zin = zipfile.ZipFile(args.in_movie, "r")
+    items = {}
+    for n in zin.namelist():
+        items[n] = zin.read(n)
+    zin.close()
+
+    hdr_name = next((n for n in items if n.lower() == "header.txt"), None)
+    if not hdr_name:
+        sys.exit("no Header.txt in movie")
+    out_lines = []
+    for line in items[hdr_name].decode("utf-8").splitlines():
+        if line.startswith("SHA1 "):
+            out_lines.append("SHA1 " + sha1)
+        elif args.name and line.startswith("GameName "):
+            out_lines.append("GameName " + args.name)
+        else:
+            out_lines.append(line)
+    items[hdr_name] = ("\n".join(out_lines) + "\n").encode("utf-8")
+
+    with zipfile.ZipFile(args.out_movie, "w", zipfile.ZIP_DEFLATED) as zout:
+        for n, data in items.items():
+            zout.writestr(n, data)
+    print(f"wrote {args.out_movie}: SHA1 -> {sha1}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shiftcheck/tas/run_tas.sh
+++ b/scripts/shiftcheck/tas/run_tas.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Drive GBAHawk (Windows, from WSL2) to replay a movie on a ROM and capture
+# checkpoint screenshots via fingerprint.lua. Sequential use (shared out/cfg.txt).
+#
+# Usage: run_tas.sh <rom_win> <movie_win> <tag> [ncheckpoints] [maxframe] [timeout_s]
+#   rom_win/movie_win : Windows-style paths (C:\...), readable by GBAHawk.exe
+#   tag               : output prefix (e.g. matching, shifted)
+#   ncheckpoints      : evenly-spaced screenshot count (default 40)
+#   maxframe          : stop early for testing (0 = full movie; default 0)
+#
+# Env: GBAHAWK_EXE (WSL path to GBAHawk.exe), WORK (WSL path to C:\gbahawk_test),
+#      LUA_WIN (Windows path to fingerprint.lua).
+set -euo pipefail
+
+ROM="$1"; MOVIE="$2"; TAG="$3"
+NCP="${4:-40}"; MAXF="${5:-0}"; TMO="${6:-7200}"
+
+WORK="${WORK:-/mnt/c/gbahawk_test}"
+GBAHAWK_EXE="${GBAHAWK_EXE:-$WORK/GBAHawk_2.1.1/GBAHawk v2.1.1/GBAHawk.exe}"
+LUA_WIN="${LUA_WIN:-C:\\gbahawk_test\\fingerprint.lua}"
+
+mkdir -p "$WORK/out"
+printf '%s\n%s\n%s\n' "$TAG" "$NCP" "$MAXF" > "$WORK/out/cfg.txt"
+rm -f "$WORK/out/${TAG}_"*.png "$WORK/out/${TAG}_manifest.txt" "$WORK/out/${TAG}_done.txt"
+
+echo "run_tas: tag=$TAG ncp=$NCP maxframe=$MAXF rom=$ROM"
+cd "$(dirname "$GBAHAWK_EXE")"
+timeout "$TMO" ./"$(basename "$GBAHAWK_EXE")" "$ROM" --movie="$MOVIE" --lua="$LUA_WIN"
+echo "run_tas: $TAG done -> $(cat "$WORK/out/${TAG}_done.txt" 2>/dev/null)"


### PR DESCRIPTION
## Shiftability QA harness (carved out of #744)

Following @CT075's [feedback on #744](https://github.com/FireEmblemUniverse/fireemblem8u/pull/744#issuecomment-4655424384) that the umbrella PR is too large to review as one unit, this is the first **self-contained slice** split out as a standalone PR. More will follow; #744 also now has a [commit-by-commit reviewer guide](https://github.com/FireEmblemUniverse/fireemblem8u/pull/744).

### What this adds
A multi-layer, **build-isolated** harness (`scripts/shiftcheck/`, `make shiftcheck*`, all `.PHONY`) that tests whether the ROM is *shiftable* — i.e. editable + recompilable without breaking pointer integrity. Byte-identity (`make compare`) does **not** prove this: a pointer stored as a raw absolute address carries no relocation and breaks the moment the layout moves.

| Layer | Check |
| --- | --- |
| 0 | build-system audit (hardcoded addresses in `Makefile`/ldscripts) |
| 1 | relocation-coverage scan (`ld --emit-relocs`; flag ROM words with no `R_ARM_ABS32`) |
| 1b | cross-resource offset scan (relocations against the *wrong* base symbol) |
| 2 | differential two-shift build (a real pointer tracks the shift; a literal stays put) |
| 3 | mGBA framebuffer oracle (libmgba) |
| 4 | full-game TAS replay (GBAHawk, `scripts/shiftcheck/tas/`) |

### Why it's safe to review/merge in isolation
- **ROM-neutral, byte-identical.** The targets never touch the matching build — the default `make`/`make compare` is unchanged (verified `make -n compare` parses identically). All the harness needs (`$(ALL_OBJECTS)`, `$(LDSCRIPT)`, `$(ELF)`, …) already exists in the Makefile.
- **Net-new files only** (`scripts/shiftcheck/`) + a `.PHONY` Makefile section + `clean` extensions. No source/data touched.

### Note
This adds the **tooling only**. Running `make shiftcheck` against the current tree flags the *pre-existing* hardcoded pointers it was built to catch (`opinfo` `gOpinfo_1`, chapter-7 `redas`, banim `FORCE_SPRITE`, cross-resource offsets). The **byte-identical fixes** for those, plus the full-game TAS validation that confirmed a `+0x40000`-shifted ROM beats the game identically, are in #744 and can land as focused follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
