### PR TITLE
Revisit `opinfo` (class reel)

### DIFF
--- a/data/data_A2EEF0.s
+++ b/data/data_A2EEF0.s
@@ -1,59 +1,59 @@
     .section .data
 
-	.global gUnknown_08A301B0
-gUnknown_08A301B0:  @ 0x08A301B0
+	.global Img_ClassReel_BigWeaponSprites
+Img_ClassReel_BigWeaponSprites:  @ 0x08A301B0
 	.incbin "baserom.gba", 0xA301B0, 0x5D0
 
 	.global gUnknown_08A30780
 gUnknown_08A30780:  @ 0x08A30780
 	.incbin "baserom.gba", 0xA30780, 0x80
 
-	.global gUnknown_08A30800
-gUnknown_08A30800:  @ 0x08A30800
+	.global Img_ClassReel_UiBox
+Img_ClassReel_UiBox:  @ 0x08A30800
 	.incbin "baserom.gba", 0xA30800, 0x178
 
-	.global gUnknown_08A30978
-gUnknown_08A30978:  @ 0x08A30978
+	.global Tsa_ClassReel_UiBox
+Tsa_ClassReel_UiBox:  @ 0x08A30978
 	.incbin "baserom.gba", 0xA30978, 0x4B4
 
-	.global gUnknown_08A30E2C
-gUnknown_08A30E2C:  @ 0x08A30E2C
+	.global Img_ClassReel_InfoBg
+Img_ClassReel_InfoBg:  @ 0x08A30E2C
 	.incbin "baserom.gba", 0xA30E2C, 0x465C
 
-	.global gUnknown_08A35488
-gUnknown_08A35488:  @ 0x08A35488
+	.global Tsa_ClassReel_InfoBg
+Tsa_ClassReel_InfoBg:  @ 0x08A35488
 	.incbin "baserom.gba", 0xA35488, 0x4B4
 
-	.global gUnknown_08A3593C
-gUnknown_08A3593C:  @ 0x08A3593C
+	.global Pal_ClassReel_InfoBg
+Pal_ClassReel_InfoBg:  @ 0x08A3593C
 	.incbin "baserom.gba", 0xA3593C, 0x100
 
-	.global gUnknown_08A35A3C
-gUnknown_08A35A3C:  @ 0x08A35A3C
+	.global Img_ClassReel_NameBg
+Img_ClassReel_NameBg:  @ 0x08A35A3C
 	.incbin "baserom.gba", 0xA35A3C, 0x594
 
-	.global gUnknown_08A35FD0
-gUnknown_08A35FD0:  @ 0x08A35FD0
+	.global Tsa_ClassReel_NameBg
+Tsa_ClassReel_NameBg:  @ 0x08A35FD0
 	.incbin "baserom.gba", 0xA35FD0, 0xF8
 
-	.global gUnknown_08A360C8
-gUnknown_08A360C8:  @ 0x08A360C8
+	.global Pal_ClassReel_NameBg
+Pal_ClassReel_NameBg:  @ 0x08A360C8
 	.incbin "baserom.gba", 0xA360C8, 0x20
 
-	.global gUnknown_08A360E8
-gUnknown_08A360E8:  @ 0x08A360E8
+	.global Img_ClassReelFiligree
+Img_ClassReelFiligree:  @ 0x08A360E8
 	.incbin "baserom.gba", 0xA360E8, 0x19C
 
-	.global gUnknown_08A36284
-gUnknown_08A36284:  @ 0x08A36284
+	.global Tsa_ClassReelFiligree
+Tsa_ClassReelFiligree:  @ 0x08A36284
 	.incbin "baserom.gba", 0xA36284, 0xB4
 
-	.global gUnknown_08A36338
-gUnknown_08A36338:  @ 0x08A36338
+	.global Img_ClassReel_ClassNameLetters
+Img_ClassReel_ClassNameLetters:  @ 0x08A36338
 	.incbin "baserom.gba", 0xA36338, 0xF88
 
-	.global gUnknown_08A372C0
-gUnknown_08A372C0:  @ 0x08A372C0
+	.global Pal_ClassReel_ClassNameLetters
+Pal_ClassReel_ClassNameLetters:  @ 0x08A372C0
 	.incbin "baserom.gba", 0xA372C0, 0x40
 
 	.global gUnknown_08A37300

--- a/data/data_B12A60.s
+++ b/data/data_B12A60.s
@@ -32,8 +32,8 @@ Pal_08B17B44:  @ 0x08B17B44
 Img_ChapterIntro_LensFlare:  @ 0x08B17B64
 	.incbin "baserom.gba", 0xB17B64, 0x1204
 
-	.global Tsa_08B18D68
-Tsa_08B18D68:  @ 0x08B18D68
+	.global Tsa_ClassReel_LensFlare
+Tsa_ClassReel_LensFlare:  @ 0x08B18D68
 	.incbin "baserom.gba", 0xB18D68, 0x16C
 
 	.global Pal_ChapterIntro_LensFlare

--- a/include/bmfx.h
+++ b/include/bmfx.h
@@ -145,7 +145,7 @@ extern struct ProcCmd ProcScr_ChapterIntro_RevealDecalSprite[];
 extern struct ProcCmd ProcScr_ChapterIntro_KeyListen[];
 extern u8 Img_CommGameBgScreen[];
 extern u8 Img_ChapterIntro_LensFlare[];
-extern u8 Tsa_08B18D68[];
+extern u8 Tsa_ClassReel_LensFlare[];
 extern u8 Img_ChapterIntro_Sprites[];
 extern u8 Pal_ChapterIntro_Sprites[];
 extern u16 Img_ChapterIntro_Fog[];

--- a/include/opinfo.h
+++ b/include/opinfo.h
@@ -152,7 +152,7 @@ struct OpInfoClassDisplayProc
     /* 34 */ struct ClassReelEnt * classReelEnt;
     /* 38 */ struct ClassReelAnimScr * script;
     /* 3C */ ProcPtr unk_3c;
-    /* 40 */ u8 unk_40[6];
+    /* 40 */ u8 stats[6];
     /* 46 */ u8 unk_46;
 };
 
@@ -168,7 +168,7 @@ struct OpInfoGaugeDrawProc
 };
 
 extern struct AnimBuffer gOpInfoData;
-extern struct AnimMagicFxBuffer gUnknown_0200A2D8;
+extern struct AnimMagicFxBuffer gClassReelMagicAnim;
 extern struct BanimUnkStructComm gUnk_Opinfo_0201DB00;
 
 // ??? ClassReel_Init(???);

--- a/include/opinfo.h
+++ b/include/opinfo.h
@@ -1,24 +1,37 @@
 #ifndef GUARD_OP_INFO_H
 #define GUARD_OP_INFO_H
 
-enum ClassReelScrOpCode {
-    CLASS_REEL_OP_0,
-    CLASS_REEL_OP_1,
-    CLASS_REEL_OP_2,
-    CLASS_REEL_OP_3,
-    CLASS_REEL_OP_4,
-    CLASS_REEL_OP_5,
-    CLASS_REEL_OP_6,
-    CLASS_REEL_OP_7,
-    CLASS_REEL_OP_8,
+enum ClassReelScrOpCode
+{
+    CLASS_REEL_OP_END = 0,
+    CLASS_REEL_OP_HIT_CLOSE = 1,
+    CLASS_REEL_OP_CRIT_CLOSE = 2,
+    CLASS_REEL_OP_RETURN_TO_STANDING = 3,
+    CLASS_REEL_OP_HIT_FAR = 4,
+    CLASS_REEL_OP_WAIT_FRAMES = 5,
+    CLASS_REEL_OP_DODGE = 6,
+    CLASS_REEL_OP_RETURN_TO_STANDING_ALT = 7,
+    CLASS_REEL_OP_ROUND_END = 8,
 };
 
-struct ClassReelAnimScr {
+#define CR_END                            { CLASS_REEL_OP_END, 0 }
+#define CR_ANIM_ROUND_HIT_CLOSE           { CLASS_REEL_OP_HIT_CLOSE, 0 }
+#define CR_ANIM_ROUND_CRIT_CLOSE          { CLASS_REEL_OP_CRIT_CLOSE, 0 }
+#define CR_RETURN_TO_STANDING             { CLASS_REEL_OP_RETURN_TO_STANDING, 0 }
+#define CR_ANIM_ROUND_NONCRIT_FAR         { CLASS_REEL_OP_HIT_FAR, 0 }
+#define CR_WAIT(frames)                   { CLASS_REEL_OP_WAIT_FRAMES, (frames) }
+#define CR_ANIM_ROUND_TAKING_MISS_CLOSE   { CLASS_REEL_OP_DODGE, 0 }
+#define CR_RETURN_TO_STANDING_ALT         { CLASS_REEL_OP_RETURN_TO_STANDING_ALT, 0 }
+#define CR_WAIT_ROUND_END                 { CLASS_REEL_OP_ROUND_END, 0 }
+
+struct ClassReelAnimScr
+{
     u16 opCode : 8;
     u16 extra  : 8;
 } __attribute__((packed));
 
-struct ClassReelEnt {
+struct ClassReelEnt
+{
     /* 00 */ u32 descTextId;
 
     /* 04 */ s8 paletteId;
@@ -34,10 +47,11 @@ struct ClassReelEnt {
     /* 0E */ u8 unk_0E; // terrain R
     /* 0F */ u8 unk_0F;
 
-    /* 10 */ struct ClassReelAnimScr* script;
+    /* 10 */ struct ClassReelAnimScr * script;
 };
 
-struct OpInfoProc {
+struct OpInfoProc
+{
     /* 00 */ PROC_HEADER;
 
     /* 29 */ u8 unk_29;
@@ -56,27 +70,29 @@ struct OpInfoProc {
     /* 38 */ int unk_38;
     /* 3C */ int unk_3c;
 
-    /* 40 */ u8 _pad[0x4C-0x40];
+    /* 40 */ STRUCT_PAD(0x40, 0x4C);
 
-    /* 4C */ struct ClassReelEnt* classReelEnt;
+    /* 4C */ struct ClassReelEnt * classReelEnt;
 };
 
-struct OpInfoEnterProc {
+struct OpInfoEnterProc
+{
     /* 00 */ PROC_HEADER;
 
     /* 2A */ u16 timer;
     /* 2C */ u16 unk_2c;
     /* 2E */ u8 classNameLength;
 
-    /* 2F */ u8 _pad1[0x34-0x2F];
+    /* 2F */ STRUCT_PAD(0x2F, 0x34);
 
-    /* 34 */ ProcPtr** letterProcsPtr;
+    /* 34 */ ProcPtr ** letterProcsPtr;
     /* 38 */ ProcPtr iconProc;
     /* 3C */ ProcPtr parentProc;
-    /* 40 */ struct ClassReelEnt* classReelEnt;
+    /* 40 */ struct ClassReelEnt * classReelEnt;
 };
 
-struct OpInfoViewProc {
+struct OpInfoViewProc
+{
     /* 00 */ PROC_HEADER;
 
     /* 29 */ u8 unk_29;
@@ -89,7 +105,8 @@ struct OpInfoViewProc {
     /* 30 */ s16 unk_30;
 };
 
-struct OpInfoIconProc {
+struct OpInfoIconProc
+{
     /* 00 */ PROC_HEADER;
 
     /* 2A */ u16 timer;
@@ -99,49 +116,53 @@ struct OpInfoIconProc {
     /* 2E */ u8 unk_2e;
 };
 
-struct OpInfoFlareProc {
+struct OpInfoFlareProc
+{
     /* 00 */ PROC_HEADER;
 
-    /* 29 */ u8 _pad[0x4C-0x29];
+    /* 29 */ STRUCT_PAD(0x29, 0x4C);
 
     /* 4C */ s16 unk_4c;
     /* 4E */ s16 unk_4e;
 };
 
-struct OpInfoBurstProc {
+struct OpInfoBurstProc
+{
     /* 00 */ PROC_HEADER;
 
-    /* 29 */ u8 _pad[0x4C-0x29];
+    /* 29 */ STRUCT_PAD(0x29, 0x4C);
 
     /* 4C */ s16 unk_4c;
 
-    /* 4E */ u8 _pad2[0x64-0x4E];
+    /* 4E */ STRUCT_PAD(0x4E, 0x64);
 
     /* 64 */ s16 unk_64;
     /* 66 */ s16 unk_66;
     /* 68 */ s16 unk_68;
 };
 
-struct OpInfoClassDisplayProc {
+struct OpInfoClassDisplayProc
+{
     /* 00 */ PROC_HEADER;
 
     /* 2A */ u16 unk_2a;
     /* 2C */ u16 unk_2c;
 
     /* 30 */ ProcPtr unk_30;
-    /* 34 */ struct ClassReelEnt* classReelEnt;
-    /* 38 */ struct ClassReelAnimScr* script;
+    /* 34 */ struct ClassReelEnt * classReelEnt;
+    /* 38 */ struct ClassReelAnimScr * script;
     /* 3C */ ProcPtr unk_3c;
     /* 40 */ u8 unk_40[6];
     /* 46 */ u8 unk_46;
 };
 
-struct OpInfoGaugeDrawProc {
+struct OpInfoGaugeDrawProc
+{
     /* 00 */ PROC_HEADER;
 
     /* 2A */ u16 unk_2a;
     /* 2C */ u16 unk_2c;
-    /* 30 */ struct OpInfoClassDisplayProc* unk_30;
+    /* 30 */ struct OpInfoClassDisplayProc * unk_30;
     /* 34 */ u8 unk_34;
     /* 35 */ u8 unk_35;
 };

--- a/include/variables.h
+++ b/include/variables.h
@@ -37,7 +37,7 @@ extern u16 gUiTmScratchC[];
 // extern ??? gUnknown_020078D8
 // extern ??? sGameStartSaveBuf
 // extern ??? gUnknown_020087A0
-// extern ??? gUnknown_0200A2D8
+// extern ??? gClassReelMagicAnim
 // extern ??? gUnknown_0200A300
 extern u8 gUnknown_0200AF00[];
 // extern ??? gUnknown_0200C300
@@ -974,20 +974,20 @@ extern u8 Img_08A2E5EC[]; // Gfx
 extern u16 Pal_08A2E8F0[]; // Pal
 extern u8 Img_SysBlackBox[]; // Gfx
 
-extern u8 gUnknown_08A301B0[]; // gfx?
+extern u8 Img_ClassReel_BigWeaponSprites[]; // gfx?
 extern u16 gUnknown_08A30780[]; // pal
-extern u8 gUnknown_08A30800[]; // gfx
-extern u16 gUnknown_08A30978[]; // tsa
-extern u8 gUnknown_08A30E2C[]; // gfx
-extern u8 gUnknown_08A35488[]; // tsa
-extern u16 gUnknown_08A3593C[]; // pal
-extern u8 gUnknown_08A35A3C[]; // gfx?
-extern u8 gUnknown_08A35FD0[]; // tsa?
-extern u16 gUnknown_08A360C8[]; // pal
-extern u8 gUnknown_08A360E8[]; // gfx?
-extern u8 gUnknown_08A36284[]; // tsa?
-extern u8 gUnknown_08A36338[]; // gfx
-extern u8 gUnknown_08A372C0[]; // pal
+extern u8 Img_ClassReel_UiBox[]; // gfx
+extern u16 Tsa_ClassReel_UiBox[]; // tsa
+extern u8 Img_ClassReel_InfoBg[]; // gfx
+extern u8 Tsa_ClassReel_InfoBg[]; // tsa
+extern u16 Pal_ClassReel_InfoBg[]; // pal
+extern u8 Img_ClassReel_NameBg[]; // gfx?
+extern u8 Tsa_ClassReel_NameBg[]; // tsa?
+extern u16 Pal_ClassReel_NameBg[]; // pal
+extern u8 Img_ClassReelFiligree[]; // gfx?
+extern u8 Tsa_ClassReelFiligree[]; // tsa?
+extern u8 Img_ClassReel_ClassNameLetters[]; // gfx
+extern u8 Pal_ClassReel_ClassNameLetters[]; // pal
 extern u16 gUnknown_08A37300[]; // pal
 // extern ??? gOverallRankWeightLookup
 // extern ??? gOverallRankLookup
@@ -1375,7 +1375,7 @@ extern u16 Pal_08B1756C[]; // pal, used in opsubtitle
 // extern ??? Img_08B17864
 // extern ??? Pal_08B17B44
 extern u8 Img_ChapterIntro_LensFlare[]; // gfx?
-extern u8 Tsa_08B18D68[];
+extern u8 Tsa_ClassReel_LensFlare[];
 extern u16 Pal_ChapterIntro_LensFlare[]; // pal
 // extern ??? Img_ChapterIntro_Fog
 // extern ??? Tsa_ChapterIntro_Fog

--- a/ldscript.txt
+++ b/ldscript.txt
@@ -80,14 +80,14 @@ SECTIONS
         . = 0x002038; gUnknown_02002038 = .;
         . = 0x007838; gUnknown_02007838 = .;
         . = 0x0078D8; gUnknown_020078D8 = .;
-        . = 0x00A2D8; gUnknown_0200A2D8 = .;
+        . = 0x00A2D8; gClassReelMagicAnim = .;
         . = 0x00A300; gUnknown_0200A300 = .;
         . = 0x00C300; gUnknown_0200C300 = .;
         . = 0x00CB00; gUnknown_0200CB00 = .;
         . = 0x01CDD4; gUnk_OpSubtitle_0201CDD4 = .;
         . = 0x01DB00; gUnk_Opinfo_0201DB00 = .;
         . = 0x01DB28; gUnk_OpInfo_0201DB28 = .;
-        . = 0x01FB28; gUnk_OpInfo_0201FB28 = .;
+        . = 0x01FB28; gClassReelTexts = .;
     }
 
     ewram_overlay_banim __ewram_start (NOLOAD) : ALIGN(4)

--- a/src/chapterintrofx.c
+++ b/src/chapterintrofx.c
@@ -431,7 +431,7 @@ void ChapterIntro_Init(struct ChapterIntroFxProc * proc)
     Decompress(Img_ChapterIntro_LensFlare, BG_CHR_ADDR(0x400));
     ApplyPalettes(Pal_ChapterIntro_LensFlare, 0, 3);
 
-    sub_800154C(gBG2TilemapBuffer, Tsa_08B18D68, 0, 5);
+    sub_800154C(gBG2TilemapBuffer, Tsa_ClassReel_LensFlare, 0, 5);
 
     Decompress(Img_ChapterIntro_Sprites, OBJ_CHR_ADDR(0x200));
     ApplyPalette(Pal_ChapterIntro_Sprites, 18);

--- a/src/classchg-sel.c
+++ b/src/classchg-sel.c
@@ -60,8 +60,8 @@ void LoadClassReelFontPalette(struct ProcPromoSel *proc, int class_id) {
             proc->u46 += 4;
     }
 
-    Decompress(&gUnknown_08A36338, OBJ_VRAM0 + 0x1000);
-    ApplyPalettes(gUnknown_08A372C0, 0x14, 0x2);
+    Decompress(&Img_ClassReel_ClassNameLetters, OBJ_VRAM0 + 0x1000);
+    ApplyPalettes(Pal_ClassReel_ClassNameLetters, 0x14, 0x2);
 }
 
 void LoadClassNameInClassReelFont(struct ProcPromoSel *proc) {
@@ -97,10 +97,10 @@ void ClassChgLoadEfxTerrain(void)
 
 void ClassChgLoadUI(void)
 {
-    u8 *src = gUnknown_08A30800;
+    u8 *src = Img_ClassReel_UiBox;
     u32 off = GetBackgroundTileDataOffset(BG_2);
     Decompress(src, (void *)VRAM + 0x3000 + off);
-    RegisterTsaWithOffset(gBG2TilemapBuffer, gUnknown_08A30978, TILEREF(0x180, BGPAL_TEXT_DEFAULT) + 0x1000);
+    RegisterTsaWithOffset(gBG2TilemapBuffer, Tsa_ClassReel_UiBox, TILEREF(0x180, BGPAL_TEXT_DEFAULT) + 0x1000);
 }
 
 void ClassChgSelDrawPidName(struct ProcPromoSel *proc) {

--- a/src/opinfo.c
+++ b/src/opinfo.c
@@ -3,26 +3,26 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "hardware.h"
-#include "m4a.h"
-#include "soundwrapper.h"
-#include "gamecontrol.h"
-#include "ctc.h"
-#include "fontgrp.h"
-#include "bmunit.h"
-#include "scene.h"
-#include "classdisplayfont.h"
-#include "opinfo.h"
 #include "anime.h"
+#include "bmlib.h"
+#include "bmunit.h"
+#include "classdisplayfont.h"
+#include "ctc.h"
 #include "efxbattle.h"
 #include "ekrbattle.h"
-#include "bmlib.h"
+#include "fontgrp.h"
+#include "gamecontrol.h"
+#include "hardware.h"
+#include "m4a.h"
+#include "opinfo.h"
+#include "scene.h"
+#include "soundwrapper.h"
 #include "sysutil.h"
 
 #include "constants/classes.h"
 #include "constants/msg.h"
 
-EWRAM_OVERLAY(gamestart) struct AnimBuffer gOpInfoData = {0};
+EWRAM_OVERLAY(gamestart) struct AnimBuffer gOpInfoData = { 0 };
 
 // TODO: Move elsewhere
 void sub_805AA68(void *);
@@ -32,29 +32,30 @@ void sub_805AE40(void *, s16, s16, s16, s16);
 // TODO: Forward declarations
 
 void sub_80B40E4(ProcPtr, int);
-struct ClassReelEnt* GetClassReelEntry(int, int);
-ProcPtr StartClassNameIntro(ProcPtr, struct ClassReelEnt*);
-ProcPtr StartClassAnimDisplay(ProcPtr, struct ClassReelEnt*);
-signed char* sub_80B369C(u8, signed char*);
+struct ClassReelEnt * GetClassReelEntry(int, int);
+ProcPtr StartClassNameIntro(ProcPtr, struct ClassReelEnt *);
+ProcPtr StartClassAnimDisplay(ProcPtr, struct ClassReelEnt *);
+signed char * sub_80B369C(u8, signed char *);
 ProcPtr StartClassNameIntroLetter(ProcPtr, u8);
 ProcPtr StartClassNameIntroIcon(ProcPtr, u8);
 
 extern struct ProcCmd CONST_DATA gProcScr_opinfo[];
 
-extern ProcPtr* gUnknown_03001D50;
+extern ProcPtr * gUnknown_03001D50;
 
-static inline int DarknessCoeff(int darkness, u8 lsr) {
+static inline int DarknessCoeff(int darkness, u8 lsr)
+{
     return 0x10 - (darkness >> (lsr));
 }
 
-void ClassReel_Init(struct OpInfoProc* proc) {
-
+//! FE8U = 0x080B2818
+void ClassReel_Init(struct OpInfoProc * proc)
+{
     gLCDControlBuffer.dispcnt.mode = 0;
 
     SetupBackgrounds(NULL);
 
     NewEfxAnimeDrvProc();
-
     ResetClassReelSpell();
 
     proc->unk_38 = 0;
@@ -74,11 +75,11 @@ void ClassReel_Init(struct OpInfoProc* proc) {
     return;
 }
 
-void ClassReel_ButtonPress_GoToTitle(struct OpInfoProc* proc) {
-
+//! FE8U = 0x080B28A0
+void ClassReel_ButtonPress_GoToTitle(struct OpInfoProc * proc)
+{
     Proc_End(Proc_Find(ProcScr_BmFadeIN));
     Proc_End(Proc_Find(ProcScr_BmFadeOUT));
-
     EndAllProcChildren(proc);
 
     Sound_FadeOutBGM(1);
@@ -92,16 +93,21 @@ void ClassReel_ButtonPress_GoToTitle(struct OpInfoProc* proc) {
     return;
 }
 
-void sub_80B2904(struct OpInfoProc* proc) {
-
-    switch (proc->mode) {
+//! FE8U = 0x080B2904
+void sub_80B2904(struct OpInfoProc * proc)
+{
+    switch (proc->mode)
+    {
         case 2:
             proc->classReelEnt = GetClassReelEntry(proc->classSet, proc->index);
 
-            if (proc->classReelEnt == 0) {
+            if (proc->classReelEnt == 0)
+            {
                 SetNextGameActionId(GAME_ACTION_CLASS_REEL);
                 Proc_Goto(proc, 4);
-            } else {
+            }
+            else
+            {
                 proc->index++;
                 proc->mode = 1;
                 StartClassNameIntro(proc, proc->classReelEnt);
@@ -115,7 +121,8 @@ void sub_80B2904(struct OpInfoProc* proc) {
             break;
 
         case 1:
-            if (gKeyStatusPtr->heldKeys & (A_BUTTON | B_BUTTON | START_BUTTON)) {
+            if (gKeyStatusPtr->heldKeys & (A_BUTTON | B_BUTTON | START_BUTTON))
+            {
                 ClassReel_ButtonPress_GoToTitle(proc);
             }
 
@@ -125,34 +132,43 @@ void sub_80B2904(struct OpInfoProc* proc) {
     return;
 }
 
-s8 sub_80B2988(void) {
-    struct OpInfoProc* proc = Proc_Find(gProcScr_opinfo);
+//! FE8U = 0x080B2988
+s8 sub_80B2988(void)
+{
+    struct OpInfoProc * proc = Proc_Find(gProcScr_opinfo);
 
-    if (proc && !GetClassReelEntry(proc->classSet, proc->index)) {
+    if (proc && !GetClassReelEntry(proc->classSet, proc->index))
+    {
         return 1;
     }
 
     return 0;
 }
 
-void SetClassReelMode(int mode) {
-    struct OpInfoProc* proc = Proc_Find(gProcScr_opinfo);
+//! FE8U = 0x080B29B8
+void SetClassReelMode(int mode)
+{
+    struct OpInfoProc * proc = Proc_Find(gProcScr_opinfo);
 
-    if (proc != 0) {
+    if (proc != 0)
+    {
         proc->mode = mode;
     }
 
     return;
 }
 
-void ClassReel_FadeOutBGM(void) {
+//! FE8U = 0x080B29D4
+void ClassReel_FadeOutBGM(void)
+{
     Sound_FadeOutBGM(3);
 
     return;
 }
 
-void ClassReel_OnEnd(ProcPtr proc) {
-
+//! FE8U = 0x080B29E0
+void ClassReel_OnEnd(ProcPtr proc)
+{
     EndAllProcChildren(proc);
 
     EndEfxAnimeDrvProc();
@@ -189,8 +205,10 @@ PROC_LABEL(5),
 
 // clang-format on
 
-void StartClassReel(u8 classSet, ProcPtr parent) {
-    struct OpInfoProc* proc = Proc_StartBlocking(gProcScr_opinfo, parent);
+//! FE8U = 0x080099E4
+void StartClassReel(u8 classSet, ProcPtr parent)
+{
+    struct OpInfoProc * proc = Proc_StartBlocking(gProcScr_opinfo, parent);
     proc->classSet = classSet;
 
     return;
@@ -206,15 +224,21 @@ u16 CONST_DATA sSprite_08A2EF48[] =
 
 // clang-format on
 
-void sub_80B2A14(u8 charId, int x, int y, u16 xScale, u16 yScale, u8 offset) {
+//! FE8U = 0x080B2A14
+void sub_80B2A14(u8 charId, int x, int y, u16 xScale, u16 yScale, u8 offset)
+{
     int i;
     int k;
 
-    for (i = 1; i < 0x10; i++) {
-        if (i + offset >= 0x10) {
+    for (i = 1; i < 0x10; i++)
+    {
+        if (i + offset >= 0x10)
+        {
             int j = 0xF;
             gPaletteBuffer[0x110 + charId * 0x10 + i] = gPaletteBuffer[0x100 + j];
-        } else {
+        }
+        else
+        {
             gPaletteBuffer[0x110 + charId * 0x10 + i] = gPaletteBuffer[0x100 + i + offset];
         }
 
@@ -223,57 +247,50 @@ void sub_80B2A14(u8 charId, int x, int y, u16 xScale, u16 yScale, u8 offset) {
 
     EnablePaletteSync();
 
-    if (yScale <= 8) {
+    if (yScale <= 8)
+    {
         return;
     }
 
-    if (xScale < 8) {
+    if (xScale < 8)
+    {
         xScale = 8;
     }
 
-    SetObjAffine(
-        charId,
-        Div(+COS(0) << 4, xScale),
-        Div(-SIN(0) << 4, yScale),
-        Div(+SIN(0) << 4, xScale),
-        Div(+COS(0) << 4, yScale)
-    );
+    SetObjAffineAuto(charId, 0, xScale, yScale);
 
-    if (offset != 0) {
+    if (offset != 0)
+    {
         PutSpriteExt(
-            4,
-            (x & 0x1FF) + (charId << 9),
-            y & 0x1FF,
-            sSprite_08A2EF48,
-            charId * 2 + OAM2_PAL(k) + 0x800
-        );
-    } else {
+            4, (x & 0x1FF) + (charId << 9), y & 0x1FF, sSprite_08A2EF48, charId * 2 + OAM2_PAL(k) + OAM2_LAYER(2));
+    }
+    else
+    {
         PutSpriteExt(
-            4,
-            (x & 0x1FF) + (charId << 9),
-            y & 0x1FF,
-            sSprite_08A2EF48,
-            charId * 2 + (k & 0xF) * 0x1000 + 0x400
-        );
+            4, (x & 0x1FF) + (charId << 9), y & 0x1FF, sSprite_08A2EF48, charId * 2 + OAM2_PAL(k) + OAM2_LAYER(1));
     }
 
     return;
 }
 
-extern u8* CONST_DATA gUnknown_08A2F2C0[];
+extern u8 * CONST_DATA gUnknown_08A2F2C0[];
 
-void ClassIntro_Init(struct OpInfoEnterProc* proc) {
-
+//! FE8U = 0x080B2B8C
+void ClassIntro_Init(struct OpInfoEnterProc * proc)
+{
     int i;
     u16 ptr;
-    signed char* str;
+    signed char * str;
 
-    u16 bgConfig[12] = {
+    // clang-format off
+    u16 bgConfig[12] =
+    {
         0x0000, 0x6000, 0,
         0x0000, 0x6800, 0,
         0x8000, 0x7000, 0,
         0x8000, 0x7800, 0,
     };
+    // clang-format on
 
     SetupBackgrounds(bgConfig);
 
@@ -299,7 +316,8 @@ void ClassIntro_Init(struct OpInfoEnterProc* proc) {
     proc->timer = 0;
     proc->letterProcsPtr = &gUnknown_03001D50;
 
-    for (i = 0; i < 0x14; i++) {
+    for (i = 0; i < 20; i++)
+    {
         *(proc->letterProcsPtr + i) = 0;
     }
 
@@ -315,9 +333,10 @@ void ClassIntro_Init(struct OpInfoEnterProc* proc) {
 
     proc->classNameLength = strlen(str);
 
-    while (*str != 0) {
-        Decompress((gUnknown_08A2F2C0[*str] != 0) ? gUnknown_08A2F2C0[*str] : gUnknown_08A2F2C0[0x58], gGenericBuffer);
-        Copy2dChr(gGenericBuffer, (void*)(ptr + 0x06010000), 2, 4);
+    while (*str != '\0')
+    {
+        Decompress((gUnknown_08A2F2C0[*str] != NULL) ? gUnknown_08A2F2C0[*str] : gUnknown_08A2F2C0['X'], gGenericBuffer);
+        Copy2dChr(gGenericBuffer, OBJ_CHR_ADDR(0x0) + ptr, 2, 4);
 
         str++;
         ptr += 0x40;
@@ -326,24 +345,24 @@ void ClassIntro_Init(struct OpInfoEnterProc* proc) {
     ApplyPalette(gUnknown_08A30780, 0x1E);
     ApplyPalette(gUnknown_08A30780, 0x1F);
 
-    Decompress(gUnknown_08A301B0, (void *)0x06016000);
+    Decompress(gUnknown_08A301B0, OBJ_CHR_ADDR(0x300));
 
     proc->unk_2c = ((240 - (((proc->classNameLength << 1) + proc->classNameLength) << 2)) >> 1) - 8;
 
     *proc->letterProcsPtr = StartClassNameIntroLetter(proc, 0);
 
-    Decompress(gUnknown_08A360E8, (void *)VRAM);
+    Decompress(gUnknown_08A360E8, BG_CHR_ADDR(0x0));
 
     Decompress(gUnknown_08A36284, gGenericBuffer);
-    CallARM_FillTileRect(TILEMAP_LOCATED(gBG0TilemapBuffer, 0, 0x7), gGenericBuffer, 0x4000);
+    CallARM_FillTileRect(TILEMAP_LOCATED(gBG0TilemapBuffer, 0, 7), gGenericBuffer, TILEREF(0x0, 4));
 
-    Decompress(gUnknown_08A35A3C, (void *)0x06000800);
+    Decompress(gUnknown_08A35A3C, BG_CHR_ADDR(0x40));
 
     Decompress(gUnknown_08A35FD0, gGenericBuffer);
-    CallARM_FillTileRect(gBG1TilemapBuffer, gGenericBuffer, 0x5040);
+    CallARM_FillTileRect(gBG1TilemapBuffer, gGenericBuffer, TILEREF(0x40, 5));
     ApplyPalette(gUnknown_08A360C8, 5);
 
-    Decompress(Img_ChapterIntro_LensFlare, (void *)0x06008000);
+    Decompress(Img_ChapterIntro_LensFlare, BG_CHR_ADDR(0x400));
 
     sub_800154C(gBG2TilemapBuffer, Tsa_08B18D68, 0, 5);
 
@@ -355,15 +374,16 @@ void ClassIntro_Init(struct OpInfoEnterProc* proc) {
 }
 
 // unused??
-void sub_80B2DF0(struct OpInfoEnterProc* proc) {
-
-    SetBlendConfig(2, 0, 0, DarknessCoeff(proc->timer, 1));
-
+//! FE8U = 0x080B2DF0
+void sub_80B2DF0(struct OpInfoEnterProc * proc)
+{
+    SetBlendBrighten(DarknessCoeff(proc->timer, 1));
     SetBlendBackdropA(1);
 
     proc->timer++;
 
-    if (proc->timer == 32) {
+    if (proc->timer == 32)
+    {
         proc->timer = 0;
         Proc_Break(proc);
     }
@@ -373,31 +393,38 @@ void sub_80B2DF0(struct OpInfoEnterProc* proc) {
 
 extern struct ProcCmd CONST_DATA gProcScr_ClassIntro_FlareFX[];
 
-void ClassIntro_LoopIn(struct OpInfoEnterProc* proc) {
+//! FE8U = 0x080B2E30
+void ClassIntro_LoopIn(struct OpInfoEnterProc * proc)
+{
     int unkA;
     int unkB;
 
-    if (proc->timer == 60) {
+    if (proc->timer == 60)
+    {
         proc->iconProc = StartClassNameIntroIcon(proc, proc->classReelEnt->classId);
         Proc_Start(gProcScr_ClassIntro_FlareFX, proc);
     }
 
-    if (proc->timer >= 96) {
+    if (proc->timer >= 96)
+    {
         Proc_Break(proc);
         proc->timer = 0;
 
         return;
     }
 
-    if (proc->timer > 15) {
+    if (proc->timer > 15)
+    {
         unkA = (proc->timer - 0x10);
 
-        if ((unkA & 1) == 0) {
+        if ((unkA & 1) == 0)
+        {
             unkB = (unkA / 2);
             unkA = unkB + 1;
-            if (unkA < proc->classNameLength) {
 
-                proc->letterProcsPtr[unkB+1] = StartClassNameIntroLetter(proc, unkA);
+            if (unkA < proc->classNameLength)
+            {
+                proc->letterProcsPtr[unkB + 1] = StartClassNameIntroLetter(proc, unkA);
             }
         }
     }
@@ -407,25 +434,29 @@ void ClassIntro_LoopIn(struct OpInfoEnterProc* proc) {
     return;
 }
 
-void ClassIntro_LoopOut(struct OpInfoEnterProc* proc) {
-
-    if (proc->timer == 20) {
+//! FE8U = 0x080B2EA8
+void ClassIntro_LoopOut(struct OpInfoEnterProc * proc)
+{
+    if (proc->timer == 20)
+    {
         Proc_Goto(proc->iconProc, 4);
     }
 
-    if (proc->timer >= 80) {
+    if (proc->timer >= 80)
+    {
         Proc_Break(proc);
         proc->timer = 0;
 
         return;
     }
 
-    if ((proc->timer % 3) == 0) {
+    if ((proc->timer % 3) == 0)
+    {
 
-        if ((proc->timer / 3) < proc->classNameLength) {
+        if ((proc->timer / 3) < proc->classNameLength)
+        {
             Proc_Break(proc->letterProcsPtr[proc->timer / 3]);
         }
-
     }
 
     proc->timer++;
@@ -433,13 +464,16 @@ void ClassIntro_LoopOut(struct OpInfoEnterProc* proc) {
     return;
 }
 
-void ClassIntro_DisableAllExceptBg1(ProcPtr proc) {
+//! FE8U = 0x080B2F08
+void ClassIntro_DisableAllExceptBg1(ProcPtr proc)
+{
     SetDispEnable(FALSE, TRUE, FALSE, FALSE, FALSE);
     return;
 }
 
-void ClassIntro_OnEnd(ProcPtr proc) {
-
+//! FE8U = 0x080B2F2C
+void ClassIntro_OnEnd(ProcPtr proc)
+{
     EndAllProcChildren(proc);
     SetClassReelMode(3);
 
@@ -476,8 +510,10 @@ PROC_LABEL(4),
 
 // clang-format on
 
-ProcPtr StartClassNameIntro(ProcPtr parent, struct ClassReelEnt* entry) {
-    struct OpInfoEnterProc* proc = Proc_Start(gProcScr_opinfoenter, parent);
+//! FE8U = 0x080B2F3C
+ProcPtr StartClassNameIntro(ProcPtr parent, struct ClassReelEnt * entry)
+{
+    struct OpInfoEnterProc * proc = Proc_Start(gProcScr_opinfoenter, parent);
 
     proc->parentProc = parent;
     proc->classReelEnt = entry;
@@ -485,13 +521,17 @@ ProcPtr StartClassNameIntro(ProcPtr parent, struct ClassReelEnt* entry) {
     return proc;
 }
 
-void ClassIntroLetter_Init(struct OpInfoViewProc* proc) {
+//! FE8U = 0x080B2F58
+void ClassIntroLetter_Init(struct OpInfoViewProc * proc)
+{
     proc->timer = 0;
-    proc->unk_2e = ((struct OpInfoEnterProc*)(proc->proc_parent))->unk_2c + (proc->charIndex * 12);
+    proc->unk_2e = ((struct OpInfoEnterProc *)(proc->proc_parent))->unk_2c + (proc->charIndex * 12);
     return;
 }
 
-void ClassIntroLetter_LoopFadeIn(struct OpInfoViewProc* proc) {
+//! FE8U = 0x080B2F74
+void ClassIntroLetter_LoopFadeIn(struct OpInfoViewProc * proc)
+{
     int timer = proc->timer, a;
 #ifndef NONMATCHING
     register int timer2 asm("r1") = timer;
@@ -499,20 +539,18 @@ void ClassIntroLetter_LoopFadeIn(struct OpInfoViewProc* proc) {
     int timer2 = timer;
 #endif
 
-    if (timer2) { ++timer2; --timer2; }
+    if (timer2)
+    {
+        ++timer2;
+        --timer2;
+    }
     timer2 >>= 4;
     a = (0x10 - timer2) * 2;
 
-    sub_80B2A14(
-        proc->charIndex,
-        proc->unk_2e - a,
-        0x18,
-        timer,
-        0x100,
-        0x10 - ({proc->timer + 0;}) / 16
-    );
+    sub_80B2A14(proc->charIndex, proc->unk_2e - a, 0x18, timer, 0x100, 0x10 - ({ proc->timer + 0; }) / 16);
 
-    if ((proc->timer += 0x10) == 0x100) {
+    if ((proc->timer += 0x10) == 0x100)
+    {
         proc->timer = 0;
         Proc_Break(proc);
     }
@@ -520,30 +558,25 @@ void ClassIntroLetter_LoopFadeIn(struct OpInfoViewProc* proc) {
     return;
 }
 
-void ClassIntroLetter_LoopDisplay(struct OpInfoViewProc* proc) {
-
+//! FE8U = 0x080B2FD0
+void ClassIntroLetter_LoopDisplay(struct OpInfoViewProc * proc)
+{
     sub_80B2A14(proc->charIndex, proc->unk_2e, 0x18, 0x100, 0x100, 0);
-
     proc->timer = 0;
-
     return;
 }
 
-void ClassIntroLetter_LoopFadeOut(struct OpInfoViewProc* proc) {
+//! FE8U = 0x080B2FF8
+void ClassIntroLetter_LoopFadeOut(struct OpInfoViewProc * proc)
+{
     u32 a4 = 0x100 + proc->timer;
     u32 a5 = 0x100 - proc->timer;
 
-    sub_80B2A14(
-        proc->charIndex,
-        proc->unk_2e,
-        0x18,
-        a4,
-        a5,
-        ({proc->timer + 0;}) / 16
-    );
+    sub_80B2A14(proc->charIndex, proc->unk_2e, 0x18, a4, a5, ({ proc->timer + 0; }) / 16);
 
-    if (proc->timer == 0x100) {
-        ((struct OpInfoEnterProc*)(proc->proc_parent))->letterProcsPtr[proc->charIndex] = NULL;
+    if (proc->timer == 0x100)
+    {
+        ((struct OpInfoEnterProc *)(proc->proc_parent))->letterProcsPtr[proc->charIndex] = NULL;
 
         Proc_Break(proc);
     }
@@ -571,39 +604,44 @@ struct ProcCmd CONST_DATA gProcScr_opinfoview[] =
 
 // clang-format on
 
-ProcPtr StartClassNameIntroLetter(ProcPtr parent, u8 index) {
-    struct OpInfoViewProc* proc = Proc_Start(gProcScr_opinfoview, parent);
-
+//! FE8U = 0x080B305C
+ProcPtr StartClassNameIntroLetter(ProcPtr parent, u8 index)
+{
+    struct OpInfoViewProc * proc = Proc_Start(gProcScr_opinfoview, parent);
     proc->charIndex = index;
-
     return proc;
 }
 
 // unused?
-void sub_80B307C(void) {
+//! FE8U = 0x080B307C
+void sub_80B307C(void)
+{
     EnablePaletteSync();
-
     return;
 }
 
-void ClassIntroIcon_Init(struct OpInfoIconProc* proc) {
-
+//! FE8U = 0x080B3088
+void ClassIntroIcon_Init(struct OpInfoIconProc * proc)
+{
     int i;
 
     proc->timer = 0;
 
-    for (i = 0; i < 0x10; i++) {
+    for (i = 0; i < 0x10; i++)
+    {
         gPaletteBuffer[0x1F0 + i] = 0;
-        gPaletteBuffer[0x40  + i] = 0;
+        gPaletteBuffer[0x40 + i] = 0;
     }
 
     proc->unk_2e = 0;
     proc->numIcons = 0;
 
-    for (i = 0; i < 8; i++) {
-        const struct ClassData* class = GetClassData(proc->classId);
+    for (i = 0; i < 8; i++)
+    {
+        const struct ClassData * class = GetClassData(proc->classId);
 
-        if (class->baseRanks[i] == 0) {
+        if (class->baseRanks[i] == 0)
+        {
             continue;
         }
 
@@ -616,20 +654,26 @@ void ClassIntroIcon_Init(struct OpInfoIconProc* proc) {
     return;
 }
 
-extern u16* CONST_DATA sSpriteLut_08A2F1D0[];
+extern u16 * CONST_DATA sSpriteLut_08A2F1D0[];
 
-void sub_80B30FC(u8 a, u8 b, u8 c) {
+//! FE8U = 0x080B30FC
+void sub_80B30FC(u8 a, u8 b, u8 c)
+{
     int i;
     int tmp;
     int tmp2;
-    u16** object;
+    u16 ** object;
 
-    for (i = 0; i < 0x10; i++) {
+    for (i = 0; i < 0x10; i++)
+    {
         u16 color;
 
-        if ((a + i) < 0x10) {
+        if ((a + i) < 0x10)
+        {
             color = a + i;
-        } else {
+        }
+        else
+        {
             color = 0xF;
         }
 
@@ -641,26 +685,32 @@ void sub_80B30FC(u8 a, u8 b, u8 c) {
 
     tmp = ((8 - (b)) << 4);
 
-    for (i = 0, object = sSpriteLut_08A2F1D0, tmp2 = tmp - 8; i < 8; object++, i++) {
-        if (((c >> i) & 1) != 0) {
+    for (i = 0, object = sSpriteLut_08A2F1D0, tmp2 = tmp - 8; i < 8; object++, i++)
+    {
+        if (((c >> i) & 1) != 0)
+        {
             PutSpriteExt(4, (tmp2) & 0x1FF, 0x50, *object, 0xF000);
             tmp2 += 0x20;
         }
-
     }
 
     return;
 }
 
-void ClassIntroIcon_LoopFadeIn(struct OpInfoIconProc* proc) {
+//! FE8U = 0x080B31B0
+void ClassIntroIcon_LoopFadeIn(struct OpInfoIconProc * proc)
+{
     u8 unk;
 
     proc->timer++;
 
-    if (proc->timer >= 33) {
+    if (proc->timer >= 33)
+    {
         unk = 0;
         Proc_Break(proc);
-    } else {
+    }
+    else
+    {
         unk = 0x10 - (proc->timer >> 1);
     }
 
@@ -669,22 +719,26 @@ void ClassIntroIcon_LoopFadeIn(struct OpInfoIconProc* proc) {
     return;
 }
 
-void ClassIntroIcon_LoopDisplay(struct OpInfoIconProc* proc) {
-
+//! FE8U = 0x080B31EC
+void ClassIntroIcon_LoopDisplay(struct OpInfoIconProc * proc)
+{
     sub_80B30FC(0, proc->numIcons, proc->unk_2e);
-
     proc->timer = 0;
-
     return;
 }
 
-void ClassIntroIcon_LoopFadeOut(struct OpInfoIconProc* proc) {
+//! FE8U = 0x080B3208
+void ClassIntroIcon_LoopFadeOut(struct OpInfoIconProc * proc)
+{
     proc->timer++;
 
-    if ((proc->timer >> 1) >= 17) {
+    if ((proc->timer >> 1) >= 17)
+    {
         SetDispEnable(FALSE, TRUE, FALSE, FALSE, TRUE);
         Proc_Break(proc);
-    } else {
+    }
+    else
+    {
         sub_80B30FC((proc->timer >> 1), proc->numIcons, proc->unk_2e);
     }
 
@@ -711,16 +765,17 @@ PROC_LABEL(4),
 
 // clang-format on
 
-ProcPtr StartClassNameIntroIcon(ProcPtr parent, u8 classId) {
-    struct OpInfoIconProc* proc;
-
-    proc = Proc_Start(gProcScr_opinfoicon, parent);
+//! FE8U = 0x080B325C
+ProcPtr StartClassNameIntroIcon(ProcPtr parent, u8 classId)
+{
+    struct OpInfoIconProc * proc = Proc_Start(gProcScr_opinfoicon, parent);
     proc->classId = classId;
-
     return proc;
 }
 
-void ClassIntroFlare_Init(struct OpInfoFlareProc* proc) {
+//! FE8U = 0x080B327C
+void ClassIntroFlare_Init(struct OpInfoFlareProc * proc)
+{
     proc->unk_4c = 0;
     proc->unk_4e = 0;
 
@@ -729,28 +784,34 @@ void ClassIntroFlare_Init(struct OpInfoFlareProc* proc) {
     return;
 }
 
-void ClassIntroFlare_Loop(struct OpInfoFlareProc* proc) {
+//! FE8U = 0x080B32AC
+void ClassIntroFlare_Loop(struct OpInfoFlareProc * proc)
+{
     int unkA;
     int unkB;
     int unkC;
     int unkD;
 
-    if (proc->unk_4c < 30) {
+    if (proc->unk_4c < 30)
+    {
         unkA = Interpolate(INTERPOLATE_RCUBIC, 4, 0x32, proc->unk_4c, 0x1E);
         unkB = Interpolate(INTERPOLATE_RSQUARE, 0, 0x10, proc->unk_4c, 0x1E);
-    } else {
+    }
+    else
+    {
         unkA = Interpolate(INTERPOLATE_LINEAR, 0x32, 100, proc->unk_4c - 0x1E, 0x1E);
         unkB = Interpolate(INTERPOLATE_LINEAR, 0x10, 0, proc->unk_4c - 0x1E, 0x1E);
     }
 
-    if (49 < unkA) {
+    if (49 < unkA)
+    {
         unkA = 100 - unkA;
     }
 
     unkC = Interpolate(INTERPOLATE_LINEAR, 0, 0xD6, proc->unk_4c, 0x3C);
     unkD = Interpolate(INTERPOLATE_LINEAR, 0x10, 0x80, proc->unk_4c, 0x3C);
 
-    BgAffinRotScaling( BG_2, (s16)proc->unk_4e, 0, 0, (s16)(unkA * 5 + 0x80), (s16)(unkA * 5 + 0x80));
+    BgAffinRotScaling(BG_2, (s16)proc->unk_4e, 0, 0, (s16)(unkA * 5 + 0x80), (s16)(unkA * 5 + 0x80));
     BgAffinScaling(BG_2, 0x100, 0x100);
     BgAffinAnchoring(BG_2, unkC, unkD, 0x50, 0x48);
 
@@ -760,7 +821,8 @@ void ClassIntroFlare_Loop(struct OpInfoFlareProc* proc) {
 
     proc->unk_4c++;
 
-    if (59 < proc->unk_4c) {
+    if (59 < proc->unk_4c)
+    {
         Proc_Break(proc);
         SetDispEnable(TRUE, TRUE, FALSE, FALSE, TRUE);
     }
@@ -788,7 +850,9 @@ struct ProcCmd CONST_DATA gProcScr_ClassIntro_FlareFX[] =
 
 // clang-format on
 
-void ClassIntroBurst_Init(struct OpInfoBurstProc* proc) {
+//! FE8U = 0x080B33E4
+void ClassIntroBurst_Init(struct OpInfoBurstProc * proc)
+{
     proc->unk_4c = 0;
     proc->unk_64 = 0;
     proc->unk_66 = 0;
@@ -799,10 +863,11 @@ void ClassIntroBurst_Init(struct OpInfoBurstProc* proc) {
 
 extern u16 CONST_DATA sSprite_08A2F1F0[];
 
-void PutClassIntroBurstSprites(struct OpInfoBurstProc* proc, int b, int c, int d) {
-
-    int x = Interpolate(5, 0x78, c, proc->unk_4c, 0x46);
-    int y = Interpolate(5, 0x50, d, proc->unk_4c, 0x46);
+//! FE8U = 0x080B33FC
+void PutClassIntroBurstSprites(struct OpInfoBurstProc * proc, int b, int c, int d)
+{
+    int x = Interpolate(INTERPOLATE_RCUBIC, 0x78, c, proc->unk_4c, 0x46);
+    int y = Interpolate(INTERPOLATE_RCUBIC, 0x50, d, proc->unk_4c, 0x46);
 
     PutSpriteExt(4, ((x - 8) & 0x1FF) | (b << 9), ((y - 8) & 0x1FF) | 0x100, sSprite_08A2F1F0, 0xF000);
 
@@ -811,52 +876,39 @@ void PutClassIntroBurstSprites(struct OpInfoBurstProc* proc, int b, int c, int d
     return;
 }
 
-void ClassIntroBurst_Loop(struct OpInfoBurstProc* proc) {
+//! FE8U = 0x080B3498
+void ClassIntroBurst_Loop(struct OpInfoBurstProc * proc)
+{
     int scale;
 
-    if (proc->unk_64 < 71) {
+    if (proc->unk_64 < 71)
+    {
         scale = Interpolate(INTERPOLATE_RSQUARE, 0x120, 0x10, proc->unk_64, 70);
 
         SetObjAffine(
-            21,
-            Div(+COS(0) << 4, scale),
-            Div(-SIN(0) << 4, scale),
-            Div(+SIN(0) << 4, scale),
-            Div(+COS(0) << 4, scale)
-        );
+            21, Div(+COS(0) << 4, scale), Div(-SIN(0) << 4, scale), Div(+SIN(0) << 4, scale), Div(+COS(0) << 4, scale));
 
         proc->unk_64++;
     }
 
     PutClassIntroBurstSprites(proc, 21, 215, 17);
 
-    if (proc->unk_66 < 71) {
+    if (proc->unk_66 < 71)
+    {
         scale = Interpolate(INTERPOLATE_LINEAR, 0x120, 0x10, proc->unk_66, 70);
 
         SetObjAffine(
-            22,
-            Div(+COS(0) << 4, scale),
-            Div(-SIN(0) << 4, scale),
-            Div(+SIN(0) << 4, scale),
-            Div(+COS(0) << 4, scale)
-        );
+            22, Div(+COS(0) << 4, scale), Div(-SIN(0) << 4, scale), Div(+SIN(0) << 4, scale), Div(+COS(0) << 4, scale));
 
         proc->unk_66++;
     }
 
     PutClassIntroBurstSprites(proc, 22, 192, 32);
 
-    if (proc->unk_68 < 71) {
+    if (proc->unk_68 < 71)
+    {
         scale = Interpolate(INTERPOLATE_SQUARE, 0x120, 0x10, proc->unk_68, 70);
-
-        SetObjAffine(
-            23,
-            Div(+COS(0) << 4, scale),
-            Div(-SIN(0) << 4, scale),
-            Div(+SIN(0) << 4, scale),
-            Div(+COS(0) << 4, scale)
-        );
-
+        SetObjAffineAuto(23, 0, scale, scale);
         proc->unk_68++;
     }
 
@@ -864,7 +916,8 @@ void ClassIntroBurst_Loop(struct OpInfoBurstProc* proc) {
 
     proc->unk_4c++;
 
-    if (proc->unk_68 > 70) {
+    if (proc->unk_68 > 70)
+    {
         Proc_Break(proc);
     }
 
@@ -885,43 +938,53 @@ struct ProcCmd CONST_DATA gProcScr_ClassIntro_BurstFX[] =
 
 // clang-format on
 
-signed char* sub_80B369C(u8 classId, signed char* buffer) {
-    char* str;
+//! FE8U = 0x080B369C
+signed char * sub_80B369C(u8 classId, signed char * buffer)
+{
+    char * str;
 
-    const struct ClassData* class = GetClassData(classId);
-    if (buffer == NULL) {
+    const struct ClassData * class = GetClassData(classId);
+
+    if (buffer == NULL)
+    {
         buffer = GetStringFromIndex(class->nameTextId);
-    } else {
+    }
+    else
+    {
         GetStringFromIndexInBuffer(class->nameTextId, buffer);
     }
 
     str = strstr(buffer, "Kn.");
-    if (str != NULL) {
+    if (str != NULL)
+    {
         sprintf(str, "Knight");
     }
 
     return buffer;
 }
 
-void sub_80B36E0(void) {
+//! FE8U = 0x080B36E0
+void sub_80B36E0(void)
+{
     u16 vcount = (REG_VCOUNT + 1);
 
-    if (vcount < 110) {
-
+    if (vcount < 110)
+    {
         REG_BG0CNT = (0xFFFC & REG_BG0CNT) + 2;
         REG_BG2CNT = (0xFFFC & REG_BG2CNT) + 2;
-
-        return;
     }
-
-
-    REG_BG0CNT = (0xFFFC & REG_BG0CNT) + 1;
-    REG_BG2CNT = (0xFFFC & REG_BG2CNT) + 1;
+    else
+    {
+        REG_BG0CNT = (0xFFFC & REG_BG0CNT) + 1;
+        REG_BG2CNT = (0xFFFC & REG_BG2CNT) + 1;
+    }
 
     return;
 }
 
-void sub_80B3740(void) {
+//! FE8U = 0x080B3740
+void sub_80B3740(void)
+{
     SetBlendAlpha(0x10, 0x10);
 
     SetBlendTargetA(0, 1, 0, 0, 0);
@@ -955,7 +1018,8 @@ extern struct Text gUnk_OpInfo_0201FB28[6];
 
 extern u8 gUnk_OpInfo_0201DB28[];
 
-const int gUnknown_08205EDC[2][6] = {
+const int gUnknown_08205EDC[2][6] =
+{
     {
         MSG_4E9, // "HP"
         MSG_4FE, // "Str"
@@ -974,15 +1038,18 @@ const int gUnknown_08205EDC[2][6] = {
     },
 };
 
-void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc* proc) {
-    union {
+//! FE8U = 0x080B37FC
+void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc * proc)
+{
+    union
+    {
         int hack_4d[2][6][1][1];
         int hack_2d[2][6];
     } hack;
     int i;
     int hasMagicRank;
     int r5;
-    u16 *buffer;
+    u16 * buffer;
 
     hasMagicRank = 0;
 
@@ -990,9 +1057,10 @@ void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc* proc) {
 
     proc->script = proc->classReelEnt->script;
 
-    for (i = 4; i <= 7; i++) {
-
-        if ((GetClassData(proc->classReelEnt->classId)->baseRanks[i]) != 0) {
+    for (i = 4; i <= 7; i++)
+    {
+        if ((GetClassData(proc->classReelEnt->classId)->baseRanks[i]) != 0)
+        {
             hasMagicRank = 1;
             break;
         }
@@ -1027,15 +1095,15 @@ void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc* proc) {
     BG_SetPosition(BG_2, 0, 0);
     BG_SetPosition(BG_3, 0, 0);
 
-    Decompress(gUnknown_08A30E2C, (void *)(GetBackgroundTileDataOffset(3) + VRAM));
+    Decompress(gUnknown_08A30E2C, (void *)(GetBackgroundTileDataOffset(BG_3) + VRAM));
     ApplyPalettes(gUnknown_08A3593C, 7, 8);
 
-    CallARM_FillTileRect(gBG3TilemapBuffer, gUnknown_08A35488, 0x7000);
+    CallARM_FillTileRect(gBG3TilemapBuffer, gUnknown_08A35488, TILEREF(0x0, 7));
 
-    Decompress(gUnknown_08A30800, (void *)(GetBackgroundTileDataOffset(2) + VRAM));
+    Decompress(gUnknown_08A30800, (void *)(GetBackgroundTileDataOffset(BG_2) + VRAM));
     ApplyPalette(gUiFramePaletteA, 6);
 
-    CallARM_FillTileRect(gBG2TilemapBuffer, gUnknown_08A30978, 0x6000);
+    CallARM_FillTileRect(gBG2TilemapBuffer, gUnknown_08A30978, TILEREF(0x0, 6));
 
     BG_EnableSyncByMask(BG0_SYNC_BIT | BG1_SYNC_BIT | BG2_SYNC_BIT | BG3_SYNC_BIT);
 
@@ -1048,24 +1116,27 @@ void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc* proc) {
     proc->unk_40[4] = GetClassData(proc->classReelEnt->classId)->baseDef;
     proc->unk_40[5] = GetClassData(proc->classReelEnt->classId)->baseRes;
 
-    for (i = 0; i <= 5; i++) {
-
+    for (i = 0; i <= 5; i++)
+    {
         InitText(&gUnk_OpInfo_0201FB28[i], 3);
 
         ClearText(&gUnk_OpInfo_0201FB28[i]);
 
-        Text_SetColor(&gUnk_OpInfo_0201FB28[i], 3);
+        Text_SetColor(&gUnk_OpInfo_0201FB28[i], TEXT_COLOR_SYSTEM_GOLD);
         Text_SetCursor(&gUnk_OpInfo_0201FB28[i], 0);
 
-        if (hasMagicRank != 0) {
+        if (hasMagicRank != 0)
+        {
             Text_DrawString(&gUnk_OpInfo_0201FB28[i], GetStringFromIndex(hack.hack_2d[1][i]));
-        } else {
+        }
+        else
+        {
             Text_DrawString(&gUnk_OpInfo_0201FB28[i], GetStringFromIndex(hack.hack_4d[0][i][1][-1]));
         }
 
         PutText(&gUnk_OpInfo_0201FB28[i], buffer + 0x21 + (i * 0x40));
 
-        PutNumber(buffer + 0x25 + (i * 0x40), 0, proc->unk_40[i]);
+        PutNumber(buffer + 0x25 + (i * 0x40), TEXT_COLOR_SYSTEM_WHITE, proc->unk_40[i]);
     }
 
     r5 = 0;
@@ -1091,8 +1162,8 @@ void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc* proc) {
     SetTalkPrintDelay(4);
 
     gOpInfoData.charPalId = proc->classReelEnt->paletteId;
-    gOpInfoData.xPos = 0x104;
-    gOpInfoData.yPos = 0x58;
+    gOpInfoData.xPos = 260;
+    gOpInfoData.yPos = 88;
     gOpInfoData.animId = proc->classReelEnt->banimId;
     gOpInfoData.roundType = 6;
     gOpInfoData.genericPalId = proc->classReelEnt->unk_06;
@@ -1133,7 +1204,7 @@ void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc* proc) {
     gUnk_Opinfo_0201DB00.distance = r5;
     gUnk_Opinfo_0201DB00.unk0E = -1;
 
-    gUnk_Opinfo_0201DB00.unk1C = (void *)0x06010000;
+    gUnk_Opinfo_0201DB00.unk1C = OBJ_CHR_ADDR(0x0);
     gUnk_Opinfo_0201DB00.unk20 = &gUnk_OpInfo_0201DB28;
 
     sub_805AA68(&gUnk_Opinfo_0201DB00);
@@ -1144,14 +1215,18 @@ void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc* proc) {
     return;
 }
 
-void sub_80B3C14(struct OpInfoClassDisplayProc* proc) {
-
-    if (proc->unk_2c == 400) {
-
-        if (sub_80B2988() != 0) {
+//! FE8U = 0x080B3C14
+void sub_80B3C14(struct OpInfoClassDisplayProc * proc)
+{
+    if (proc->unk_2c == 400)
+    {
+        if (sub_80B2988() != 0)
+        {
             Sound_FadeOutBGM(60);
             Proc_Goto(proc, 7);
-        } else {
+        }
+        else
+        {
             Proc_Goto(proc, 4);
         }
     }
@@ -1161,17 +1236,19 @@ void sub_80B3C14(struct OpInfoClassDisplayProc* proc) {
     return;
 }
 
-void ClassInfoDisplay_LoopWindowIn(struct OpInfoClassDisplayProc* proc) {
-
+//! FE8U = 0x080B3C50
+void ClassInfoDisplay_LoopWindowIn(struct OpInfoClassDisplayProc * proc)
+{
     int unk;
 
-    u8* ptr = &proc->unk_46;
+    u8 * ptr = &proc->unk_46;
 
     unk = ~((80 - proc->unk_2a) / 14);
 
     proc->unk_46 = unk + *ptr;
 
-    if (proc->unk_46 < 180) {
+    if (proc->unk_46 < 180)
+    {
         proc->unk_46 = 180;
     }
 
@@ -1183,14 +1260,17 @@ void ClassInfoDisplay_LoopWindowIn(struct OpInfoClassDisplayProc* proc) {
     SetWin0Layers(1, 1, 1, 1, 1);
     SetWOutLayers(0, 0, 0, 0, 0);
 
-    if (proc->unk_2a == 80) {
+    if (proc->unk_2a == 80)
+    {
         proc->unk_46 = 180;
         proc->unk_2a = 0;
 
         Proc_Break(proc);
 
         StartParallelWorker(sub_80B3C14, proc);
-    } else {
+    }
+    else
+    {
         proc->unk_2a += 4;
     }
 
@@ -1202,8 +1282,11 @@ void ClassInfoDisplay_LoopWindowIn(struct OpInfoClassDisplayProc* proc) {
     return;
 }
 
-void ClassInfoDisplay_ExecScript(struct OpInfoClassDisplayProc* proc) {
-    switch (proc->script->opCode) {
+//! FE8U = 0x080B3D84
+void ClassInfoDisplay_ExecScript(struct OpInfoClassDisplayProc * proc)
+{
+    switch (proc->script->opCode)
+    {
         case CLASS_REEL_OP_END:
             Proc_Goto(proc, 10);
 
@@ -1249,9 +1332,11 @@ void ClassInfoDisplay_ExecScript(struct OpInfoClassDisplayProc* proc) {
     return;
 }
 
-void ClassInfoDisplay_LoopScript(struct OpInfoClassDisplayProc* proc) {
-
-    switch (proc->script->opCode) {
+//! FE8U = 0x080B3E18
+void ClassInfoDisplay_LoopScript(struct OpInfoClassDisplayProc * proc)
+{
+    switch (proc->script->opCode)
+    {
         case CLASS_REEL_OP_HIT_CLOSE:
         case CLASS_REEL_OP_CRIT_CLOSE:
         case CLASS_REEL_OP_RETURN_TO_STANDING:
@@ -1266,7 +1351,8 @@ void ClassInfoDisplay_LoopScript(struct OpInfoClassDisplayProc* proc) {
         case CLASS_REEL_OP_WAIT_FRAMES:
             proc->unk_2a++;
 
-            if (proc->unk_2a < proc->script->extra) {
+            if (proc->unk_2a < proc->script->extra)
+            {
                 return;
             }
 
@@ -1276,7 +1362,8 @@ void ClassInfoDisplay_LoopScript(struct OpInfoClassDisplayProc* proc) {
             break;
 
         case CLASS_REEL_OP_ROUND_END:
-            if (sub_805A96C(&gOpInfoData) != 0) {
+            if (sub_805A96C(&gOpInfoData) != 0)
+            {
                 proc->script++;
                 Proc_Break(proc);
             }
@@ -1285,8 +1372,9 @@ void ClassInfoDisplay_LoopScript(struct OpInfoClassDisplayProc* proc) {
     return;
 }
 
-void ClassInfoDisplay_OnEnd(struct OpInfoClassDisplayProc* proc) {
-
+//! FE8U = 0x080B3E9C
+void ClassInfoDisplay_OnEnd(struct OpInfoClassDisplayProc * proc)
+{
     SetPrimaryHBlankHandler(NULL);
 
     EndTalk();
@@ -1295,7 +1383,8 @@ void ClassInfoDisplay_OnEnd(struct OpInfoClassDisplayProc* proc) {
     EndActiveClassReelSpell();
     sub_805AA28(&gOpInfoData);
 
-    if (proc->unk_3c != 0) {
+    if (proc->unk_3c != 0)
+    {
         Proc_End(proc->unk_3c);
     }
 
@@ -1304,8 +1393,11 @@ void ClassInfoDisplay_OnEnd(struct OpInfoClassDisplayProc* proc) {
     return;
 }
 
-struct ProcCmd CONST_DATA gProcScr_ClassInfoDisplay[] = {
-    PROC_SLEEP(0),
+// clang-format off
+
+struct ProcCmd CONST_DATA gProcScr_ClassInfoDisplay[] =
+{
+    PROC_YIELD,
 
     PROC_CALL_ARG(NewFadeOut, 8),
     PROC_WHILE(FadeOutExists),
@@ -1337,12 +1429,15 @@ PROC_LABEL(7),
     PROC_WHILE(FadeOutExists),
 
 PROC_LABEL(8),
-
     PROC_END,
 };
 
-ProcPtr StartClassAnimDisplay(ProcPtr parent, struct ClassReelEnt* entry) {
-    struct OpInfoClassDisplayProc* proc = Proc_Start(gProcScr_ClassInfoDisplay, parent);
+// clang-format on
+
+//! FE8U = 0x080B3EDC
+ProcPtr StartClassAnimDisplay(ProcPtr parent, struct ClassReelEnt * entry)
+{
+    struct OpInfoClassDisplayProc * proc = Proc_Start(gProcScr_ClassInfoDisplay, parent);
 
     proc->unk_30 = parent;
     proc->classReelEnt = entry;
@@ -1351,8 +1446,10 @@ ProcPtr StartClassAnimDisplay(ProcPtr parent, struct ClassReelEnt* entry) {
     return proc;
 }
 
-void ClassStatsDisplay_Init(struct OpInfoGaugeDrawProc* proc) {
-    struct ClassDisplayFont* res;
+//! FE8U = 0x080B3EFC
+void ClassStatsDisplay_Init(struct OpInfoGaugeDrawProc * proc)
+{
+    struct ClassDisplayFont * res;
     int i;
 
     signed char buffer[32];
@@ -1364,64 +1461,62 @@ void ClassStatsDisplay_Init(struct OpInfoGaugeDrawProc* proc) {
 
     sub_80B369C(proc->unk_30->classReelEnt->classId, buffer);
 
-    for (i = 0; buffer[i] != 0; ) {
-
+    for (i = 0; buffer[i] != 0;)
+    {
         res = GetClassDisplayFontInfo(buffer[i]);
 
-        if (res != 0) {
+        if (res != 0)
+        {
             proc->unk_34 += res->width - res->xBase;
-        } else {
+        }
+        else
+        {
             proc->unk_34 += 4;
         }
 
         i++;
 
-        if ((int)(buffer + i) > (int)(buffer + 13)) {
+        if ((int)(buffer + i) > (int)(buffer + 13))
+        {
             break;
         }
     }
 
-    Decompress(gUnknown_08A36338, (void *)0x06010000);
+    Decompress(gUnknown_08A36338, OBJ_CHR_ADDR(0x0));
 
     ApplyPalettes(gUnknown_08A372C0, 0x14, 2);
 
     return;
 }
 
-extern u16* CONST_DATA sSpriteLut_GaugePips[];
+extern u16 * CONST_DATA sSpriteLut_GaugePips[];
 
-void ClassStatsDisplay_Loop(struct OpInfoGaugeDrawProc* proc) {
+//! FE8U = 0x080B3F90
+void ClassStatsDisplay_Loop(struct OpInfoGaugeDrawProc * proc)
+{
     signed char buffer[32];
 
     u8 value;
     int i;
     int x;
 
-    for (i = 0; i < 6; i++) {
+    for (i = 0; i < 6; i++)
+    {
         value = proc->unk_30->unk_40[i];
 
-        if (value >= 30) {
+        if (value >= 30)
+        {
             value = 30;
         }
 
-        for (x = 0; (x < (value >> 2)); x++) {
-            PutSpriteExt(
-                13,
-                (x * 8) + 48,
-                (i * 16) + 16,
-                sSpriteLut_GaugePips[3],
-                0x4000
-            );
+        for (x = 0; (x < (value >> 2)); x++)
+        {
+            PutSpriteExt(13, (x * 8) + 48, (i * 16) + 16, sSpriteLut_GaugePips[3], 0x4000);
         }
 
-        if ((value & 3) != 0) {
-            PutSpriteExt(
-                13,
-                (x * 8) + 48,
-                (i * 16) + 16,
-                sSpriteLut_GaugePips[(value & 3) - 1],
-                0x4000
-            );
+        if ((value & 3) != 0)
+        {
+            PutSpriteExt(13, (x * 8) + 48, (i * 16) + 16, sSpriteLut_GaugePips[(value & 3) - 1], 0x4000);
         }
     }
 
@@ -1429,35 +1524,35 @@ void ClassStatsDisplay_Loop(struct OpInfoGaugeDrawProc* proc) {
 
     sub_80B369C(proc->unk_30->classReelEnt->classId, buffer);
 
-    for (i = 0; (buffer[i] != 0); ) {
-        struct ClassDisplayFont* res = GetClassDisplayFontInfo(buffer[i]);
+    for (i = 0; (buffer[i] != 0);)
+    {
+        struct ClassDisplayFont * res = GetClassDisplayFontInfo(buffer[i]);
 
-        if (res != 0) {
+        if (res != 0)
+        {
 
-            if (res->a != 0) {
-                PutSpriteExt(
-                    4,
-                    x - res->xBase - 2,
-                    5 - res->yBase,
-                    res->a,
-                    0x4000
-                );
+            if (res->a != 0)
+            {
+                PutSpriteExt(4, x - res->xBase - 2, 5 - res->yBase, res->a, 0x4000);
 
                 x += (res->width - res->xBase);
             }
-
-        } else {
+        }
+        else
+        {
             x += 4;
         }
 
         i++;
 
-        if (i > 13) {
+        if (i > 13)
+        {
             break;
         }
     }
 
-    if (proc->unk_2a < 255) {
+    if (proc->unk_2a < 255)
+    {
         proc->unk_2a++;
     }
 
@@ -1480,12 +1575,16 @@ struct ProcCmd CONST_DATA gProcScr_opinfogaugedraw[] =
 
 // clang-format on
 
-ProcPtr StartClassStatsDisplay(ProcPtr proc) {
+//! FE8U = 0x080B40D0
+ProcPtr StartClassStatsDisplay(ProcPtr proc)
+{
     return Proc_Start(gProcScr_opinfogaugedraw, proc);
 }
 
-void sub_80B40E4(ProcPtr proc, int unk) {
-    ((struct OpInfoGaugeDrawProc*)(proc))->unk_35 = unk;
+//! FE8U = 0x080B40E4
+void sub_80B40E4(ProcPtr proc, int unk)
+{
+    ((struct OpInfoGaugeDrawProc *)(proc))->unk_35 = unk;
     return;
 }
 // clang-format off
@@ -2179,6 +2278,8 @@ struct ClassReelEnt * CONST_DATA gClassReelOrderedLut[] =
 
 // clang-format on
 
-struct ClassReelEnt* GetClassReelEntry(int classSet, int index) {
+//! FE8U = 0x080B40EC
+struct ClassReelEnt * GetClassReelEntry(int classSet, int index)
+{
     return gClassReelOrderedLut[sClassReelClassSetLut[classSet] + index];
 }

--- a/src/opinfo.c
+++ b/src/opinfo.c
@@ -1225,43 +1225,43 @@ void ClassInfoDisplay_LoopWindowIn(struct OpInfoClassDisplayProc* proc) {
 
 void ClassInfoDisplay_ExecScript(struct OpInfoClassDisplayProc* proc) {
     switch (proc->script->opCode) {
-        case CLASS_REEL_OP_0:
+        case CLASS_REEL_OP_END:
             Proc_Goto(proc, 10);
 
             break;
 
-        case CLASS_REEL_OP_1:
+        case CLASS_REEL_OP_HIT_CLOSE:
             gOpInfoData.roundType = ANIM_ROUND_HIT_CLOSE;
             sub_805A7B4(&gOpInfoData);
 
             break;
 
-        case CLASS_REEL_OP_2:
+        case CLASS_REEL_OP_CRIT_CLOSE:
             gOpInfoData.roundType = ANIM_ROUND_CRIT_CLOSE;
             sub_805A7B4(&gOpInfoData);
 
             break;
 
-        case CLASS_REEL_OP_3:
-        case CLASS_REEL_OP_7:
+        case CLASS_REEL_OP_RETURN_TO_STANDING:
+        case CLASS_REEL_OP_RETURN_TO_STANDING_ALT:
             sub_805A990(&gOpInfoData);
 
             break;
 
-        case CLASS_REEL_OP_4:
+        case CLASS_REEL_OP_HIT_FAR:
             gOpInfoData.roundType = ANIM_ROUND_NONCRIT_FAR;
             sub_805A7B4(&gOpInfoData);
 
             break;
 
-        case CLASS_REEL_OP_6:
+        case CLASS_REEL_OP_DODGE:
             gOpInfoData.roundType = ANIM_ROUND_TAKING_MISS_CLOSE;
             sub_805A7B4(&gOpInfoData);
 
             break;
 
-        case CLASS_REEL_OP_5:
-        case CLASS_REEL_OP_8:
+        case CLASS_REEL_OP_WAIT_FRAMES:
+        case CLASS_REEL_OP_ROUND_END:
             break;
     }
 
@@ -1273,18 +1273,18 @@ void ClassInfoDisplay_ExecScript(struct OpInfoClassDisplayProc* proc) {
 void ClassInfoDisplay_LoopScript(struct OpInfoClassDisplayProc* proc) {
 
     switch (proc->script->opCode) {
-        case CLASS_REEL_OP_1:
-        case CLASS_REEL_OP_2:
-        case CLASS_REEL_OP_3:
-        case CLASS_REEL_OP_4:
-        case CLASS_REEL_OP_6:
-        case CLASS_REEL_OP_7:
+        case CLASS_REEL_OP_HIT_CLOSE:
+        case CLASS_REEL_OP_CRIT_CLOSE:
+        case CLASS_REEL_OP_RETURN_TO_STANDING:
+        case CLASS_REEL_OP_HIT_FAR:
+        case CLASS_REEL_OP_DODGE:
+        case CLASS_REEL_OP_RETURN_TO_STANDING_ALT:
             proc->script++;
             Proc_Break(proc);
 
             break;
 
-        case CLASS_REEL_OP_5:
+        case CLASS_REEL_OP_WAIT_FRAMES:
             proc->unk_2a++;
 
             if (proc->unk_2a < proc->script->extra) {
@@ -1296,7 +1296,7 @@ void ClassInfoDisplay_LoopScript(struct OpInfoClassDisplayProc* proc) {
 
             break;
 
-        case CLASS_REEL_OP_8:
+        case CLASS_REEL_OP_ROUND_END:
             if (sub_805A96C(&gOpInfoData) != 0) {
                 proc->script++;
                 Proc_Break(proc);
@@ -1588,146 +1588,159 @@ u16 CONST_DATA sSprite_08A2F1F0[] = {
     0x0000, 0x4000, 0x0780,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F1F8[] = {
-    { 5, 0x1E, },
-    { 1,    0, },
-    { 8,    0, },
-    { 5, 0x28, },
-    { 3,    0, },
-    { 5, 0x50, },
-    { 1,    0, },
-    { 8,    0, },
-    { 5, 0x28, },
-    { 3,    0, },
-    { 0,    0, },
+struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F1F8[] =
+{
+    CR_WAIT(30),
+    CR_ANIM_ROUND_HIT_CLOSE,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(40),
+    CR_RETURN_TO_STANDING,
+    CR_WAIT(80),
+    CR_ANIM_ROUND_HIT_CLOSE,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(40),
+    CR_RETURN_TO_STANDING,
+    CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F20E[] = {
-    { 5, 0x28, },
-    { 1,    0, },
-    { 8,    0, },
-    { 5, 0x28, },
-    { 3,    0, },
-    { 5, 0x64, },
-    { 1,    0, },
-    { 8,    0, },
-    { 5, 0x28, },
-    { 3,    0, },
-    { 0,    0, },
+struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F20E[] =
+{
+    CR_WAIT(40),
+    CR_ANIM_ROUND_HIT_CLOSE,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(40),
+    CR_RETURN_TO_STANDING,
+    CR_WAIT(100),
+    CR_ANIM_ROUND_HIT_CLOSE,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(40),
+    CR_RETURN_TO_STANDING,
+    CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F224[] = {
-    { 5, 0x28, },
-    { 1,    0, },
-    { 8,    0, },
-    { 5, 0x5A, },
-    { 3,    0, },
-    { 0,    0, },
+struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F224[] =
+{
+    CR_WAIT(40),
+    CR_ANIM_ROUND_HIT_CLOSE,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(90),
+    CR_RETURN_TO_STANDING,
+    CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F230[] = {
-    { 5, 0x3C, },
-    { 4,    0, },
-    { 8,    0, },
-    { 5, 0x46, },
-    { 3,    0, },
-    { 0,    0, },
+struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F230[] =
+{
+    CR_WAIT(60),
+    CR_ANIM_ROUND_NONCRIT_FAR,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(70),
+    CR_RETURN_TO_STANDING,
+    CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F23C[] = {
-    { 5, 0x3C, },
-    { 1,    0, },
-    { 8,    0, },
-    { 5, 0x28, },
-    { 3,    0, },
-    { 0,    0, },
+struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F23C[] =
+{
+    CR_WAIT(60),
+    CR_ANIM_ROUND_HIT_CLOSE,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(40),
+    CR_RETURN_TO_STANDING,
+    CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F248[] = {
-    { 5, 0x28, },
-    { 4,    0, },
-    { 8,    0, },
-    { 5, 0x28, },
-    { 3,    0, },
-    { 5, 0x48, },
-    { 4,    0, },
-    { 8,    0, },
-    { 5, 0x28, },
-    { 3,    0, },
-    { 0,    0, },
+struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F248[] =
+{
+    CR_WAIT(40),
+    CR_ANIM_ROUND_NONCRIT_FAR,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(40),
+    CR_RETURN_TO_STANDING,
+    CR_WAIT(72),
+    CR_ANIM_ROUND_NONCRIT_FAR,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(40),
+    CR_RETURN_TO_STANDING,
+    CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F25E[] = {
-    { 5, 0x28, },
-    { 4,    0, },
-    { 8,    0, },
-    { 5, 0x28, },
-    { 3,    0, },
-    { 0,    0, },
+struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F25E[] =
+{
+    CR_WAIT(40),
+    CR_ANIM_ROUND_NONCRIT_FAR,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(40),
+    CR_RETURN_TO_STANDING,
+    CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F26A[] = {
-    { 5, 0x50, },
-    { 4,    0, },
-    { 8,    0, },
-    { 5, 0x5A, },
-    { 3,    0, },
-    { 0,    0, },
+struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F26A[] =
+{
+    CR_WAIT(80),
+    CR_ANIM_ROUND_NONCRIT_FAR,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(90),
+    CR_RETURN_TO_STANDING,
+    CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F276[] = {
-    { 5, 0x50, },
-    { 4,    0, },
-    { 8,    0, },
-    { 5, 0x5A, },
-    { 3,    0, },
-    { 0,    0, },
+struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F276[] =
+{
+    CR_WAIT(80),
+    CR_ANIM_ROUND_NONCRIT_FAR,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(90),
+    CR_RETURN_TO_STANDING,
+    CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F282[] = {
-    { 5, 0x50, },
-    { 1,    0, },
-    { 8,    0, },
-    { 5, 0x64, },
-    { 3,    0, },
-    { 0,    0, },
+struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F282[] =
+{
+    CR_WAIT(80),
+    CR_ANIM_ROUND_HIT_CLOSE,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(100),
+    CR_RETURN_TO_STANDING,
+    CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F28E[] = {
-    { 5, 0x78, },
-    { 1,    0, },
-    { 8,    0, },
-    { 5, 0x28, },
-    { 3,    0, },
-    { 0,    0, },
+struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F28E[] =
+{
+    CR_WAIT(120),
+    CR_ANIM_ROUND_HIT_CLOSE,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(40),
+    CR_RETURN_TO_STANDING,
+    CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F29A[] = {
-    { 5, 0x28, },
-    { 4,    0, },
-    { 8,    0, },
-    { 5, 0xAA, },
-    { 3,    0, },
-    { 0,    0, },
+struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F29A[] =
+{
+    CR_WAIT(40),
+    CR_ANIM_ROUND_NONCRIT_FAR,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(170),
+    CR_RETURN_TO_STANDING,
+    CR_END,
 };
 
 struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F2A6[] = {
-    { 5, 0x3C, },
-    { 4,    0, },
-    { 8,    0, },
-    { 5, 0x60, },
-    { 3,    0, },
-    { 0,    0, },
+    CR_WAIT(60),
+    CR_ANIM_ROUND_NONCRIT_FAR,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(96),
+    CR_RETURN_TO_STANDING,
+    CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F2B2[] = {
-    { 5, 0x28, },
-    { 4,    0, },
-    { 8,    0, },
-    { 5, 0xC8, },
-    { 3,    0, },
-    { 0,    0, },
-    { 0,    0, },
+struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F2B2[] =
+{
+    CR_WAIT(40),
+    CR_ANIM_ROUND_NONCRIT_FAR,
+    CR_WAIT_ROUND_END,
+    CR_WAIT(200),
+    CR_RETURN_TO_STANDING,
+    CR_END,
+    CR_END,
 };
 
 u8* CONST_DATA gUnknown_08A2F2C0[] = {

--- a/src/opinfo.c
+++ b/src/opinfo.c
@@ -345,27 +345,23 @@ void ClassIntro_Init(struct OpInfoEnterProc * proc)
     ApplyPalette(gUnknown_08A30780, 0x1E);
     ApplyPalette(gUnknown_08A30780, 0x1F);
 
-    Decompress(gUnknown_08A301B0, OBJ_CHR_ADDR(0x300));
+    Decompress(Img_ClassReel_BigWeaponSprites, OBJ_CHR_ADDR(0x300));
 
     proc->unk_2c = ((240 - (((proc->classNameLength << 1) + proc->classNameLength) << 2)) >> 1) - 8;
 
     *proc->letterProcsPtr = StartClassNameIntroLetter(proc, 0);
 
-    Decompress(gUnknown_08A360E8, BG_CHR_ADDR(0x0));
-
-    Decompress(gUnknown_08A36284, gGenericBuffer);
+    Decompress(Img_ClassReelFiligree, BG_CHR_ADDR(0x0));
+    Decompress(Tsa_ClassReelFiligree, gGenericBuffer);
     CallARM_FillTileRect(TILEMAP_LOCATED(gBG0TilemapBuffer, 0, 7), gGenericBuffer, TILEREF(0x0, 4));
 
-    Decompress(gUnknown_08A35A3C, BG_CHR_ADDR(0x40));
-
-    Decompress(gUnknown_08A35FD0, gGenericBuffer);
+    Decompress(Img_ClassReel_NameBg, BG_CHR_ADDR(0x40));
+    Decompress(Tsa_ClassReel_NameBg, gGenericBuffer);
     CallARM_FillTileRect(gBG1TilemapBuffer, gGenericBuffer, TILEREF(0x40, 5));
-    ApplyPalette(gUnknown_08A360C8, 5);
+    ApplyPalette(Pal_ClassReel_NameBg, 5);
 
     Decompress(Img_ChapterIntro_LensFlare, BG_CHR_ADDR(0x400));
-
-    sub_800154C(gBG2TilemapBuffer, Tsa_08B18D68, 0, 5);
-
+    sub_800154C(gBG2TilemapBuffer, Tsa_ClassReel_LensFlare, 0, 5);
     ApplyPalettes(Pal_ChapterIntro_LensFlare, 0, 3);
 
     BG_EnableSyncByMask(BG2_SYNC_BIT);
@@ -689,7 +685,7 @@ void sub_80B30FC(u8 a, u8 b, u8 c)
     {
         if (((c >> i) & 1) != 0)
         {
-            PutSpriteExt(4, (tmp2) & 0x1FF, 0x50, *object, 0xF000);
+            PutSpriteExt(4, (tmp2) & 0x1FF, 0x50, *object, OAM2_PAL(15));
             tmp2 += 0x20;
         }
     }
@@ -794,13 +790,13 @@ void ClassIntroFlare_Loop(struct OpInfoFlareProc * proc)
 
     if (proc->unk_4c < 30)
     {
-        unkA = Interpolate(INTERPOLATE_RCUBIC, 4, 0x32, proc->unk_4c, 0x1E);
-        unkB = Interpolate(INTERPOLATE_RSQUARE, 0, 0x10, proc->unk_4c, 0x1E);
+        unkA = Interpolate(INTERPOLATE_RCUBIC, 4, 50, proc->unk_4c, 30);
+        unkB = Interpolate(INTERPOLATE_RSQUARE, 0, 16, proc->unk_4c, 30);
     }
     else
     {
-        unkA = Interpolate(INTERPOLATE_LINEAR, 0x32, 100, proc->unk_4c - 0x1E, 0x1E);
-        unkB = Interpolate(INTERPOLATE_LINEAR, 0x10, 0, proc->unk_4c - 0x1E, 0x1E);
+        unkA = Interpolate(INTERPOLATE_LINEAR, 50, 100, proc->unk_4c - 30, 30);
+        unkB = Interpolate(INTERPOLATE_LINEAR, 16, 0, proc->unk_4c - 30, 30);
     }
 
     if (49 < unkA)
@@ -808,8 +804,8 @@ void ClassIntroFlare_Loop(struct OpInfoFlareProc * proc)
         unkA = 100 - unkA;
     }
 
-    unkC = Interpolate(INTERPOLATE_LINEAR, 0, 0xD6, proc->unk_4c, 0x3C);
-    unkD = Interpolate(INTERPOLATE_LINEAR, 0x10, 0x80, proc->unk_4c, 0x3C);
+    unkC = Interpolate(INTERPOLATE_LINEAR, 0, 214, proc->unk_4c, 60);
+    unkD = Interpolate(INTERPOLATE_LINEAR, 16, 128, proc->unk_4c, 60);
 
     BgAffinRotScaling(BG_2, (s16)proc->unk_4e, 0, 0, (s16)(unkA * 5 + 0x80), (s16)(unkA * 5 + 0x80));
     BgAffinScaling(BG_2, 0x100, 0x100);
@@ -861,17 +857,20 @@ void ClassIntroBurst_Init(struct OpInfoBurstProc * proc)
     return;
 }
 
-extern u16 CONST_DATA sSprite_08A2F1F0[];
+extern u16 CONST_DATA Sprite_ClassIntroBurstBubble[];
 
 //! FE8U = 0x080B33FC
-void PutClassIntroBurstSprites(struct OpInfoBurstProc * proc, int b, int c, int d)
+void PutClassIntroBurstSprites(struct OpInfoBurstProc * proc, int affineId, int c, int d)
 {
-    int x = Interpolate(INTERPOLATE_RCUBIC, 0x78, c, proc->unk_4c, 0x46);
-    int y = Interpolate(INTERPOLATE_RCUBIC, 0x50, d, proc->unk_4c, 0x46);
+    int x = Interpolate(INTERPOLATE_RCUBIC, DISPLAY_WIDTH / 2, c, proc->unk_4c, 70);
+    int y = Interpolate(INTERPOLATE_RCUBIC, DISPLAY_HEIGHT / 2, d, proc->unk_4c, 70);
 
-    PutSpriteExt(4, ((x - 8) & 0x1FF) | (b << 9), ((y - 8) & 0x1FF) | 0x100, sSprite_08A2F1F0, 0xF000);
-
-    PutSpriteExt(4, ((0xE8 - x) & 0x1FF) | (b << 9), ((0x98 - y) & 0x1FF) | 0x100, sSprite_08A2F1F0, 0xF000);
+    PutSpriteExt(
+        4, (OAM1_X(x - 8)) | OAM1_AFFINE_ID(affineId), ((y - 8) & 0x1FF) | OAM0_AFFINE_ENABLE,
+        Sprite_ClassIntroBurstBubble, OAM2_PAL(15));
+    PutSpriteExt(
+        4, (OAM1_X(DISPLAY_WIDTH - 8 - x)) | OAM1_AFFINE_ID(affineId),
+        ((DISPLAY_HEIGHT - 8 - y) & 0x1FF) | OAM0_AFFINE_ENABLE, Sprite_ClassIntroBurstBubble, OAM2_PAL(15));
 
     return;
 }
@@ -883,11 +882,8 @@ void ClassIntroBurst_Loop(struct OpInfoBurstProc * proc)
 
     if (proc->unk_64 < 71)
     {
-        scale = Interpolate(INTERPOLATE_RSQUARE, 0x120, 0x10, proc->unk_64, 70);
-
-        SetObjAffine(
-            21, Div(+COS(0) << 4, scale), Div(-SIN(0) << 4, scale), Div(+SIN(0) << 4, scale), Div(+COS(0) << 4, scale));
-
+        scale = Interpolate(INTERPOLATE_RSQUARE, 288, 16, proc->unk_64, 70);
+        SetObjAffineAuto(21, 0, scale, scale);
         proc->unk_64++;
     }
 
@@ -895,11 +891,8 @@ void ClassIntroBurst_Loop(struct OpInfoBurstProc * proc)
 
     if (proc->unk_66 < 71)
     {
-        scale = Interpolate(INTERPOLATE_LINEAR, 0x120, 0x10, proc->unk_66, 70);
-
-        SetObjAffine(
-            22, Div(+COS(0) << 4, scale), Div(-SIN(0) << 4, scale), Div(+SIN(0) << 4, scale), Div(+COS(0) << 4, scale));
-
+        scale = Interpolate(INTERPOLATE_LINEAR, 288, 16, proc->unk_66, 70);
+        SetObjAffineAuto(22, 0, scale, scale);
         proc->unk_66++;
     }
 
@@ -907,7 +900,7 @@ void ClassIntroBurst_Loop(struct OpInfoBurstProc * proc)
 
     if (proc->unk_68 < 71)
     {
-        scale = Interpolate(INTERPOLATE_SQUARE, 0x120, 0x10, proc->unk_68, 70);
+        scale = Interpolate(INTERPOLATE_SQUARE, 288, 16, proc->unk_68, 70);
         SetObjAffineAuto(23, 0, scale, scale);
         proc->unk_68++;
     }
@@ -1014,7 +1007,7 @@ extern u8 gUnknown_0200A300[];
 extern u8 gUnknown_0200C300[];
 extern u8 gUnknown_0200CB00[];
 
-extern struct Text gUnk_OpInfo_0201FB28[6];
+extern struct Text gClassReelTexts[6];
 
 extern u8 gUnk_OpInfo_0201DB28[];
 
@@ -1048,10 +1041,9 @@ void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc * proc)
     } hack;
     int i;
     int hasMagicRank;
-    int r5;
     u16 * buffer;
 
-    hasMagicRank = 0;
+    hasMagicRank = FALSE;
 
     memcpy(hack.hack_2d, gUnknown_08205EDC, sizeof(hack.hack_2d));
 
@@ -1061,12 +1053,12 @@ void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc * proc)
     {
         if ((GetClassData(proc->classReelEnt->classId)->baseRanks[i]) != 0)
         {
-            hasMagicRank = 1;
+            hasMagicRank = TRUE;
             break;
         }
     }
 
-    SetupBackgrounds(0);
+    SetupBackgrounds(NULL);
 
     proc->unk_2a = 0;
     proc->unk_2c = 0;
@@ -1095,51 +1087,46 @@ void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc * proc)
     BG_SetPosition(BG_2, 0, 0);
     BG_SetPosition(BG_3, 0, 0);
 
-    Decompress(gUnknown_08A30E2C, (void *)(GetBackgroundTileDataOffset(BG_3) + VRAM));
-    ApplyPalettes(gUnknown_08A3593C, 7, 8);
+    Decompress(Img_ClassReel_InfoBg, (void *)(GetBackgroundTileDataOffset(BG_3) + VRAM));
+    ApplyPalettes(Pal_ClassReel_InfoBg, 7, 8);
+    CallARM_FillTileRect(gBG3TilemapBuffer, Tsa_ClassReel_InfoBg, TILEREF(0x0, 7));
 
-    CallARM_FillTileRect(gBG3TilemapBuffer, gUnknown_08A35488, TILEREF(0x0, 7));
-
-    Decompress(gUnknown_08A30800, (void *)(GetBackgroundTileDataOffset(BG_2) + VRAM));
+    Decompress(Img_ClassReel_UiBox, (void *)(GetBackgroundTileDataOffset(BG_2) + VRAM));
     ApplyPalette(gUiFramePaletteA, 6);
-
-    CallARM_FillTileRect(gBG2TilemapBuffer, gUnknown_08A30978, TILEREF(0x0, 6));
+    CallARM_FillTileRect(gBG2TilemapBuffer, Tsa_ClassReel_UiBox, TILEREF(0x0, 6));
 
     BG_EnableSyncByMask(BG0_SYNC_BIT | BG1_SYNC_BIT | BG2_SYNC_BIT | BG3_SYNC_BIT);
 
     BG_Fill(buffer, 0);
 
-    proc->unk_40[0] = GetClassData(proc->classReelEnt->classId)->baseHP;
-    proc->unk_40[1] = GetClassData(proc->classReelEnt->classId)->basePow;
-    proc->unk_40[2] = GetClassData(proc->classReelEnt->classId)->baseSkl;
-    proc->unk_40[3] = GetClassData(proc->classReelEnt->classId)->baseSpd;
-    proc->unk_40[4] = GetClassData(proc->classReelEnt->classId)->baseDef;
-    proc->unk_40[5] = GetClassData(proc->classReelEnt->classId)->baseRes;
+    proc->stats[0] = GetClassData(proc->classReelEnt->classId)->baseHP;
+    proc->stats[1] = GetClassData(proc->classReelEnt->classId)->basePow;
+    proc->stats[2] = GetClassData(proc->classReelEnt->classId)->baseSkl;
+    proc->stats[3] = GetClassData(proc->classReelEnt->classId)->baseSpd;
+    proc->stats[4] = GetClassData(proc->classReelEnt->classId)->baseDef;
+    proc->stats[5] = GetClassData(proc->classReelEnt->classId)->baseRes;
 
     for (i = 0; i <= 5; i++)
     {
-        InitText(&gUnk_OpInfo_0201FB28[i], 3);
+        InitText(&gClassReelTexts[i], 3);
 
-        ClearText(&gUnk_OpInfo_0201FB28[i]);
+        ClearText(&gClassReelTexts[i]);
 
-        Text_SetColor(&gUnk_OpInfo_0201FB28[i], TEXT_COLOR_SYSTEM_GOLD);
-        Text_SetCursor(&gUnk_OpInfo_0201FB28[i], 0);
+        Text_SetColor(&gClassReelTexts[i], TEXT_COLOR_SYSTEM_GOLD);
+        Text_SetCursor(&gClassReelTexts[i], 0);
 
         if (hasMagicRank != 0)
         {
-            Text_DrawString(&gUnk_OpInfo_0201FB28[i], GetStringFromIndex(hack.hack_2d[1][i]));
+            Text_DrawString(&gClassReelTexts[i], GetStringFromIndex(hack.hack_2d[1][i]));
         }
         else
         {
-            Text_DrawString(&gUnk_OpInfo_0201FB28[i], GetStringFromIndex(hack.hack_4d[0][i][1][-1]));
+            Text_DrawString(&gClassReelTexts[i], GetStringFromIndex(hack.hack_4d[0][i][1][-1]));
         }
 
-        PutText(&gUnk_OpInfo_0201FB28[i], buffer + 0x21 + (i * 0x40));
-
-        PutNumber(buffer + 0x25 + (i * 0x40), TEXT_COLOR_SYSTEM_WHITE, proc->unk_40[i]);
+        PutText(&gClassReelTexts[i], TILEMAP_LOCATED(buffer, 1, i * 2 + 1));
+        PutNumber(TILEMAP_LOCATED(buffer, 5, i * 2 + 1), TEXT_COLOR_SYSTEM_WHITE, proc->stats[i]);
     }
-
-    r5 = 0;
 
     proc->unk_3c = StartClassStatsDisplay(proc);
 
@@ -1175,23 +1162,23 @@ void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc * proc)
     gOpInfoData.unk_20 = gUnknown_02007838;
     gOpInfoData.unk_28 = gUnknown_020078D8;
 
-    gOpInfoData.unk_30 = &gUnknown_0200A2D8;
+    gOpInfoData.unk_30 = &gClassReelMagicAnim;
 
-    gUnknown_0200A2D8.magicFuncIdx = proc->classReelEnt->magicFx;
-    gUnknown_0200A2D8.xOffsetBg = proc->classReelEnt->unk_09;
-    gUnknown_0200A2D8.yOffsetBg = proc->classReelEnt->unk_0A;
-    gUnknown_0200A2D8.xOffsetObj = proc->classReelEnt->unk_0B;
-    gUnknown_0200A2D8.yOffsetObj = proc->classReelEnt->unk_0C;
-    gUnknown_0200A2D8.objChr = 0x280;
-    gUnknown_0200A2D8.objPalId = 0xF;
-    gUnknown_0200A2D8.bgChr = 0x200;
-    gUnknown_0200A2D8.bgPalId = 0xF;
-    gUnknown_0200A2D8.bg = 1;
-    gUnknown_0200A2D8.bgTmBuf = gBG1TilemapBuffer;
-    gUnknown_0200A2D8.bgImgBuf = gUnknown_0200A300;
-    gUnknown_0200A2D8.bgTsaBuf = gUnknown_0200C300;
-    gUnknown_0200A2D8.objImgBuf = gUnknown_0200CB00;
-    gUnknown_0200A2D8.resetCallback = sub_80B3740;
+    gClassReelMagicAnim.magicFuncIdx = proc->classReelEnt->magicFx;
+    gClassReelMagicAnim.xOffsetBg = proc->classReelEnt->unk_09;
+    gClassReelMagicAnim.yOffsetBg = proc->classReelEnt->unk_0A;
+    gClassReelMagicAnim.xOffsetObj = proc->classReelEnt->unk_0B;
+    gClassReelMagicAnim.yOffsetObj = proc->classReelEnt->unk_0C;
+    gClassReelMagicAnim.objChr = 0x280;
+    gClassReelMagicAnim.objPalId = 0xF;
+    gClassReelMagicAnim.bgChr = 0x200;
+    gClassReelMagicAnim.bgPalId = 0xF;
+    gClassReelMagicAnim.bg = 1;
+    gClassReelMagicAnim.bgTmBuf = gBG1TilemapBuffer;
+    gClassReelMagicAnim.bgImgBuf = gUnknown_0200A300;
+    gClassReelMagicAnim.bgTsaBuf = gUnknown_0200C300;
+    gClassReelMagicAnim.objImgBuf = gUnknown_0200CB00;
+    gClassReelMagicAnim.resetCallback = sub_80B3740;
 
     NewEkrUnitMainMini(&gOpInfoData);
 
@@ -1201,7 +1188,7 @@ void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc * proc)
     gUnk_Opinfo_0201DB00.terrain_r = proc->classReelEnt->unk_0E;
     gUnk_Opinfo_0201DB00.pal_r = 11;
     gUnk_Opinfo_0201DB00.chr_r = 0x3C0;
-    gUnk_Opinfo_0201DB00.distance = r5;
+    gUnk_Opinfo_0201DB00.distance = 0;
     gUnk_Opinfo_0201DB00.unk0E = -1;
 
     gUnk_Opinfo_0201DB00.unk1C = OBJ_CHR_ADDR(0x0);
@@ -1482,9 +1469,8 @@ void ClassStatsDisplay_Init(struct OpInfoGaugeDrawProc * proc)
         }
     }
 
-    Decompress(gUnknown_08A36338, OBJ_CHR_ADDR(0x0));
-
-    ApplyPalettes(gUnknown_08A372C0, 0x14, 2);
+    Decompress(Img_ClassReel_ClassNameLetters, OBJ_CHR_ADDR(0x0));
+    ApplyPalettes(Pal_ClassReel_ClassNameLetters, 0x14, 2);
 
     return;
 }
@@ -1502,7 +1488,7 @@ void ClassStatsDisplay_Loop(struct OpInfoGaugeDrawProc * proc)
 
     for (i = 0; i < 6; i++)
     {
-        value = proc->unk_30->unk_40[i];
+        value = proc->unk_30->stats[i];
 
         if (value >= 30)
         {
@@ -1681,7 +1667,7 @@ u16* CONST_DATA sSpriteLut_08A2F1D0[] =
     sSprite_08A2F1C8,
 };
 
-u16 CONST_DATA sSprite_08A2F1F0[] =
+u16 CONST_DATA Sprite_ClassIntroBurstBubble[] =
 {
     1,
     OAM0_SHAPE_16x16, OAM1_SIZE_16x16, OAM2_CHR(0x380) + OAM2_LAYER(1),

--- a/src/opinfo.c
+++ b/src/opinfo.c
@@ -18,7 +18,9 @@
 #include "ekrbattle.h"
 #include "bmlib.h"
 #include "sysutil.h"
+
 #include "constants/classes.h"
+#include "constants/msg.h"
 
 EWRAM_OVERLAY(gamestart) struct AnimBuffer gOpInfoData = {0};
 
@@ -49,7 +51,7 @@ void ClassReel_Init(struct OpInfoProc* proc) {
 
     gLCDControlBuffer.dispcnt.mode = 0;
 
-    SetupBackgrounds(0);
+    SetupBackgrounds(NULL);
 
     NewEfxAnimeDrvProc();
 
@@ -58,16 +60,12 @@ void ClassReel_Init(struct OpInfoProc* proc) {
     proc->unk_38 = 0;
     proc->unk_3c = 0;
 
-    gLCDControlBuffer.dispcnt.bg0_on = 0;
-    gLCDControlBuffer.dispcnt.bg1_on = 0;
-    gLCDControlBuffer.dispcnt.bg2_on = 0;
-    gLCDControlBuffer.dispcnt.bg3_on = 0;
-    gLCDControlBuffer.dispcnt.obj_on = 0;
+    SetDispEnable(FALSE, FALSE, FALSE, FALSE, FALSE);
 
-    BG_SetPosition(0, 0, 0);
-    BG_SetPosition(1, 0, 0);
-    BG_SetPosition(2, 0, 0);
-    BG_SetPosition(3, 0, 0);
+    BG_SetPosition(BG_0, 0, 0);
+    BG_SetPosition(BG_1, 0, 0);
+    BG_SetPosition(BG_2, 0, 0);
+    BG_SetPosition(BG_3, 0, 0);
 
     proc->index = 0;
     proc->mode = 2;
@@ -85,11 +83,7 @@ void ClassReel_ButtonPress_GoToTitle(struct OpInfoProc* proc) {
 
     Sound_FadeOutBGM(1);
 
-    gLCDControlBuffer.dispcnt.bg0_on = 0;
-    gLCDControlBuffer.dispcnt.bg1_on = 0;
-    gLCDControlBuffer.dispcnt.bg2_on = 0;
-    gLCDControlBuffer.dispcnt.bg3_on = 0;
-    gLCDControlBuffer.dispcnt.obj_on = 0;
+    SetDispEnable(FALSE, FALSE, FALSE, FALSE, FALSE);
 
     SetNextGameActionId(GAME_ACTION_EVENT_RETURN);
 
@@ -168,7 +162,10 @@ void ClassReel_OnEnd(ProcPtr proc) {
     return;
 }
 
-struct ProcCmd CONST_DATA gProcScr_opinfo[] = {
+// clang-format off
+
+struct ProcCmd CONST_DATA gProcScr_opinfo[] =
+{
     PROC_NAME("opinfo"),
     PROC_SLEEP(0),
 
@@ -190,6 +187,8 @@ PROC_LABEL(5),
     PROC_END,
 };
 
+// clang-format on
+
 void StartClassReel(u8 classSet, ProcPtr parent) {
     struct OpInfoProc* proc = Proc_StartBlocking(gProcScr_opinfo, parent);
     proc->classSet = classSet;
@@ -197,10 +196,15 @@ void StartClassReel(u8 classSet, ProcPtr parent) {
     return;
 }
 
-u16 CONST_DATA sSprite_08A2EF48[] = {
+// clang-format off
+
+u16 CONST_DATA sSprite_08A2EF48[] =
+{
     1,
-    0x8300, 0x8000, 0x0400
+    OAM0_SHAPE_16x32 + OAM0_AFFINE_ENABLE + OAM0_DOUBLESIZE, OAM1_SIZE_16x32, OAM2_LAYER(1),
 };
+
+// clang-format on
 
 void sub_80B2A14(u8 charId, int x, int y, u16 xScale, u16 yScale, u8 offset) {
     int i;
@@ -241,7 +245,7 @@ void sub_80B2A14(u8 charId, int x, int y, u16 xScale, u16 yScale, u8 offset) {
             (x & 0x1FF) + (charId << 9),
             y & 0x1FF,
             sSprite_08A2EF48,
-            charId * 2 + (k & 0xF) * 0x1000 + 0x800
+            charId * 2 + OAM2_PAL(k) + 0x800
         );
     } else {
         PutSpriteExt(
@@ -280,20 +284,14 @@ void ClassIntro_Init(struct OpInfoEnterProc* proc) {
     gLCDControlBuffer.bg2cnt.priority = 0;
     gLCDControlBuffer.bg3cnt.priority = 3;
 
-    gLCDControlBuffer.dispcnt.bg0_on = 0;
-    gLCDControlBuffer.dispcnt.bg1_on = 1;
-    gLCDControlBuffer.dispcnt.bg2_on = 1;
-    gLCDControlBuffer.dispcnt.bg3_on = 0;
-    gLCDControlBuffer.dispcnt.obj_on = 1;
+    SetDispEnable(FALSE, TRUE, TRUE, FALSE, TRUE);
 
     gLCDControlBuffer.bg2cnt.screenSize = 1;
     gLCDControlBuffer.bg2cnt.areaOverflowMode = 0;
 
-    gLCDControlBuffer.dispcnt.win0_on = 0;
-    gLCDControlBuffer.dispcnt.win1_on = 0;
-    gLCDControlBuffer.dispcnt.objWin_on = 0;
+    SetWinEnable(FALSE, FALSE, FALSE);
 
-    SetBlendConfig(1, 0, 0x10, 0);
+    SetBlendAlpha(0, 0x10);
 
     SetBlendTargetA(0, 0, 1, 0, 0);
     SetBlendTargetB(1, 1, 0, 0, 1);
@@ -351,7 +349,7 @@ void ClassIntro_Init(struct OpInfoEnterProc* proc) {
 
     ApplyPalettes(Pal_ChapterIntro_LensFlare, 0, 3);
 
-    BG_EnableSyncByMask(4);
+    BG_EnableSyncByMask(BG2_SYNC_BIT);
 
     return;
 }
@@ -436,12 +434,7 @@ void ClassIntro_LoopOut(struct OpInfoEnterProc* proc) {
 }
 
 void ClassIntro_DisableAllExceptBg1(ProcPtr proc) {
-    gLCDControlBuffer.dispcnt.bg0_on = 0;
-    gLCDControlBuffer.dispcnt.bg1_on = 1;
-    gLCDControlBuffer.dispcnt.bg2_on = 0;
-    gLCDControlBuffer.dispcnt.bg3_on = 0;
-    gLCDControlBuffer.dispcnt.obj_on = 0;
-
+    SetDispEnable(FALSE, TRUE, FALSE, FALSE, FALSE);
     return;
 }
 
@@ -453,7 +446,10 @@ void ClassIntro_OnEnd(ProcPtr proc) {
     return;
 }
 
-struct ProcCmd CONST_DATA gProcScr_opinfoenter[] = {
+// clang-format off
+
+struct ProcCmd CONST_DATA gProcScr_opinfoenter[] =
+{
     PROC_NAME("opinfoenter"),
 
     PROC_CALL_ARG(NewFadeIn, 16),
@@ -477,6 +473,8 @@ PROC_LABEL(4),
 
     PROC_END,
 };
+
+// clang-format on
 
 ProcPtr StartClassNameIntro(ProcPtr parent, struct ClassReelEnt* entry) {
     struct OpInfoEnterProc* proc = Proc_Start(gProcScr_opinfoenter, parent);
@@ -555,7 +553,10 @@ void ClassIntroLetter_LoopFadeOut(struct OpInfoViewProc* proc) {
     return;
 }
 
-struct ProcCmd CONST_DATA gProcScr_opinfoview[] = {
+// clang-format off
+
+struct ProcCmd CONST_DATA gProcScr_opinfoview[] =
+{
     PROC_NAME("opinfoview"),
     PROC_SLEEP(1),
 
@@ -567,6 +568,8 @@ struct ProcCmd CONST_DATA gProcScr_opinfoview[] = {
 
     PROC_END,
 };
+
+// clang-format on
 
 ProcPtr StartClassNameIntroLetter(ProcPtr parent, u8 index) {
     struct OpInfoViewProc* proc = Proc_Start(gProcScr_opinfoview, parent);
@@ -679,12 +682,7 @@ void ClassIntroIcon_LoopFadeOut(struct OpInfoIconProc* proc) {
     proc->timer++;
 
     if ((proc->timer >> 1) >= 17) {
-        gLCDControlBuffer.dispcnt.bg0_on = 0;
-        gLCDControlBuffer.dispcnt.bg1_on = 1;
-        gLCDControlBuffer.dispcnt.bg2_on = 0;
-        gLCDControlBuffer.dispcnt.bg3_on = 0;
-        gLCDControlBuffer.dispcnt.obj_on = 1;
-
+        SetDispEnable(FALSE, TRUE, FALSE, FALSE, TRUE);
         Proc_Break(proc);
     } else {
         sub_80B30FC((proc->timer >> 1), proc->numIcons, proc->unk_2e);
@@ -693,7 +691,10 @@ void ClassIntroIcon_LoopFadeOut(struct OpInfoIconProc* proc) {
     return;
 }
 
-struct ProcCmd CONST_DATA gProcScr_opinfoicon[] = {
+// clang-format off
+
+struct ProcCmd CONST_DATA gProcScr_opinfoicon[] =
+{
     PROC_NAME("opinfoicon"),
     PROC_SLEEP(1),
 
@@ -708,6 +709,8 @@ PROC_LABEL(4),
     PROC_END,
 };
 
+// clang-format on
+
 ProcPtr StartClassNameIntroIcon(ProcPtr parent, u8 classId) {
     struct OpInfoIconProc* proc;
 
@@ -721,11 +724,7 @@ void ClassIntroFlare_Init(struct OpInfoFlareProc* proc) {
     proc->unk_4c = 0;
     proc->unk_4e = 0;
 
-    gLCDControlBuffer.dispcnt.bg0_on = 1;
-    gLCDControlBuffer.dispcnt.bg1_on = 1;
-    gLCDControlBuffer.dispcnt.bg2_on = 1;
-    gLCDControlBuffer.dispcnt.bg3_on = 0;
-    gLCDControlBuffer.dispcnt.obj_on = 1;
+    SetDispEnable(TRUE, TRUE, TRUE, FALSE, TRUE);
 
     return;
 }
@@ -737,40 +736,33 @@ void ClassIntroFlare_Loop(struct OpInfoFlareProc* proc) {
     int unkD;
 
     if (proc->unk_4c < 30) {
-        unkA = Interpolate(5, 4, 0x32, proc->unk_4c, 0x1E);
-        unkB = Interpolate(4, 0, 0x10, proc->unk_4c, 0x1E);
+        unkA = Interpolate(INTERPOLATE_RCUBIC, 4, 0x32, proc->unk_4c, 0x1E);
+        unkB = Interpolate(INTERPOLATE_RSQUARE, 0, 0x10, proc->unk_4c, 0x1E);
     } else {
-        unkA = Interpolate(0, 0x32, 100, proc->unk_4c - 0x1E, 0x1E);
-        unkB = Interpolate(0, 0x10, 0, proc->unk_4c - 0x1E, 0x1E);
+        unkA = Interpolate(INTERPOLATE_LINEAR, 0x32, 100, proc->unk_4c - 0x1E, 0x1E);
+        unkB = Interpolate(INTERPOLATE_LINEAR, 0x10, 0, proc->unk_4c - 0x1E, 0x1E);
     }
 
     if (49 < unkA) {
         unkA = 100 - unkA;
     }
 
-    unkC = Interpolate(0, 0, 0xD6, proc->unk_4c, 0x3C);
-    unkD = Interpolate(0, 0x10, 0x80, proc->unk_4c, 0x3C);
+    unkC = Interpolate(INTERPOLATE_LINEAR, 0, 0xD6, proc->unk_4c, 0x3C);
+    unkD = Interpolate(INTERPOLATE_LINEAR, 0x10, 0x80, proc->unk_4c, 0x3C);
 
-    BgAffinRotScaling(2, (s16)proc->unk_4e, 0, 0, (s16)(unkA * 5 + 0x80), (s16)(unkA * 5 + 0x80));
-
-    BgAffinScaling(2, 0x100, 0x100);
-
-    BgAffinAnchoring(2, unkC, unkD, 0x50, 0x48);
+    BgAffinRotScaling( BG_2, (s16)proc->unk_4e, 0, 0, (s16)(unkA * 5 + 0x80), (s16)(unkA * 5 + 0x80));
+    BgAffinScaling(BG_2, 0x100, 0x100);
+    BgAffinAnchoring(BG_2, unkC, unkD, 0x50, 0x48);
 
     proc->unk_4e -= 0x40;
 
-    SetBlendConfig(1, unkB, 0x10, 0);
+    SetBlendAlpha(unkB, 0x10);
 
     proc->unk_4c++;
 
     if (59 < proc->unk_4c) {
         Proc_Break(proc);
-
-        gLCDControlBuffer.dispcnt.bg0_on = 1;
-        gLCDControlBuffer.dispcnt.bg1_on = 1;
-        gLCDControlBuffer.dispcnt.bg2_on = 0;
-        gLCDControlBuffer.dispcnt.bg3_on = 0;
-        gLCDControlBuffer.dispcnt.obj_on = 1;
+        SetDispEnable(TRUE, TRUE, FALSE, FALSE, TRUE);
     }
 
     return;
@@ -778,7 +770,10 @@ void ClassIntroFlare_Loop(struct OpInfoFlareProc* proc) {
 
 extern struct ProcCmd CONST_DATA gProcScr_ClassIntro_BurstFX[];
 
-struct ProcCmd CONST_DATA gProcScr_ClassIntro_FlareFX[] = {
+// clang-format off
+
+struct ProcCmd CONST_DATA gProcScr_ClassIntro_FlareFX[] =
+{
     PROC_SLEEP(1),
 
     PROC_CALL(ClassIntroFlare_Init),
@@ -790,6 +785,8 @@ struct ProcCmd CONST_DATA gProcScr_ClassIntro_FlareFX[] = {
 
     PROC_END,
 };
+
+// clang-format on
 
 void ClassIntroBurst_Init(struct OpInfoBurstProc* proc) {
     proc->unk_4c = 0;
@@ -818,7 +815,7 @@ void ClassIntroBurst_Loop(struct OpInfoBurstProc* proc) {
     int scale;
 
     if (proc->unk_64 < 71) {
-        scale = Interpolate(4, 0x120, 0x10, proc->unk_64, 70);
+        scale = Interpolate(INTERPOLATE_RSQUARE, 0x120, 0x10, proc->unk_64, 70);
 
         SetObjAffine(
             21,
@@ -834,7 +831,7 @@ void ClassIntroBurst_Loop(struct OpInfoBurstProc* proc) {
     PutClassIntroBurstSprites(proc, 21, 215, 17);
 
     if (proc->unk_66 < 71) {
-        scale = Interpolate(0, 0x120, 0x10, proc->unk_66, 70);
+        scale = Interpolate(INTERPOLATE_LINEAR, 0x120, 0x10, proc->unk_66, 70);
 
         SetObjAffine(
             22,
@@ -850,7 +847,7 @@ void ClassIntroBurst_Loop(struct OpInfoBurstProc* proc) {
     PutClassIntroBurstSprites(proc, 22, 192, 32);
 
     if (proc->unk_68 < 71) {
-        scale = Interpolate(1, 0x120, 0x10, proc->unk_68, 70);
+        scale = Interpolate(INTERPOLATE_SQUARE, 0x120, 0x10, proc->unk_68, 70);
 
         SetObjAffine(
             23,
@@ -874,7 +871,10 @@ void ClassIntroBurst_Loop(struct OpInfoBurstProc* proc) {
     return;
 }
 
-struct ProcCmd CONST_DATA gProcScr_ClassIntro_BurstFX[] = {
+// clang-format off
+
+struct ProcCmd CONST_DATA gProcScr_ClassIntro_BurstFX[] =
+{
     PROC_SLEEP(30),
 
     PROC_CALL(ClassIntroBurst_Init),
@@ -882,6 +882,8 @@ struct ProcCmd CONST_DATA gProcScr_ClassIntro_BurstFX[] = {
 
     PROC_END,
 };
+
+// clang-format on
 
 signed char* sub_80B369C(u8 classId, signed char* buffer) {
     char* str;
@@ -920,32 +922,16 @@ void sub_80B36E0(void) {
 }
 
 void sub_80B3740(void) {
-
-    SetBlendConfig(1, 0x10, 0x10, 0);
+    SetBlendAlpha(0x10, 0x10);
 
     SetBlendTargetA(0, 1, 0, 0, 0);
     SetBlendTargetB(0, 0, 1, 1, 1);
 
-    gLCDControlBuffer.dispcnt.win0_on = 1;
-    gLCDControlBuffer.dispcnt.win1_on = 0;
-    gLCDControlBuffer.dispcnt.objWin_on = 0;
+    SetWinEnable(TRUE, FALSE, FALSE);
+    SetWin0Box(0, 0, DISPLAY_WIDTH, DISPLAY_HEIGHT);
 
-    gLCDControlBuffer.win0_left = 0;
-    gLCDControlBuffer.win0_top = 0;
-    gLCDControlBuffer.win0_right = 240;
-    gLCDControlBuffer.win0_bottom = 160;
-
-    gLCDControlBuffer.wincnt.win0_enableBg0 = 1;
-    gLCDControlBuffer.wincnt.win0_enableBg1 = 1;
-    gLCDControlBuffer.wincnt.win0_enableBg2 = 1;
-    gLCDControlBuffer.wincnt.win0_enableBg3 = 1;
-    gLCDControlBuffer.wincnt.win0_enableObj = 1;
-
-    gLCDControlBuffer.wincnt.wout_enableBg0 = 1;
-    gLCDControlBuffer.wincnt.wout_enableBg1 = 0;
-    gLCDControlBuffer.wincnt.wout_enableBg2 = 1;
-    gLCDControlBuffer.wincnt.wout_enableBg3 = 1;
-    gLCDControlBuffer.wincnt.wout_enableObj = 1;
+    SetWin0Layers(TRUE, TRUE, TRUE, TRUE, TRUE);
+    SetWOutLayers(TRUE, FALSE, TRUE, TRUE, TRUE);
 
     gLCDControlBuffer.wincnt.win0_enableBlend = 1;
     gLCDControlBuffer.wincnt.wout_enableBlend = 0;
@@ -971,20 +957,20 @@ extern u8 gUnk_OpInfo_0201DB28[];
 
 const int gUnknown_08205EDC[2][6] = {
     {
-        0x4E9, // "HP"
-        0x4FE, // "Str"
-        0x4EC, // "Skill"
-        0x4ED, // "Spd"
-        0x4EF, // "Def"
-        0x4F0, // "Res"
+        MSG_4E9, // "HP"
+        MSG_4FE, // "Str"
+        MSG_4EC, // "Skill"
+        MSG_4ED, // "Spd"
+        MSG_4EF, // "Def"
+        MSG_4F0, // "Res"
     },
     {
-        0x4E9, // "HP"
-        0x4FF, // "Mag"
-        0x4EC, // "Skill"
-        0x4ED, // "Spd"
-        0x4EF, // "Def"
-        0x4F0, // "Res"
+        MSG_4E9, // "HP"
+        MSG_4FF, // "Mag"
+        MSG_4EC, // "Skill"
+        MSG_4ED, // "Spd"
+        MSG_4EF, // "Def"
+        MSG_4F0, // "Res"
     },
 };
 
@@ -1023,18 +1009,12 @@ void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc* proc) {
     BG_Fill(gBG1TilemapBuffer, 0);
     BG_Fill(gBG2TilemapBuffer, 0);
 
-    gLCDControlBuffer.dispcnt.bg0_on = 0;
-    gLCDControlBuffer.dispcnt.bg1_on = 0;
-    gLCDControlBuffer.dispcnt.bg2_on = 0;
-    gLCDControlBuffer.dispcnt.bg3_on = 0;
-    gLCDControlBuffer.dispcnt.obj_on = 0;
+    SetDispEnable(FALSE, FALSE, FALSE, FALSE, FALSE);
 
     gLCDControlBuffer.dispcnt.mode = 0;
 
     SetDefaultColorEffects();
-
     ResetTextFont();
-
     ResetText();
 
     gLCDControlBuffer.bg0cnt.priority = 2;
@@ -1042,10 +1022,10 @@ void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc* proc) {
     gLCDControlBuffer.bg2cnt.priority = 2;
     gLCDControlBuffer.bg3cnt.priority = 3;
 
-    BG_SetPosition(0, 0, 0);
-    BG_SetPosition(1, 0, 0);
-    BG_SetPosition(2, 0, 0);
-    BG_SetPosition(3, 0, 0);
+    BG_SetPosition(BG_0, 0, 0);
+    BG_SetPosition(BG_1, 0, 0);
+    BG_SetPosition(BG_2, 0, 0);
+    BG_SetPosition(BG_3, 0, 0);
 
     Decompress(gUnknown_08A30E2C, (void *)(GetBackgroundTileDataOffset(3) + VRAM));
     ApplyPalettes(gUnknown_08A3593C, 7, 8);
@@ -1057,7 +1037,7 @@ void ClassInfoDisplay_Init(struct OpInfoClassDisplayProc* proc) {
 
     CallARM_FillTileRect(gBG2TilemapBuffer, gUnknown_08A30978, 0x6000);
 
-    BG_EnableSyncByMask(0xF);
+    BG_EnableSyncByMask(BG0_SYNC_BIT | BG1_SYNC_BIT | BG2_SYNC_BIT | BG3_SYNC_BIT);
 
     BG_Fill(buffer, 0);
 
@@ -1196,7 +1176,6 @@ void ClassInfoDisplay_LoopWindowIn(struct OpInfoClassDisplayProc* proc) {
     }
 
     SetDispEnable(1, 1, 1, 1, 1);
-
     SetWinEnable(1, 0, 0);
 
     SetWin0Box(0, 80 - proc->unk_2a, 240, proc->unk_2a + 80);
@@ -1308,7 +1287,7 @@ void ClassInfoDisplay_LoopScript(struct OpInfoClassDisplayProc* proc) {
 
 void ClassInfoDisplay_OnEnd(struct OpInfoClassDisplayProc* proc) {
 
-    SetPrimaryHBlankHandler(0);
+    SetPrimaryHBlankHandler(NULL);
 
     EndTalk();
     EndActiveClassReelBgColorProc();
@@ -1485,7 +1464,10 @@ void ClassStatsDisplay_Loop(struct OpInfoGaugeDrawProc* proc) {
     return;
 }
 
-struct ProcCmd CONST_DATA gProcScr_opinfogaugedraw[] ={
+// clang-format off
+
+struct ProcCmd CONST_DATA gProcScr_opinfogaugedraw[] =
+{
     PROC_NAME("opinfogaugedraw"),
 
     PROC_SLEEP(3),
@@ -1496,6 +1478,8 @@ struct ProcCmd CONST_DATA gProcScr_opinfogaugedraw[] ={
     PROC_END,
 };
 
+// clang-format on
+
 ProcPtr StartClassStatsDisplay(ProcPtr proc) {
     return Proc_Start(gProcScr_opinfogaugedraw, proc);
 }
@@ -1504,25 +1488,31 @@ void sub_80B40E4(ProcPtr proc, int unk) {
     ((struct OpInfoGaugeDrawProc*)(proc))->unk_35 = unk;
     return;
 }
+// clang-format off
 
-u16 CONST_DATA sSprite_08A2F160[] = {
+
+u16 CONST_DATA sSprite_08A2F160[] =
+{
     1,
-    0x0000, 0x0000, 0x093F,
+    OAM0_SHAPE_8x8, OAM1_SIZE_8x8, OAM2_CHR(0x13F) + OAM2_LAYER(2),
 };
 
-u16 CONST_DATA sSprite_08A2F168[] = {
+u16 CONST_DATA sSprite_08A2F168[] =
+{
     1,
-    0x0000, 0x0000, 0x093E,
+    OAM0_SHAPE_8x8, OAM1_SIZE_8x8, OAM2_CHR(0x13E) + OAM2_LAYER(2),
 };
 
-u16 CONST_DATA sSprite_08A2F170[] = {
+u16 CONST_DATA sSprite_08A2F170[] =
+{
     1,
-    0x0000, 0x0000, 0x093D,
+    OAM0_SHAPE_8x8, OAM1_SIZE_8x8, OAM2_CHR(0x13D) + OAM2_LAYER(2),
 };
 
-u16 CONST_DATA sSprite_08A2F178[] = {
+u16 CONST_DATA sSprite_08A2F178[] =
+{
     1,
-    0x0000, 0x0000, 0x093C,
+    OAM0_SHAPE_8x8, OAM1_SIZE_8x8, OAM2_CHR(0x13C) + OAM2_LAYER(2),
 };
 
 u16* CONST_DATA sSpriteLut_GaugePips[] = {
@@ -1532,47 +1522,56 @@ u16* CONST_DATA sSpriteLut_GaugePips[] = {
     sSprite_08A2F178,
 };
 
-u16 CONST_DATA sSprite_08A2F190[] = {
+u16 CONST_DATA sSprite_08A2F190[] =
+{
     1,
-    0x0000, 0x8000, 0x0700,
+    OAM0_SHAPE_32x32, OAM1_SIZE_32x32, OAM2_CHR(0x300) + OAM2_LAYER(1),
 };
 
-u16 CONST_DATA sSprite_08A2F198[] = {
+u16 CONST_DATA sSprite_08A2F198[] =
+{
     1,
-    0x0000, 0x8000, 0x0704,
+    OAM0_SHAPE_32x32, OAM1_SIZE_32x32, OAM2_CHR(0x304) + OAM2_LAYER(1),
 };
 
-u16 CONST_DATA sSprite_08A2F1A0[] = {
+u16 CONST_DATA sSprite_08A2F1A0[] =
+{
     1,
-    0x0000, 0x8000, 0x0708,
+    OAM0_SHAPE_32x32, OAM1_SIZE_32x32, OAM2_CHR(0x308) + OAM2_LAYER(1),
 };
 
-u16 CONST_DATA sSprite_08A2F1A8[] = {
+u16 CONST_DATA sSprite_08A2F1A8[] =
+{
     1,
-    0x0000, 0x8000, 0x070C,
+    OAM0_SHAPE_32x32, OAM1_SIZE_32x32, OAM2_CHR(0x30C) + OAM2_LAYER(1),
 };
 
-u16 CONST_DATA sSprite_08A2F1B0[] = {
+u16 CONST_DATA sSprite_08A2F1B0[] =
+{
     1,
-    0x0000, 0x8000, 0x0710,
+    OAM0_SHAPE_32x32, OAM1_SIZE_32x32, OAM2_CHR(0x310) + OAM2_LAYER(1),
 };
 
-u16 CONST_DATA sSprite_08A2F1B8[] = {
+u16 CONST_DATA sSprite_08A2F1B8[] =
+{
     1,
-    0x0000, 0x8000, 0x0714,
+    OAM0_SHAPE_32x32, OAM1_SIZE_32x32, OAM2_CHR(0x314) + OAM2_LAYER(1),
 };
 
-u16 CONST_DATA sSprite_08A2F1C0[] = {
+u16 CONST_DATA sSprite_08A2F1C0[] =
+{
     1,
-    0x0000, 0x8000, 0x0718,
+    OAM0_SHAPE_32x32, OAM1_SIZE_32x32, OAM2_CHR(0x318) + OAM2_LAYER(1),
 };
 
-u16 CONST_DATA sSprite_08A2F1C8[] = {
+u16 CONST_DATA sSprite_08A2F1C8[] =
+{
     1,
-    0x0000, 0x8000, 0x071C,
+    OAM0_SHAPE_32x32, OAM1_SIZE_32x32, OAM2_CHR(0x31C) + OAM2_LAYER(1),
 };
 
-u16* CONST_DATA sSpriteLut_08A2F1D0[] = {
+u16* CONST_DATA sSpriteLut_08A2F1D0[] =
+{
     sSprite_08A2F190,
     sSprite_08A2F198,
     sSprite_08A2F1A0,
@@ -1583,12 +1582,13 @@ u16* CONST_DATA sSpriteLut_08A2F1D0[] = {
     sSprite_08A2F1C8,
 };
 
-u16 CONST_DATA sSprite_08A2F1F0[] = {
+u16 CONST_DATA sSprite_08A2F1F0[] =
+{
     1,
-    0x0000, 0x4000, 0x0780,
+    OAM0_SHAPE_16x16, OAM1_SIZE_16x16, OAM2_CHR(0x380) + OAM2_LAYER(1),
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F1F8[] =
+struct ClassReelAnimScr CONST_DATA ClassReelScr_CloseDoubleHit[] =
 {
     CR_WAIT(30),
     CR_ANIM_ROUND_HIT_CLOSE,
@@ -1603,7 +1603,7 @@ struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F1F8[] =
     CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F20E[] =
+struct ClassReelAnimScr CONST_DATA ClassReelScr_Sniper[] =
 {
     CR_WAIT(40),
     CR_ANIM_ROUND_HIT_CLOSE,
@@ -1618,7 +1618,7 @@ struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F20E[] =
     CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F224[] =
+struct ClassReelAnimScr CONST_DATA ClassReelScr_CloseSingleHit[] =
 {
     CR_WAIT(40),
     CR_ANIM_ROUND_HIT_CLOSE,
@@ -1628,7 +1628,7 @@ struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F224[] =
     CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F230[] =
+struct ClassReelAnimScr CONST_DATA ClassReelScr_Ranger[] =
 {
     CR_WAIT(60),
     CR_ANIM_ROUND_NONCRIT_FAR,
@@ -1638,7 +1638,7 @@ struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F230[] =
     CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F23C[] =
+struct ClassReelAnimScr CONST_DATA ClassReelScr_Assassin[] =
 {
     CR_WAIT(60),
     CR_ANIM_ROUND_HIT_CLOSE,
@@ -1648,7 +1648,7 @@ struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F23C[] =
     CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F248[] =
+struct ClassReelAnimScr CONST_DATA ClassReelScr_AnimaDoubleCast[] =
 {
     CR_WAIT(40),
     CR_ANIM_ROUND_NONCRIT_FAR,
@@ -1663,7 +1663,7 @@ struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F248[] =
     CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F25E[] =
+struct ClassReelAnimScr CONST_DATA ClassReelScr_Pupil[] =
 {
     CR_WAIT(40),
     CR_ANIM_ROUND_NONCRIT_FAR,
@@ -1673,7 +1673,7 @@ struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F25E[] =
     CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F26A[] =
+struct ClassReelAnimScr CONST_DATA ClassReelScr_MagicSingleCast[] =
 {
     CR_WAIT(80),
     CR_ANIM_ROUND_NONCRIT_FAR,
@@ -1683,7 +1683,7 @@ struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F26A[] =
     CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F276[] =
+struct ClassReelAnimScr CONST_DATA ClassReelScr_StaffSingleCast[] =
 {
     CR_WAIT(80),
     CR_ANIM_ROUND_NONCRIT_FAR,
@@ -1693,7 +1693,7 @@ struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F276[] =
     CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F282[] =
+struct ClassReelAnimScr CONST_DATA ClassReelScr_Dancer[] =
 {
     CR_WAIT(80),
     CR_ANIM_ROUND_HIT_CLOSE,
@@ -1703,7 +1703,7 @@ struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F282[] =
     CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F28E[] =
+struct ClassReelAnimScr CONST_DATA ClassReelScr_Manakete[] =
 {
     CR_WAIT(120),
     CR_ANIM_ROUND_HIT_CLOSE,
@@ -1713,7 +1713,7 @@ struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F28E[] =
     CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F29A[] =
+struct ClassReelAnimScr CONST_DATA ClassReelScr_DarkMagicSingleCast[] =
 {
     CR_WAIT(40),
     CR_ANIM_ROUND_NONCRIT_FAR,
@@ -1723,7 +1723,7 @@ struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F29A[] =
     CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F2A6[] = {
+struct ClassReelAnimScr CONST_DATA ClassReelScr_Mogall[] = {
     CR_WAIT(60),
     CR_ANIM_ROUND_NONCRIT_FAR,
     CR_WAIT_ROUND_END,
@@ -1732,7 +1732,7 @@ struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F2A6[] = {
     CR_END,
 };
 
-struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F2B2[] =
+struct ClassReelAnimScr CONST_DATA ClassReelScr_Gorgon[] =
 {
     CR_WAIT(40),
     CR_ANIM_ROUND_NONCRIT_FAR,
@@ -1743,7 +1743,8 @@ struct ClassReelAnimScr CONST_DATA sClassReelScr_08A2F2B2[] =
     CR_END,
 };
 
-u8* CONST_DATA gUnknown_08A2F2C0[] = {
+u8 * CONST_DATA gUnknown_08A2F2C0[] =
+{
     NULL,
     NULL,
     NULL,
@@ -2002,75 +2003,77 @@ u8* CONST_DATA gUnknown_08A2F2C0[] = {
     NULL,
 };
 
-struct ClassReelEnt CONST_DATA gClassReelData[65] = {
-    [0x00] = { 0x6F6, 0xFF, CLASS_EIRIKA_LORD, 0, 0x02, 0, 0, 0, 0, 0, 0x14, 0x14, 0, sClassReelScr_08A2F1F8 },
-    [0x01] = { 0x6FA, 0x3B, CLASS_PALADIN, 0, 0x3A, 0, 0, 0, 0, 0, 0x0B, 0x12, 0, sClassReelScr_08A2F224 },
-    [0x02] = { 0x6FB, 0x02, CLASS_ARMOR_KNIGHT, 0, 0x3F, 0, 0, 0, 0, 0, 0x02, 0x02, 0, sClassReelScr_08A2F224 },
-    [0x03] = { 0x6F9, 0xFF, CLASS_CAVALIER, 0, 0x33, 0, 0, 0, 0, 0, 0x11, 0, 0, sClassReelScr_08A2F1F8 },
-    [0x04] = { 0x71C, 0x3F, CLASS_PEGASUS_KNIGHT, 0, 0x65, 0, 0, 0, 0, 0, 0x19, 0x19, 0, sClassReelScr_08A2F1F8 },
-    [0x05] = { 0x71A, 0x44, CLASS_PRIEST, 0, 0x7E, 0x03, 0, 0, 0, 0, 0x0B, 0x12, 0, sClassReelScr_08A2F276 },
-    [0x06] = { 0x70E, 0xFF, CLASS_JOURNEYMAN, 0, 0x91, 0, 0, 0, 0, 0, 0x11, 0, 0, sClassReelScr_08A2F1F8 },
-    [0x07] = { 0x711, 0x1D, CLASS_FIGHTER, 0, 0x18, 0, 0, 0, 0, 0, 0, 0, 0, sClassReelScr_08A2F1F8 },
-    [0x08] = { 0x6FD, 0x5D, CLASS_THIEF, 0, 0x88, 0, 0, 0, 0, 0, 0x1C, 0x1C, 0, sClassReelScr_08A2F1F8 },
-    [0x09] = { 0x703, 0, CLASS_ARCHER, 0, 0x27, 0, 0, 0, 0, 0, 0x13, 0x13, 0, sClassReelScr_08A2F1F8 },
-    [0x0A] = { 0x709, 0x2E, CLASS_MAGE_F, 0, 0x6B, 0x01, 0, 0, 0, 0, 0x19, 0x19, 0, sClassReelScr_08A2F248 },
-    [0x0B] = { 0x719, 0x36, CLASS_MONK, 0, 0x7C, 0x04, 0, 0, 0, 0, 0, 0, 0, sClassReelScr_08A2F26A },
-    [0x0C] = { 0x725, 0xFF, CLASS_REVENANT, 0x01, 0x9F, 0, 0, 0, 0, 0, 0, 0, 0, sClassReelScr_08A2F224 },
-    [0x0D] = { 0x726, 0xFF, CLASS_ENTOUMBED, 0x01, 0xA0, 0, 0, 0, 0, 0, 0x13, 0x13, 0, sClassReelScr_08A2F224 },
-    [0x0E] = { 0x727, 0xFF, CLASS_BONEWALKER, 0x01, 0xA1, 0, 0, 0, 0, 0, 0x0E, 0x0F, 0, sClassReelScr_08A2F224 },
-    [0x0F] = { 0x730, 0xFF, CLASS_MOGALL, 0x01, 0xB9, 0x07, 0, 0, 0, 0, 0x19, 0x19, 0, sClassReelScr_08A2F2A6 },
-    [0x10] = { 0x729, 0xFF, CLASS_BAEL, 0x01, 0xAB, 0, 0, 0, 0, 0, 0x04, 0x04, 0, sClassReelScr_08A2F224 },
-    [0x11] = { 0x700, 0x37, CLASS_MYRMIDON, 0, 0x10, 0, 0, 0, 0, 0, 0x0B, 0x18, 0, sClassReelScr_08A2F1F8 },
-    [0x12] = { 0x71E, 0x42, CLASS_CLERIC, 0, 0x7F, 0x03, 0, 0, 0, 0, 0x0B, 0x12, 0, sClassReelScr_08A2F276 },
-    [0x13] = { 0x6F5, 0xFF, CLASS_EPHRAIM_LORD, 0, 0, 0, 0, 0, 0, 0, 0x14, 0x14, 0, sClassReelScr_08A2F1F8 },
-    [0x14] = { 0x723, 0xFF, CLASS_PIRATE, 0x01, 0x99, 0, 0, 0, 0, 0, 0x0C, 0x0C, 0, sClassReelScr_08A2F1F8 },
-    [0x15] = { 0x713, 0xFF, CLASS_BRIGAND, 0x01, 0x1F, 0, 0, 0, 0, 0, 0x16, 0x16, 0, sClassReelScr_08A2F1F8 },
-    [0x16] = { 0x716, 0xFF, CLASS_SHAMAN, 0x01, 0x74, 0x05, 0, 0, 0, 0, 0x15, 0x15, 0, sClassReelScr_08A2F29A },
-    [0x17] = { 0x704, 0x51, CLASS_SNIPER, 0, 0x29, 0, 0, 0, 0, 0, 0x14, 0x14, 0, sClassReelScr_08A2F20E },
-    [0x18] = { 0x6FE, 0x30, CLASS_MERCENARY, 0, 0x0A, 0, 0, 0, 0, 0, 0x01, 0x01, 0, sClassReelScr_08A2F1F8 },
-    [0x19] = { 0x721, 0x14, CLASS_DANCER, 0, 0x90, 0, 0, 0, 0, 0, 0x0E, 0x0E, 0, sClassReelScr_08A2F282 },
-    [0x1A] = { 0x70F, 0xFF, CLASS_PUPIL, 0, 0x94, 0x01, 0, 0, 0, 0, 0x19, 0x19, 0, sClassReelScr_08A2F25E },
-    [0x1B] = { 0x700, 0xFF, CLASS_MYRMIDON_F, 0, 0x12, 0, 0, 0, 0, 0, 0x0B, 0x12, 0, sClassReelScr_08A2F1F8 },
-    [0x1C] = { 0x71B, 0xFF, CLASS_RECRUIT, 0, 0x95, 0, 0, 0, 0, 0, 0, 0, 0, sClassReelScr_08A2F1F8 },
-    [0x1D] = { 0x733, 0xFF, CLASS_GARGOYLE, 0x01, 0xBC, 0, 0, 0, 0, 0, 0x16, 0x16, 0, sClassReelScr_08A2F224 },
-    [0x1E] = { 0x72F, 0xFF, CLASS_MAELDUIN, 0x01, 0xB5, 0, 0, 0, 0, 0, 0x01, 0x01, 0, sClassReelScr_08A2F1F8 },
-    [0x1F] = { 0x72B, 0xFF, CLASS_CYCLOPS, 0x01, 0xAD, 0, 0, 0, 0, 0, 0x04, 0x04, 0, sClassReelScr_08A2F1F8 },
-    [0x20] = { 0x72C, 0xFF, CLASS_MAUTHEDOOG, 0x01, 0xB0, 0, 0, 0, 0, 0, 0x13, 0x13, 0, sClassReelScr_08A2F1F8 },
-    [0x21] = { 0x728, 0xFF, CLASS_WIGHT, 0x01, 0xA6, 0, 0, 0, 0, 0, 0x0E, 0x0F, 0, sClassReelScr_08A2F224 },
-    [0x22] = { 0x71F, 0x61, CLASS_TROUBADOUR, 0, 0x85, 0x03, 0, 0, 0, 0, 0, 0x11, 0, sClassReelScr_08A2F276 },
-    [0x23] = { 0x714, 0x12, CLASS_BERSERKER, 0, 0x22, 0, 0, 0, 0, 0, 0x10, 0x10, 0, sClassReelScr_08A2F1F8 },
-    [0x24] = { 0x710, 0x45, CLASS_ROGUE, 0, 0x8E, 0, 0, 0, 0, 0, 0x1C, 0x1C, 0, sClassReelScr_08A2F224 },
-    [0x25] = { 0x70A, 0x4B, CLASS_SAGE, 0, 0x6C, 0x01, 0, 0, 0, 0, 0x19, 0x19, 0, sClassReelScr_08A2F248 },
-    [0x26] = { 0x715, 0x2C, CLASS_GREAT_KNIGHT, 0, 0x4F, 0, 0, 0, 0, 0, 0x0B, 0x12, 0, sClassReelScr_08A2F224 },
-    [0x27] = { 0x6F8, 0xFF, CLASS_EIRIKA_MASTER_LORD, 0, 0x07, 0, 0, 0, 0, 0, 0x14, 0x14, 0, sClassReelScr_08A2F224 },
-    [0x28] = { 0x705, 0xFF, CLASS_RANGER, 0x01, 0x2E, 0, 0, 0, 0, 0, 0x13, 0x13, 0, sClassReelScr_08A2F230 },
-    [0x29] = { 0x712, 0xFF, CLASS_WARRIOR, 0x01, 0x1B, 0, 0, 0, 0, 0, 0x13, 0x13, 0, sClassReelScr_08A2F1F8 },
-    [0x2A] = { 0x702, 0xFF, CLASS_ASSASSIN, 0x01, 0x8A, 0, 0, 0, 0, 0, 0x1D, 0x1D, 0, sClassReelScr_08A2F23C },
-    [0x2B] = { 0x70B, 0x35, CLASS_MAGE_KNIGHT_F, 0, 0x70, 0x02, 0, 0, 0, 0, 0x11, 0, 0, sClassReelScr_08A2F26A },
-    [0x2C] = { 0x6F7, 0xFF, CLASS_EPHRAIM_MASTER_LORD, 0, 0x04, 0, 0, 0, 0, 0, 0x14, 0x14, 0, sClassReelScr_08A2F224 },
-    [0x2D] = { 0x720, 0xFF, CLASS_VALKYRIE, 0, 0x86, 0x04, 0, 0, 0, 0, 0x11, 0, 0, sClassReelScr_08A2F26A },
-    [0x2E] = { 0x717, 0xFF, CLASS_DRUID, 0x01, 0x76, 0x05, 0, 0, 0, 0, 0x15, 0x15, 0, sClassReelScr_08A2F29A },
-    [0x2F] = { 0x6FC, 0xFF, CLASS_GENERAL, 0x01, 0x44, 0, 0, 0, 0, 0, 0x02, 0x02, 0, sClassReelScr_08A2F224 },
-    [0x30] = { 0x701, 0xFF, CLASS_SWORDMASTER, 0, 0x14, 0, 0, 0, 0, 0, 0x09, 0x09, 0, sClassReelScr_08A2F224 },
-    [0x31] = { 0x708, 0x68, CLASS_WYVERN_KNIGHT, 0, 0x61, 0, 0, 0, 0, 0, 0x16, 0x16, 0, sClassReelScr_08A2F224 },
-    [0x32] = { 0x70C, 0x0D, CLASS_BISHOP, 0, 0x81, 0x04, 0, 0, 0, 0, 0x14, 0x14, 0, sClassReelScr_08A2F26A },
-    [0x33] = { 0x707, 0x17, CLASS_WYVERN_LORD, 0, 0x5C, 0, 0, 0, 0, 0, 0x16, 0x16, 0, sClassReelScr_08A2F224 },
-    [0x34] = { 0x6FF, 0x6B, CLASS_HERO, 0, 0x0D, 0, 0, 0, 0, 0, 0x17, 0x17, 0, sClassReelScr_08A2F1F8 },
-    [0x35] = { 0x71D, 0x1C, CLASS_FALCON_KNIGHT, 0, 0x67, 0, 0, 0, 0, 0, 0x0D, 0x0D, 0, sClassReelScr_08A2F224 },
-    [0x36] = { 0x72A, 0xFF, CLASS_ELDER_BAEL, 0x01, 0xAC, 0, 0, 0, 0, 0, 0x04, 0x04, 0, sClassReelScr_08A2F224 },
-    [0x37] = { 0x72E, 0xFF, CLASS_TARVOS, 0x01, 0xB2, 0, 0, 0, 0, 0, 0x01, 0x01, 0, sClassReelScr_08A2F1F8 },
-    [0x38] = { 0x734, 0xFF, CLASS_DEATHGOYLE, 0x01, 0xBE, 0, 0, 0, 0, 0, 0x16, 0x16, 0, sClassReelScr_08A2F224 },
-    [0x39] = { 0x72D, 0xFF, CLASS_GWYLLGI, 0x01, 0xB1, 0, 0, 0, 0, 0, 0x13, 0x13, 0, sClassReelScr_08A2F1F8 },
-    [0x3A] = { 0x732, 0xFF, CLASS_GORGON, 0x01, 0xBB, 0x08, 0, 0, 0, 0, 0x01, 0x01, 0, sClassReelScr_08A2F2B2 },
-    [0x3B] = { 0x724, 0xFF, CLASS_NECROMANCER, 0x01, 0x9C, 0x02, 0, 0, 0, 0, 0x14, 0x14, 0, sClassReelScr_08A2F26A },
-    [0x3C] = { 0x718, 0x4F, CLASS_SUMMONER, 0x01, 0x7A, 0x05, 0, 0, 0, 0, 0x15, 0x15, 0, sClassReelScr_08A2F29A },
-    [0x3D] = { 0x70D, 0xFF, CLASS_MANAKETE_MYRRH, 0, 0xC4, 0x06, 0, 0, 0, 0, 0x10, 0x10, 0, sClassReelScr_08A2F28E },
-    [0x3E] = { 0x731, 0xFF, CLASS_ARCH_MOGALL, 0x01, 0xBA, 0x07, 0, 0, 0, 0, 0x06, 0x06, 0, sClassReelScr_08A2F2A6 },
-    [0x3F] = { 0x706, 0x15, CLASS_WYVERN_RIDER, 0, 0x57, 0, 0, 0, 0, 0, 0x04, 0x04, 0, sClassReelScr_08A2F1F8 },
-    [0x40] = { 0x722, 0xFF, CLASS_SOLDIER, 0x01, 0x97, 0, 0, 0, 0, 0, 0x14, 0x14, 0, sClassReelScr_08A2F1F8 }
+struct ClassReelEnt CONST_DATA gClassReelData[65] =
+{
+    [0x00] = { MSG_6F6, 0xFF, CLASS_EIRIKA_LORD, 0, 0x02, 0, 0, 0, 0, 0, 0x14, 0x14, 0, ClassReelScr_CloseDoubleHit },
+    [0x01] = { MSG_6FA, 0x3B, CLASS_PALADIN, 0, 0x3A, 0, 0, 0, 0, 0, 0x0B, 0x12, 0, ClassReelScr_CloseSingleHit },
+    [0x02] = { MSG_6FB, 0x02, CLASS_ARMOR_KNIGHT, 0, 0x3F, 0, 0, 0, 0, 0, 0x02, 0x02, 0, ClassReelScr_CloseSingleHit },
+    [0x03] = { MSG_6F9, 0xFF, CLASS_CAVALIER, 0, 0x33, 0, 0, 0, 0, 0, 0x11, 0, 0, ClassReelScr_CloseDoubleHit },
+    [0x04] = { MSG_71C, 0x3F, CLASS_PEGASUS_KNIGHT, 0, 0x65, 0, 0, 0, 0, 0, 0x19, 0x19, 0, ClassReelScr_CloseDoubleHit },
+    [0x05] = { MSG_71A, 0x44, CLASS_PRIEST, 0, 0x7E, 0x03, 0, 0, 0, 0, 0x0B, 0x12, 0, ClassReelScr_StaffSingleCast },
+    [0x06] = { MSG_70E, 0xFF, CLASS_JOURNEYMAN, 0, 0x91, 0, 0, 0, 0, 0, 0x11, 0, 0, ClassReelScr_CloseDoubleHit },
+    [0x07] = { MSG_711, 0x1D, CLASS_FIGHTER, 0, 0x18, 0, 0, 0, 0, 0, 0, 0, 0, ClassReelScr_CloseDoubleHit },
+    [0x08] = { MSG_6FD, 0x5D, CLASS_THIEF, 0, 0x88, 0, 0, 0, 0, 0, 0x1C, 0x1C, 0, ClassReelScr_CloseDoubleHit },
+    [0x09] = { MSG_703, 0, CLASS_ARCHER, 0, 0x27, 0, 0, 0, 0, 0, 0x13, 0x13, 0, ClassReelScr_CloseDoubleHit },
+    [0x0A] = { MSG_709, 0x2E, CLASS_MAGE_F, 0, 0x6B, 0x01, 0, 0, 0, 0, 0x19, 0x19, 0, ClassReelScr_AnimaDoubleCast },
+    [0x0B] = { MSG_719, 0x36, CLASS_MONK, 0, 0x7C, 0x04, 0, 0, 0, 0, 0, 0, 0, ClassReelScr_MagicSingleCast },
+    [0x0C] = { MSG_725, 0xFF, CLASS_REVENANT, 0x01, 0x9F, 0, 0, 0, 0, 0, 0, 0, 0, ClassReelScr_CloseSingleHit },
+    [0x0D] = { MSG_726, 0xFF, CLASS_ENTOUMBED, 0x01, 0xA0, 0, 0, 0, 0, 0, 0x13, 0x13, 0, ClassReelScr_CloseSingleHit },
+    [0x0E] = { MSG_727, 0xFF, CLASS_BONEWALKER, 0x01, 0xA1, 0, 0, 0, 0, 0, 0x0E, 0x0F, 0, ClassReelScr_CloseSingleHit },
+    [0x0F] = { MSG_730, 0xFF, CLASS_MOGALL, 0x01, 0xB9, 0x07, 0, 0, 0, 0, 0x19, 0x19, 0, ClassReelScr_Mogall },
+    [0x10] = { MSG_729, 0xFF, CLASS_BAEL, 0x01, 0xAB, 0, 0, 0, 0, 0, 0x04, 0x04, 0, ClassReelScr_CloseSingleHit },
+    [0x11] = { MSG_700, 0x37, CLASS_MYRMIDON, 0, 0x10, 0, 0, 0, 0, 0, 0x0B, 0x18, 0, ClassReelScr_CloseDoubleHit },
+    [0x12] = { MSG_71E, 0x42, CLASS_CLERIC, 0, 0x7F, 0x03, 0, 0, 0, 0, 0x0B, 0x12, 0, ClassReelScr_StaffSingleCast },
+    [0x13] = { MSG_6F5, 0xFF, CLASS_EPHRAIM_LORD, 0, 0, 0, 0, 0, 0, 0, 0x14, 0x14, 0, ClassReelScr_CloseDoubleHit },
+    [0x14] = { MSG_723, 0xFF, CLASS_PIRATE, 0x01, 0x99, 0, 0, 0, 0, 0, 0x0C, 0x0C, 0, ClassReelScr_CloseDoubleHit },
+    [0x15] = { MSG_713, 0xFF, CLASS_BRIGAND, 0x01, 0x1F, 0, 0, 0, 0, 0, 0x16, 0x16, 0, ClassReelScr_CloseDoubleHit },
+    [0x16] = { MSG_716, 0xFF, CLASS_SHAMAN, 0x01, 0x74, 0x05, 0, 0, 0, 0, 0x15, 0x15, 0, ClassReelScr_DarkMagicSingleCast },
+    [0x17] = { MSG_704, 0x51, CLASS_SNIPER, 0, 0x29, 0, 0, 0, 0, 0, 0x14, 0x14, 0, ClassReelScr_Sniper },
+    [0x18] = { MSG_6FE, 0x30, CLASS_MERCENARY, 0, 0x0A, 0, 0, 0, 0, 0, 0x01, 0x01, 0, ClassReelScr_CloseDoubleHit },
+    [0x19] = { MSG_721, 0x14, CLASS_DANCER, 0, 0x90, 0, 0, 0, 0, 0, 0x0E, 0x0E, 0, ClassReelScr_Dancer },
+    [0x1A] = { MSG_70F, 0xFF, CLASS_PUPIL, 0, 0x94, 0x01, 0, 0, 0, 0, 0x19, 0x19, 0, ClassReelScr_Pupil },
+    [0x1B] = { MSG_700, 0xFF, CLASS_MYRMIDON_F, 0, 0x12, 0, 0, 0, 0, 0, 0x0B, 0x12, 0, ClassReelScr_CloseDoubleHit },
+    [0x1C] = { MSG_71B, 0xFF, CLASS_RECRUIT, 0, 0x95, 0, 0, 0, 0, 0, 0, 0, 0, ClassReelScr_CloseDoubleHit },
+    [0x1D] = { MSG_733, 0xFF, CLASS_GARGOYLE, 0x01, 0xBC, 0, 0, 0, 0, 0, 0x16, 0x16, 0, ClassReelScr_CloseSingleHit },
+    [0x1E] = { MSG_72F, 0xFF, CLASS_MAELDUIN, 0x01, 0xB5, 0, 0, 0, 0, 0, 0x01, 0x01, 0, ClassReelScr_CloseDoubleHit },
+    [0x1F] = { MSG_72B, 0xFF, CLASS_CYCLOPS, 0x01, 0xAD, 0, 0, 0, 0, 0, 0x04, 0x04, 0, ClassReelScr_CloseDoubleHit },
+    [0x20] = { MSG_72C, 0xFF, CLASS_MAUTHEDOOG, 0x01, 0xB0, 0, 0, 0, 0, 0, 0x13, 0x13, 0, ClassReelScr_CloseDoubleHit },
+    [0x21] = { MSG_728, 0xFF, CLASS_WIGHT, 0x01, 0xA6, 0, 0, 0, 0, 0, 0x0E, 0x0F, 0, ClassReelScr_CloseSingleHit },
+    [0x22] = { MSG_71F, 0x61, CLASS_TROUBADOUR, 0, 0x85, 0x03, 0, 0, 0, 0, 0, 0x11, 0, ClassReelScr_StaffSingleCast },
+    [0x23] = { MSG_714, 0x12, CLASS_BERSERKER, 0, 0x22, 0, 0, 0, 0, 0, 0x10, 0x10, 0, ClassReelScr_CloseDoubleHit },
+    [0x24] = { MSG_710, 0x45, CLASS_ROGUE, 0, 0x8E, 0, 0, 0, 0, 0, 0x1C, 0x1C, 0, ClassReelScr_CloseSingleHit },
+    [0x25] = { MSG_70A, 0x4B, CLASS_SAGE, 0, 0x6C, 0x01, 0, 0, 0, 0, 0x19, 0x19, 0, ClassReelScr_AnimaDoubleCast },
+    [0x26] = { MSG_715, 0x2C, CLASS_GREAT_KNIGHT, 0, 0x4F, 0, 0, 0, 0, 0, 0x0B, 0x12, 0, ClassReelScr_CloseSingleHit },
+    [0x27] = { MSG_6F8, 0xFF, CLASS_EIRIKA_MASTER_LORD, 0, 0x07, 0, 0, 0, 0, 0, 0x14, 0x14, 0, ClassReelScr_CloseSingleHit },
+    [0x28] = { MSG_705, 0xFF, CLASS_RANGER, 0x01, 0x2E, 0, 0, 0, 0, 0, 0x13, 0x13, 0, ClassReelScr_Ranger },
+    [0x29] = { MSG_712, 0xFF, CLASS_WARRIOR, 0x01, 0x1B, 0, 0, 0, 0, 0, 0x13, 0x13, 0, ClassReelScr_CloseDoubleHit },
+    [0x2A] = { MSG_702, 0xFF, CLASS_ASSASSIN, 0x01, 0x8A, 0, 0, 0, 0, 0, 0x1D, 0x1D, 0, ClassReelScr_Assassin },
+    [0x2B] = { MSG_70B, 0x35, CLASS_MAGE_KNIGHT_F, 0, 0x70, 0x02, 0, 0, 0, 0, 0x11, 0, 0, ClassReelScr_MagicSingleCast },
+    [0x2C] = { MSG_6F7, 0xFF, CLASS_EPHRAIM_MASTER_LORD, 0, 0x04, 0, 0, 0, 0, 0, 0x14, 0x14, 0, ClassReelScr_CloseSingleHit },
+    [0x2D] = { MSG_720, 0xFF, CLASS_VALKYRIE, 0, 0x86, 0x04, 0, 0, 0, 0, 0x11, 0, 0, ClassReelScr_MagicSingleCast },
+    [0x2E] = { MSG_717, 0xFF, CLASS_DRUID, 0x01, 0x76, 0x05, 0, 0, 0, 0, 0x15, 0x15, 0, ClassReelScr_DarkMagicSingleCast },
+    [0x2F] = { MSG_6FC, 0xFF, CLASS_GENERAL, 0x01, 0x44, 0, 0, 0, 0, 0, 0x02, 0x02, 0, ClassReelScr_CloseSingleHit },
+    [0x30] = { MSG_701, 0xFF, CLASS_SWORDMASTER, 0, 0x14, 0, 0, 0, 0, 0, 0x09, 0x09, 0, ClassReelScr_CloseSingleHit },
+    [0x31] = { MSG_708, 0x68, CLASS_WYVERN_KNIGHT, 0, 0x61, 0, 0, 0, 0, 0, 0x16, 0x16, 0, ClassReelScr_CloseSingleHit },
+    [0x32] = { MSG_70C, 0x0D, CLASS_BISHOP, 0, 0x81, 0x04, 0, 0, 0, 0, 0x14, 0x14, 0, ClassReelScr_MagicSingleCast },
+    [0x33] = { MSG_707, 0x17, CLASS_WYVERN_LORD, 0, 0x5C, 0, 0, 0, 0, 0, 0x16, 0x16, 0, ClassReelScr_CloseSingleHit },
+    [0x34] = { MSG_6FF, 0x6B, CLASS_HERO, 0, 0x0D, 0, 0, 0, 0, 0, 0x17, 0x17, 0, ClassReelScr_CloseDoubleHit },
+    [0x35] = { MSG_71D, 0x1C, CLASS_FALCON_KNIGHT, 0, 0x67, 0, 0, 0, 0, 0, 0x0D, 0x0D, 0, ClassReelScr_CloseSingleHit },
+    [0x36] = { MSG_72A, 0xFF, CLASS_ELDER_BAEL, 0x01, 0xAC, 0, 0, 0, 0, 0, 0x04, 0x04, 0, ClassReelScr_CloseSingleHit },
+    [0x37] = { MSG_72E, 0xFF, CLASS_TARVOS, 0x01, 0xB2, 0, 0, 0, 0, 0, 0x01, 0x01, 0, ClassReelScr_CloseDoubleHit },
+    [0x38] = { MSG_734, 0xFF, CLASS_DEATHGOYLE, 0x01, 0xBE, 0, 0, 0, 0, 0, 0x16, 0x16, 0, ClassReelScr_CloseSingleHit },
+    [0x39] = { MSG_72D, 0xFF, CLASS_GWYLLGI, 0x01, 0xB1, 0, 0, 0, 0, 0, 0x13, 0x13, 0, ClassReelScr_CloseDoubleHit },
+    [0x3A] = { MSG_732, 0xFF, CLASS_GORGON, 0x01, 0xBB, 0x08, 0, 0, 0, 0, 0x01, 0x01, 0, ClassReelScr_Gorgon },
+    [0x3B] = { MSG_724, 0xFF, CLASS_NECROMANCER, 0x01, 0x9C, 0x02, 0, 0, 0, 0, 0x14, 0x14, 0, ClassReelScr_MagicSingleCast },
+    [0x3C] = { MSG_718, 0x4F, CLASS_SUMMONER, 0x01, 0x7A, 0x05, 0, 0, 0, 0, 0x15, 0x15, 0, ClassReelScr_DarkMagicSingleCast },
+    [0x3D] = { MSG_70D, 0xFF, CLASS_MANAKETE_MYRRH, 0, 0xC4, 0x06, 0, 0, 0, 0, 0x10, 0x10, 0, ClassReelScr_Manakete },
+    [0x3E] = { MSG_731, 0xFF, CLASS_ARCH_MOGALL, 0x01, 0xBA, 0x07, 0, 0, 0, 0, 0x06, 0x06, 0, ClassReelScr_Mogall },
+    [0x3F] = { MSG_706, 0x15, CLASS_WYVERN_RIDER, 0, 0x57, 0, 0, 0, 0, 0, 0x04, 0x04, 0, ClassReelScr_CloseDoubleHit },
+    [0x40] = { MSG_722, 0xFF, CLASS_SOLDIER, 0x01, 0x97, 0, 0, 0, 0, 0, 0x14, 0x14, 0, ClassReelScr_CloseDoubleHit }
 };
 
-u8 CONST_DATA sClassReelClassSetLut[] = {
+u8 CONST_DATA sClassReelClassSetLut[] =
+{
     [0x0] = 0x35,
     [0x1] = 0x2F,
     [0x2] = 0x29,
@@ -2085,7 +2088,8 @@ u8 CONST_DATA sClassReelClassSetLut[] = {
     [0xB] = 0
 };
 
-struct ClassReelEnt* CONST_DATA gClassReelOrderedLut[] = {
+struct ClassReelEnt * CONST_DATA gClassReelOrderedLut[] =
+{
     // Class Set 9
     [0x00] = &gClassReelData[0x27],
     [0x01] = &gClassReelData[0x3B],
@@ -2172,6 +2176,8 @@ struct ClassReelEnt* CONST_DATA gClassReelOrderedLut[] = {
 
     NULL,
 };
+
+// clang-format on
 
 struct ClassReelEnt* GetClassReelEntry(int classSet, int index) {
     return gClassReelOrderedLut[sClassReelClassSetLut[classSet] + index];

--- a/src/opsubtitle.c
+++ b/src/opsubtitle.c
@@ -205,7 +205,7 @@ void Subtitle_LightFlareFx_Init(struct OpSubtitleProc* proc) {
     proc->unk_4c = 0;
     proc->unk_4e = 0;
 
-    sub_800154C(gBG2TilemapBuffer, Tsa_08B18D68, 0, 5);
+    sub_800154C(gBG2TilemapBuffer, Tsa_ClassReel_LensFlare, 0, 5);
 
     BG_EnableSyncByMask(BG2_SYNC_BIT);
 


### PR DESCRIPTION
* Adds macros / identify opcodes for Class Reel scripts and add names for the scripts themselves (thanks @Veslyquix!)
* Names some data symbols for graphics/TSA/palettes
* Improved general macro usage in the file
* Ran clang-format using the [`mgfembp` style](https://github.com/StanHash/mgfembp/blob/main/.clang-format)